### PR TITLE
✨ Redis Configuration 설정

### DIFF
--- a/pennyway-domain/build.gradle
+++ b/pennyway-domain/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
+
+    /* Redis */
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 def querydslDir = 'src/main/generated'

--- a/pennyway-domain/src/main/java/kr/co/pennyway/common/annotation/DomainRedisCacheManager.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/common/annotation/DomainRedisCacheManager.java
@@ -1,0 +1,13 @@
+package kr.co.pennyway.common.annotation;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD,
+        ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier("domainRedisCacheManager")
+public @interface DomainRedisCacheManager {
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/common/annotation/DomainRedisConnectionFactory.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/common/annotation/DomainRedisConnectionFactory.java
@@ -1,0 +1,13 @@
+package kr.co.pennyway.common.annotation;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD,
+        ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier("redisCacheConnectionFactory")
+public @interface DomainRedisConnectionFactory {
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/common/annotation/DomainRedisTemplate.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/common/annotation/DomainRedisTemplate.java
@@ -1,2 +1,13 @@
-package kr.co.pennyway.common.annotation;public @interface DomainRedisTemplate {
+package kr.co.pennyway.common.annotation;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD,
+        ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier("domainRedisTemplate")
+public @interface DomainRedisTemplate {
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/common/annotation/DomainRedisTemplate.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/common/annotation/DomainRedisTemplate.java
@@ -1,0 +1,2 @@
+package kr.co.pennyway.common.annotation;public @interface DomainRedisTemplate {
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/config/RedisConfig.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/config/RedisConfig.java
@@ -1,2 +1,0 @@
-package kr.co.pennyway.config;public class RedisConfig {
-}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/config/RedisConfig.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/config/RedisConfig.java
@@ -1,2 +1,83 @@
-package kr.co.pennyway.config;public class RedisConfig {
+package kr.co.pennyway.config;
+
+import kr.co.pennyway.common.annotation.DomainRedisCacheManager;
+import kr.co.pennyway.common.annotation.DomainRedisConnectionFactory;
+import kr.co.pennyway.common.annotation.DomainRedisTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import java.time.Duration;
+
+@Configuration
+@EnableRedisRepositories
+@EnableTransactionManagement
+public class RedisConfig {
+    private final String host;
+    private final int port;
+    private final String password;
+
+    public RedisConfig(
+            @Value("${spring.data.redis.host}") String host,
+            @Value("${spring.data.redis.port}") int port,
+            @Value("${spring.data.redis.password}") String password
+    ) {
+        this.host = host;
+        this.port = port;
+        this.password = password;
+    }
+
+    @Bean
+    @DomainRedisConnectionFactory
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(password);
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder().build();
+        return new LettuceConnectionFactory(config, clientConfig);
+    }
+
+    @Bean
+    @DomainRedisTemplate
+    public RedisTemplate<String, ?> redisTemplate() {
+        RedisTemplate<String, ?> template = new RedisTemplate<>();
+
+        template.setConnectionFactory(redisConnectionFactory());
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    @Bean
+    @DomainRedisCacheManager
+    public CacheManager redisCacheManager(@DomainRedisConnectionFactory RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration =
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeKeysWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new StringRedisSerializer()))
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new GenericJackson2JsonRedisSerializer()))
+                        .entryTtl(Duration.ofHours(1L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/config/RedisConfig.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/config/RedisConfig.java
@@ -1,0 +1,2 @@
+package kr.co.pennyway.config;public class RedisConfig {
+}

--- a/pennyway-domain/src/main/resources/application-domain.yml
+++ b/pennyway-domain/src/main/resources/application-domain.yml
@@ -10,6 +10,11 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  data.redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
+    password: ${REDIS_PASSWORD}
+
 ---
 spring:
   config:

--- a/pennyway-infra/build.gradle
+++ b/pennyway-infra/build.gradle
@@ -8,4 +8,7 @@ dependencies {
     api group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.5'
+
+    /* redis */
+    api 'org.springframework.boot:spring-boot-starter-data-redis'
 }

--- a/pennyway-infra/src/main/java/kr/co/infra/common/annotation/InfraRedisConnectionFactory.java
+++ b/pennyway-infra/src/main/java/kr/co/infra/common/annotation/InfraRedisConnectionFactory.java
@@ -1,0 +1,13 @@
+package kr.co.infra.common.annotation;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD,
+        ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier("infraRedisConnectionFactory")
+public @interface InfraRedisConnectionFactory {
+}

--- a/pennyway-infra/src/main/java/kr/co/infra/common/annotation/OidcCacheManager.java
+++ b/pennyway-infra/src/main/java/kr/co/infra/common/annotation/OidcCacheManager.java
@@ -1,0 +1,13 @@
+package kr.co.infra.common.annotation;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD,
+        ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier("oidcCacheManager")
+public @interface OidcCacheManager {
+}

--- a/pennyway-infra/src/main/java/kr/co/infra/common/annotation/SecurityUserCacheManager.java
+++ b/pennyway-infra/src/main/java/kr/co/infra/common/annotation/SecurityUserCacheManager.java
@@ -1,0 +1,13 @@
+package kr.co.infra.common.annotation;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD,
+        ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier("securityUserCacheManager")
+public @interface SecurityUserCacheManager {
+}

--- a/pennyway-infra/src/main/java/kr/co/infra/config/CacheConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/infra/config/CacheConfig.java
@@ -1,2 +1,123 @@
-package kr.co.infra.config;public class CacheConfig {
+package kr.co.infra.config;
+
+import kr.co.infra.common.annotation.InfraRedisConnectionFactory;
+import kr.co.infra.common.annotation.OidcCacheManager;
+import kr.co.infra.common.annotation.SecurityUserCacheManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    private final String host;
+    private final int port;
+    private final String password;
+
+    private final long defaultCacheTtlSec = 60;
+    private final long securityUserCacheTtlSec = 30;
+    private final long oidcCacheTtlDay = 7;
+
+    public CacheConfig(
+            @Value("${spring.data.redis.host}") String host,
+            @Value("${spring.data.redis.port}") int port,
+            @Value("${spring.data.redis.password}") String password
+    ) {
+        this.host = host;
+        this.port = port;
+        this.password = password;
+    }
+
+    @Bean
+    @InfraRedisConnectionFactory
+    public RedisConnectionFactory infraRedisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(password);
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder().build();
+        return new LettuceConnectionFactory(config, clientConfig);
+    }
+
+    /**
+     * CacheManager를 명시하지 않을 경우 default로 사용되는 CacheManager
+     */
+    @Bean
+    @Primary
+    public CacheManager defaultCacheManager(@InfraRedisConnectionFactory RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .computePrefixWith(CacheKeyPrefix.simple())
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+                )
+                .entryTtl(Duration.ofSeconds(defaultCacheTtlSec));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+
+    @Bean
+    @SecurityUserCacheManager
+    public CacheManager securityUserCacheManager(@InfraRedisConnectionFactory RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .computePrefixWith(CacheKeyPrefix.simple())
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+                )
+                .entryTtl(Duration.ofSeconds(securityUserCacheTtlSec));
+        Map<String, RedisCacheConfiguration> redisCacheConfigurationMap = Map.of("securityConfig", config);
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(config)
+                .withInitialCacheConfigurations(redisCacheConfigurationMap)
+                .build();
+    }
+
+    @Bean
+    @OidcCacheManager
+    public CacheManager oidcCacheManger(@InfraRedisConnectionFactory RedisConnectionFactory cf) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()
+                        ))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer()
+                        ))
+                .entryTtl(Duration.ofDays(oidcCacheTtlDay));
+        Map<String, RedisCacheConfiguration> redisCacheConfigurationMap = Map.of("oidcConfig", config);
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(cf)
+                .cacheDefaults(config)
+                .withInitialCacheConfigurations(redisCacheConfigurationMap)
+                .build();
+    }
 }

