### PR TITLE
Swagger 관련 환경 변수 오타 수정

### DIFF
--- a/pennyway-app-external-api/src/main/resources/application.yml
+++ b/pennyway-app-external-api/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
       local: common, domain, infra
       dev: common, domain, infra
 
-pennywah:
+pennyway:
   domain:
     local: ${PENNYWAY_DOMAIN_LOCAL}
     dev: ${PENNYWAY_DOMAIN_DEV}


### PR DESCRIPTION
## 작업 이유

- Swagger 관련 환경 변수 오타 수정


<br/>

## 작업 사항

- `external-api`의 환경 변수 파일인 `application.yml`의 'pennywah' => 'pennyway'로 수정


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- 없음


<br/>

## 발견한 이슈

- 없음
