### PR TITLE
✨ OpenAPI Swagger config 설정

### DIFF
--- a/pennyway-app-external-api/build.gradle
+++ b/pennyway-app-external-api/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     implementation project(':pennyway-domain')
     implementation project(':pennyway-infra')
 
+    /* Swagger */
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
+
     implementation 'org.springframework.boot:spring-boot-starter-web:3.2.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.2.3'
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/config/SwaggerConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/config/SwaggerConfig.java
@@ -1,2 +1,69 @@
-package kr.co.pennyway.config;public class SwaggerConfig {
+package kr.co.pennyway.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.ForwardedHeaderFilter;
+
+@Configuration
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "${pennyway.domain.local}", description = "Local Server"),
+                @Server(url = "${pennyway.domain.dev}", description = "Develop Server")
+        }
+)
+@RequiredArgsConstructor
+public class SwaggerConfig {
+        private static final String JWT = "JWT";
+        private final Environment environment;
+
+        @Bean
+        public OpenAPI openAPI() {
+                String activeProfile = "";
+                if (!ObjectUtils.isEmpty(environment.getActiveProfiles()) && environment.getActiveProfiles().length >= 1) {
+                        activeProfile = environment.getActiveProfiles()[0];
+                }
+
+                SecurityRequirement securityRequirement = new SecurityRequirement().addList(JWT);
+
+                return new OpenAPI()
+                        .info(apiInfo(activeProfile))
+                        .addServersItem(new io.swagger.v3.oas.models.servers.Server().url(""))
+                        .addSecurityItem(securityRequirement)
+                        .components(securitySchemes());
+        }
+
+        @Bean
+        ForwardedHeaderFilter forwardedHeaderFilter() {
+                return new ForwardedHeaderFilter();
+        }
+
+        private Components securitySchemes() {
+                final var securitySchemeAccessToken = new SecurityScheme()
+                        .name(JWT)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT")
+                        .in(SecurityScheme.In.HEADER)
+                        .name("Authorization");
+
+                return new Components()
+                        .addSecuritySchemes(JWT, securitySchemeAccessToken);
+        }
+
+        private Info apiInfo(String activeProfile) {
+                return new Info()
+                        .title("Pennyway API (" + activeProfile + ")")
+                        .description("지출 관리 SNS 플랫폼 Pennyway API 명세서")
+                        .version("v1.0.0");
+        }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/config/SwaggerConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/config/SwaggerConfig.java
@@ -1,0 +1,2 @@
+package kr.co.pennyway.config;public class SwaggerConfig {
+}

--- a/pennyway-app-external-api/src/main/resources/application.yml
+++ b/pennyway-app-external-api/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   profiles:
     group:
       local: common, domain, infra
-      prod: common, domain, infra
+      dev: common, domain, infra
 
 pennywah:
   domain:
@@ -40,7 +40,7 @@ springdoc:
 spring:
   config:
     activate:
-      on-profile: prod
+      on-profile: dev
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/pennyway-app-external-api/src/main/resources/application.yml
+++ b/pennyway-app-external-api/src/main/resources/application.yml
@@ -4,6 +4,11 @@ spring:
       local: common, domain, infra
       prod: common, domain, infra
 
+pennywah:
+  domain:
+    local: ${PENNYWAY_DOMAIN_LOCAL}
+    dev: ${PENNYWAY_DOMAIN_DEV}
+
 jwt:
   secret-key:
     access-token: ${JWT_ACCESS_SECRET_KEY}
@@ -19,8 +24,32 @@ spring:
     activate:
       on-profile: local
 
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger-ui
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    groups:
+      enabled: true
+
 ---
 spring:
   config:
     activate:
       on-profile: prod
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger-ui
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    groups:
+      enabled: true

--- a/pennyway-common/src/main/resources/application-common.yml
+++ b/pennyway-common/src/main/resources/application-common.yml
@@ -8,4 +8,4 @@ spring:
 spring:
   config:
     activate:
-      on-profile: prod
+      on-profile: dev

--- a/pennyway-domain/src/main/resources/application-domain.yml
+++ b/pennyway-domain/src/main/resources/application-domain.yml
@@ -2,7 +2,7 @@ spring:
   profiles:
     group:
       local: common
-      prod: common
+      dev: common
 
   datasource:
     url: ${DB_URL}
@@ -42,7 +42,7 @@ logging:
 spring:
   config:
     activate:
-      on-profile: prod
+      on-profile: dev
 
   jpa:
     database: MySQL

--- a/pennyway-infra/src/main/resources/application-infra.yml
+++ b/pennyway-infra/src/main/resources/application-infra.yml
@@ -2,7 +2,7 @@ spring:
   profiles:
     group:
       local: common
-      prod: common
+      dev: common
 
 ---
 spring:
@@ -14,4 +14,4 @@ spring:
 spring:
   config:
     activate:
-      on-profile: prod
+      on-profile: dev


### PR DESCRIPTION
## 작업 이유
- OpenApi 의존성 주입을 통한 Swagger UI 구성

<br/>

## 작업 사항
### 1️⃣ 라이브러리 추가
```gradle
implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
```
- `infra` 모듈에 세팅하려 했으나, 하위 모든 application 모듈이 swagger를 사용하진 않을 거 같아 `extenal-api` 모듈에 주입했습니다.
- 추후 필요성이 느껴지면 infra 모듈로 옮겨도 되니, "결정되지 않은 사항들을 최대한 미루라"는 원칙을 준수하기로 했습니다.

<br/>

### 2️⃣ application.yml 추가
```yml
springdoc:
  default-consumes-media-type: application/json;charset=UTF-8
  default-produces-media-type: application/json;charset=UTF-8
  swagger-ui:
    path: /swagger-ui
    disable-swagger-default-url: true
    display-request-duration: true
    operations-sorter: alpha
  api-docs:
    groups:
      enabled: true
```
- local, dev 모두 `/swagger-ui`를 end-point로 설정해두었습니다.
   - dev의 swagger 경로를 감춰야 한다고 하면 환경 변수로 주입하도록 변경하겠습니다.

<br/>

### 3️⃣ local 환경 테스트

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/d6afb1a8-56a0-4885-ac8c-36b3d0937e79" width="600px"/>
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/5fabd91f-018b-4814-80b8-42ba58a2a676" width="300px"/><br>
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/923b5c5e-a637-4220-b0d9-723dd42d5faf" width="500px"/>
</div>

- 개발 서버 환경에선 `사진(2)`의 `Developer Server`를 선택하시면 됩니다.
- `Authorize`가 필요한 경우 발급받은 Access Token을 넣어주면 됩니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 해당 라이브러리 사용법은 [공식문서](https://springdoc.org/#migrating-from-springfox)에서 확인 가능합니다.
   - `springfox`와 비교하는 부분이라서 `after` 부분이 저희가 사용하는 방식입니다.
- 현재는 swagger 설정이 완전히 동일함에도, profile 별로 별도 설정이 필요하게 될 수도 있을 거 같아 분리해놓았습니다. 문제가 될 것 같은지 확인 부탁드립니다.
- 아래 환경 변수 추가 부탁드립니다.

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/438dfee7-8083-415d-976e-28f7bc886776" width="400px"/>
</div>

- 아래 url에서 확인할 수 있습니다.
   - `/swagger-ui` : docs UI에서 api 확인
   - `/v3/api-docs` : Json 포맷으로 docs 확인

<br/>

## 발견한 이슈

![image](https://github.com/CollaBu/pennyway-was/assets/96044622/3680155c-1f48-4306-b32a-1375dae7da40)
- `dev` profile 환경에서 `show-sql` 기능을 꺼놨었는데, 개발 서버에서는 켜둬야 할 거 같아서 고민 중입니다.
- 기존에 `prod` profile로 설정되어 있던 `application.yml` 모두 찾아내서 `dev`로 수정했습니다.