--- a/pennyway-infra/src/main/java/kr/co/infra/config/CacheConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/infra/config/CacheConfig.java
@@ -1,0 +1,2 @@
+package kr.co.infra.config;public class CacheConfig {
+}


### PR DESCRIPTION
## 작업 이유
- domain 모듈에 Redis Repository를 위한 Config 설정
- infra 모듈에 Caching을 위한 Config 설정

<br/>

## 작업 사항
### 1️⃣ Domain Redis : Redis Repository로 캐시 관리
```java
@Configuration
@EnableRedisRepositories
@EnableTransactionManagement
public class RedisConfig {
```
- `RefreshToken`과 같이 단순 캐싱이 아닌 `Domain Service` 수준의 비지니스 로직이 필요한 데이터를 관리하기 위함.
- `implementation`으로 redis 의존성을 주입한다.

<br/>

### 2️⃣ Infra Redis : 캐싱
```java
@Configuration
@EnableCaching
public class CacheConfig {
   ...
}
```
- `@Cacheable`, `@CacheEvict` 어노테이션 등을 활용하는 경우 사용
- 일반적인 cache는 `defaultCacheManager()`를 통해 캐싱을 관리하며, `ttl = 60sec`이다.
- 별도의 세팅값을 가져야 하는 `securityUserCacheManager`와 `oidcCacheManager`는 `Custom Qualify`로 `Bean`을 추가 등록
- `api`로 redis 의존성을 주입한다.

<br/>

**🟡 예시**
```java
@Slf4j
@Service
@RequiredArgsConstructor
public class UserDetailServiceImpl implements UserDetailsService {
    private final MemberRepository userRepository;

    @Override
    @Cacheable(value = "securityUser", key = "#userId", unless = "#result == null", cacheManager = "securityUserCacheManager")
    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
        log.warn("loadUserByUsername userId : {}", userId);
        return userRepository.findById(Long.parseLong(userId))
                .map(CustomUserDetails::of)
                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
    }
}
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- domain Service 내에서 혹시나 캐싱을 할 필요가 있을까 싶어서 `CacheManager` 빈을 등록시켜두긴 했는데, 필요성에 대해 논의가 필요합니다.
- 다음 환경 변수값을 주입해주셔야 합니다.

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/17eb6ebd-41dc-4cba-9446-6da58f5a1d47" width="500px" />
</div>

<br/>

## 발견한 이슈
- 없음

