### PR TITLE
✨️ 회원가입 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
@@ -1,0 +1,41 @@
+package kr.co.pennyway.api.apis.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
+import kr.co.pennyway.api.apis.auth.usecase.AuthUseCase;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import kr.co.pennyway.api.common.security.jwt.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@Slf4j
+@Tag(name = "[인증 API]")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final AuthUseCase authUseCase;
+
+    @Operation(summary = "일반 회원가입")
+    @PostMapping("/sign-up")
+    // TODO: Spring Security 설정 후 @PreAuthorize("isAnonymous()") 추가
+    public ResponseEntity<?> signUp(@RequestBody @Validated SignUpReq.General request) {
+        Pair<Long, Jwts> jwts = authUseCase.signUp(request);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, jwts.getValue().refreshToken())
+                .header(HttpHeaders.AUTHORIZATION, jwts.getValue().accessToken())
+                .body(SuccessResponse.from("user", Map.of("id", jwts.getKey())))
+                ;
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
@@ -6,10 +6,12 @@ import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
 import kr.co.pennyway.api.apis.auth.usecase.AuthUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.jwt.Jwts;
+import kr.co.pennyway.api.common.util.CookieUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Duration;
 import java.util.Map;
 
 @Slf4j
@@ -26,14 +29,17 @@ import java.util.Map;
 @RequestMapping("/api/v1/auth")
 public class AuthController {
     private final AuthUseCase authUseCase;
+    private final CookieUtil cookieUtil;
 
     @Operation(summary = "일반 회원가입")
     @PostMapping("/sign-up")
     // TODO: Spring Security 설정 후 @PreAuthorize("isAnonymous()") 추가
     public ResponseEntity<?> signUp(@RequestBody @Validated SignUpReq.General request) {
         Pair<Long, Jwts> jwts = authUseCase.signUp(request);
+        ResponseCookie cookie = cookieUtil.createCookie("refreshToken", jwts.getValue().refreshToken(), Duration.ofDays(7).toSeconds());
+
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, jwts.getValue().refreshToken())
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .header(HttpHeaders.AUTHORIZATION, jwts.getValue().accessToken())
                 .body(SuccessResponse.from("user", Map.of("id", jwts.getKey())))
                 ;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/Jwts.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/Jwts.java
@@ -1,0 +1,10 @@
+package kr.co.pennyway.api.apis.auth.dto;
+
+public record Jwts(
+        String accessToken,
+        String refreshToken
+) {
+    public static Jwts of(String accessToken, String refreshToken) {
+        return new Jwts(accessToken, refreshToken);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneCertificationReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneCertificationReq.java
@@ -1,0 +1,30 @@
+package kr.co.pennyway.api.apis.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public class PhoneCertificationReq {
+    @Schema(title = "인증번호 요청 DTO", description = "전화번호로 인증번호 송신 요청을 위한 DTO")
+    public record PushCodeReq(
+            @Schema(description = "전화번호", example = "01012345678")
+            @NotNull(message = "전화번호는 필수입니다.")
+            @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$\n", message = "전화번호 형식이 올바르지 않습니다.")
+            String phoneNumber
+    ) {
+    }
+
+    @Schema(title = "인증번호 검증 DTO", description = "전화번호로 인증번호 검증 요청을 위한 DTO")
+    public record VerifyCodeReq(
+            @Schema(description = "전화번호", example = "01012345678")
+            @NotNull(message = "전화번호는 필수입니다.")
+            @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$\n", message = "전화번호 형식이 올바르지 않습니다.")
+            String phoneNumber,
+            @Schema(description = "6자리 정수 인증번호", example = "123456")
+            @NotBlank(message = "인증번호는 필수입니다.")
+            @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
+            String code
+    ) {
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneVerificationReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneVerificationReq.java
@@ -5,13 +5,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
-public class PhoneCertificationReq {
+public class PhoneVerificationReq {
     @Schema(title = "인증번호 요청 DTO", description = "전화번호로 인증번호 송신 요청을 위한 DTO")
     public record PushCodeReq(
             @Schema(description = "전화번호", example = "01012345678")
             @NotNull(message = "전화번호는 필수입니다.")
             @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$\n", message = "전화번호 형식이 올바르지 않습니다.")
-            String phoneNumber
+            String phone
     ) {
     }
 
@@ -20,7 +20,7 @@ public class PhoneCertificationReq {
             @Schema(description = "전화번호", example = "01012345678")
             @NotNull(message = "전화번호는 필수입니다.")
             @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$\n", message = "전화번호 형식이 올바르지 않습니다.")
-            String phoneNumber,
+            String phone,
             @Schema(description = "6자리 정수 인증번호", example = "123456")
             @NotBlank(message = "인증번호는 필수입니다.")
             @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자여야 합니다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneVerificationReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneVerificationReq.java
@@ -10,7 +10,7 @@ public class PhoneVerificationReq {
     public record PushCodeReq(
             @Schema(description = "전화번호", example = "01012345678")
             @NotNull(message = "전화번호는 필수입니다.")
-            @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$\n", message = "전화번호 형식이 올바르지 않습니다.")
+            @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
             String phone
     ) {
     }
@@ -19,7 +19,7 @@ public class PhoneVerificationReq {
     public record VerifyCodeReq(
             @Schema(description = "전화번호", example = "01012345678")
             @NotNull(message = "전화번호는 필수입니다.")
-            @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$\n", message = "전화번호 형식이 올바르지 않습니다.")
+            @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
             String phone,
             @Schema(description = "6자리 정수 인증번호", example = "123456")
             @NotBlank(message = "인증번호는 필수입니다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneVerificationReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneVerificationReq.java
@@ -2,14 +2,13 @@ package kr.co.pennyway.api.apis.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public class PhoneVerificationReq {
     @Schema(title = "인증번호 요청 DTO", description = "전화번호로 인증번호 송신 요청을 위한 DTO")
     public record PushCodeReq(
             @Schema(description = "전화번호", example = "01012345678")
-            @NotNull(message = "전화번호는 필수입니다.")
+            @NotBlank(message = "전화번호는 필수입니다.")
             @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
             String phone
     ) {
@@ -18,7 +17,7 @@ public class PhoneVerificationReq {
     @Schema(title = "인증번호 검증 DTO", description = "전화번호로 인증번호 검증 요청을 위한 DTO")
     public record VerifyCodeReq(
             @Schema(description = "전화번호", example = "01012345678")
-            @NotNull(message = "전화번호는 필수입니다.")
+            @NotBlank(message = "전화번호는 필수입니다.")
             @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
             String phone,
             @Schema(description = "6자리 정수 인증번호", example = "123456")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -31,7 +31,7 @@ public class SignUpReq {
             String password,
             @Schema(description = "전화번호", example = "010-1234-5678")
             @NotEmpty(message = "전화번호를 입력해주세요")
-            @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$\n", message = "전화번호 형식이 올바르지 않습니다.")
+            @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
             String phone,
             @Schema(description = "6자리 정수 인증번호", example = "123456")
             @NotBlank(message = "인증번호는 필수입니다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -29,7 +29,7 @@ public class SignUpReq {
             @NotEmpty(message = "비밀번호를 입력해주세요")
             @Password(message = "8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해주세요. (적어도 하나의 영문 소문자, 숫자 포함)")
             String password,
-            @Schema(description = "전화번호", example = "01012345678")
+            @Schema(description = "전화번호", example = "010-1234-5678")
             @NotEmpty(message = "전화번호를 입력해주세요")
             @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$\n", message = "전화번호 형식이 올바르지 않습니다.")
             String phone,
@@ -48,7 +48,7 @@ public class SignUpReq {
                     .profileVisibility(ProfileVisibility.PUBLIC)
                     .build();
         }
-        
+
     }
 
     @Schema(title = "소셜 회원가입 요청 DTO")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -2,7 +2,6 @@ package kr.co.pennyway.api.apis.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import kr.co.pennyway.api.common.validator.Password;
 import kr.co.pennyway.domain.domains.user.domain.User;
@@ -18,19 +17,19 @@ public class SignUpReq {
     @Schema(title = "일반 회원가입 요청 DTO")
     public record General(
             @Schema(description = "아이디", example = "pennyway")
-            @NotEmpty(message = "아이디를 입력해주세요")
+            @NotBlank(message = "아이디를 입력해주세요")
             @Pattern(regexp = "^[a-z-_.]{5,20}$", message = "5~20자의 영문 소문자, -, _, . 만 사용 가능합니다.")
             String username,
             @Schema(description = "이름", example = "페니웨이")
-            @NotEmpty(message = "이름을 입력해주세요")
+            @NotBlank(message = "이름을 입력해주세요")
             @Pattern(regexp = "^[가-힣a-zA-Z]{2,20}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
             String name,
             @Schema(description = "비밀번호", example = "pennyway1234")
-            @NotEmpty(message = "비밀번호를 입력해주세요")
+            @NotBlank(message = "비밀번호를 입력해주세요")
             @Password(message = "8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해주세요. (적어도 하나의 영문 소문자, 숫자 포함)")
             String password,
             @Schema(description = "전화번호", example = "010-1234-5678")
-            @NotEmpty(message = "전화번호를 입력해주세요")
+            @NotBlank(message = "전화번호를 입력해주세요")
             @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
             String phone,
             @Schema(description = "6자리 정수 인증번호", example = "123456")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -1,0 +1,54 @@
+package kr.co.pennyway.api.apis.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import kr.co.pennyway.api.common.validator.Password;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
+import kr.co.pennyway.domain.domains.user.type.Role;
+
+/**
+ * 회원가입 요청 Dto
+ * <br/>
+ * 일반 회원가입 시엔 General, 소셜 회원가입 시엔 Oauth를 사용합니다.
+ */
+public class SignUpReq {
+    @Schema(title = "일반 회원가입 요청 DTO")
+    public record General(
+            @Schema(description = "아이디", example = "pennyway")
+            @NotEmpty(message = "아이디를 입력해주세요")
+            @Pattern(regexp = "^[a-z-_.]{5,20}$", message = "5~20자의 영문 소문자, -, _, . 만 사용 가능합니다.")
+            String username,
+            @Schema(description = "이름", example = "페니웨이")
+            @NotEmpty(message = "이름을 입력해주세요")
+            @Pattern(regexp = "^[가-힣a-zA-Z]{2,20}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
+            String name,
+            @Schema(description = "비밀번호", example = "pennyway1234")
+            @NotEmpty(message = "비밀번호를 입력해주세요")
+            @Password(message = "8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해주세요. (적어도 하나의 영문 소문자, 숫자 포함)")
+            String password,
+            @Schema(description = "전화번호", example = "01012345678")
+            @NotEmpty(message = "전화번호를 입력해주세요")
+            @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$\n", message = "전화번호 형식이 올바르지 않습니다.")
+            String phone
+    ) {
+        public User toEntity() {
+            return User.builder()
+                    .username(username)
+                    .name(name)
+                    .password(password)
+                    .phone(phone)
+                    .role(Role.USER)
+                    .profileVisibility(ProfileVisibility.PUBLIC)
+                    .build();
+        }
+    }
+
+    @Schema(title = "소셜 회원가입 요청 DTO")
+    public record Oauth(
+
+    ) {
+
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import kr.co.pennyway.api.common.validator.Password;
@@ -31,7 +32,11 @@ public class SignUpReq {
             @Schema(description = "전화번호", example = "01012345678")
             @NotEmpty(message = "전화번호를 입력해주세요")
             @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$\n", message = "전화번호 형식이 올바르지 않습니다.")
-            String phone
+            String phone,
+            @Schema(description = "6자리 정수 인증번호", example = "123456")
+            @NotBlank(message = "인증번호는 필수입니다.")
+            @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
+            String code
     ) {
         public User toEntity() {
             return User.builder()
@@ -43,6 +48,7 @@ public class SignUpReq {
                     .profileVisibility(ProfileVisibility.PUBLIC)
                     .build();
         }
+        
     }
 
     @Schema(title = "소셜 회원가입 요청 DTO")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/mapper/JwtAuthMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/mapper/JwtAuthMapper.java
@@ -1,0 +1,52 @@
+package kr.co.pennyway.api.apis.auth.mapper;
+
+import kr.co.infra.common.jwt.JwtProvider;
+import kr.co.pennyway.api.apis.auth.dto.Jwts;
+import kr.co.pennyway.api.common.annotation.AccessTokenStrategy;
+import kr.co.pennyway.api.common.annotation.RefreshTokenStrategy;
+import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
+import kr.co.pennyway.common.annotation.Mapper;
+import kr.co.pennyway.domain.common.redis.refresh.RefreshToken;
+import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Mapper
+public class JwtAuthMapper {
+    private final JwtProvider accessTokenProvider;
+    private final JwtProvider refreshTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    public JwtAuthMapper(
+            @AccessTokenStrategy JwtProvider accessTokenProvider,
+            @RefreshTokenStrategy JwtProvider refreshTokenProvider,
+            RefreshTokenService refreshTokenService
+    ) {
+        this.accessTokenProvider = accessTokenProvider;
+        this.refreshTokenProvider = refreshTokenProvider;
+        this.refreshTokenService = refreshTokenService;
+    }
+
+    /**
+     * 사용자 정보 기반으로 access token과 refresh token을 생성하는 메서드 <br/>
+     * refresh token은 redis에 저장된다.
+     *
+     * @param user {@link User}
+     * @return {@link Jwts}
+     */
+    public Jwts createToken(User user) {
+        String accessToken = accessTokenProvider.generateToken(AccessTokenClaim.of(user.getId(), user.getRole().getType()));
+        String refreshToken = refreshTokenProvider.generateToken(AccessTokenClaim.of(user.getId(), user.getRole().getType()));
+
+        refreshTokenService.save(RefreshToken.of(user.getId(), refreshToken, toSeconds(refreshTokenProvider.getExpiryDate(refreshToken))));
+        return Jwts.of(accessToken, refreshToken);
+    }
+
+    private long toSeconds(LocalDateTime expiryTime) {
+        return Duration.between(LocalDateTime.now(), expiryTime).getSeconds();
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/mapper/JwtAuthMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/mapper/JwtAuthMapper.java
@@ -1,9 +1,9 @@
 package kr.co.pennyway.api.apis.auth.mapper;
 
 import kr.co.infra.common.jwt.JwtProvider;
-import kr.co.pennyway.api.apis.auth.dto.Jwts;
 import kr.co.pennyway.api.common.annotation.AccessTokenStrategy;
 import kr.co.pennyway.api.common.annotation.RefreshTokenStrategy;
+import kr.co.pennyway.api.common.security.jwt.Jwts;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
 import kr.co.pennyway.common.annotation.Mapper;
 import kr.co.pennyway.domain.common.redis.refresh.RefreshToken;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/mapper/JwtAuthMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/mapper/JwtAuthMapper.java
@@ -5,6 +5,7 @@ import kr.co.pennyway.api.common.annotation.AccessTokenStrategy;
 import kr.co.pennyway.api.common.annotation.RefreshTokenStrategy;
 import kr.co.pennyway.api.common.security.jwt.Jwts;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
+import kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaim;
 import kr.co.pennyway.common.annotation.Mapper;
 import kr.co.pennyway.domain.common.redis.refresh.RefreshToken;
 import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenService;
@@ -40,7 +41,7 @@ public class JwtAuthMapper {
      */
     public Jwts createToken(User user) {
         String accessToken = accessTokenProvider.generateToken(AccessTokenClaim.of(user.getId(), user.getRole().getType()));
-        String refreshToken = refreshTokenProvider.generateToken(AccessTokenClaim.of(user.getId(), user.getRole().getType()));
+        String refreshToken = refreshTokenProvider.generateToken(RefreshTokenClaim.of(user.getId(), user.getRole().getType()));
 
         refreshTokenService.save(RefreshToken.of(user.getId(), refreshToken, toSeconds(refreshTokenProvider.getExpiryDate(refreshToken))));
         return Jwts.of(accessToken, refreshToken);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthUseCase.java
@@ -1,0 +1,31 @@
+package kr.co.pennyway.api.apis.auth.usecase;
+
+import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
+import kr.co.pennyway.api.apis.auth.mapper.JwtAuthMapper;
+import kr.co.pennyway.api.common.security.jwt.Jwts;
+import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class AuthUseCase {
+    private final UserService userService;
+
+    private final JwtAuthMapper jwtAuthMapper;
+
+    @Transactional
+    public Pair<Long, Jwts> signUp(SignUpReq.General request) {
+        // TODO: 인증 번호 확인 로직 추가
+        // phoneVerificationHelper.verify(request.phone(), request.code());
+
+        User user = userService.createUser(request.toEntity());
+
+        return Pair.of(user.getId(), jwtAuthMapper.createToken(user));
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/Jwts.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/Jwts.java
@@ -1,4 +1,4 @@
-package kr.co.pennyway.api.apis.auth.dto;
+package kr.co.pennyway.api.common.security.jwt;
 
 public record Jwts(
         String accessToken,

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/refresh/RefreshTokenProvider.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/refresh/RefreshTokenProvider.java
@@ -14,7 +14,6 @@ import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
 import kr.co.pennyway.common.util.DateUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -28,7 +27,6 @@ import static kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaimKe
 import static kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaimKeys.USER_ID;
 
 @Slf4j
-@Primary
 @Component
 @RefreshTokenStrategy
 public class RefreshTokenProvider implements JwtProvider {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/util/CookieUtil.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/util/CookieUtil.java
@@ -34,10 +34,10 @@ public class CookieUtil {
      *
      * @param cookieName String : 생성할 쿠키의 이름
      * @param value      String : 생성할 쿠키의 값
-     * @param maxAge     int : 생성할 쿠키의 만료 시간
+     * @param maxAge     long : 생성할 쿠키의 만료 시간
      * @return ResponseCookie : 생성된 쿠키
      */
-    public ResponseCookie createCookie(String cookieName, String value, int maxAge) {
+    public ResponseCookie createCookie(String cookieName, String value, long maxAge) {
         return ResponseCookie.from(cookieName, value)
                 .path("/")
                 .httpOnly(true)

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/util/CookieUtil.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/util/CookieUtil.java
@@ -1,0 +1,70 @@
+package kr.co.pennyway.api.common.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class CookieUtil {
+    /**
+     * request에서 cookieName에 해당하는 쿠키를 찾아서 반환합니다.
+     *
+     * @param request    HttpServletRequest : 쿠키를 찾을 request
+     * @param cookieName String : 찾을 쿠키의 이름
+     * @return Optional<Cookie> : 쿠키가 존재하면 해당 쿠키를, 존재하지 않으면 Optional.empty()를 반환합니다.
+     */
+    public Optional<Cookie> getCookieFromRequest(HttpServletRequest request, String cookieName) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookieName.equals(cookie.getName()))
+                .findAny();
+    }
+
+    /**
+     * cookieName에 해당하는 쿠키를 생성합니다.
+     *
+     * @param cookieName String : 생성할 쿠키의 이름
+     * @param value      String : 생성할 쿠키의 값
+     * @param maxAge     int : 생성할 쿠키의 만료 시간
+     * @return ResponseCookie : 생성된 쿠키
+     */
+    public ResponseCookie createCookie(String cookieName, String value, int maxAge) {
+        return ResponseCookie.from(cookieName, value)
+                .path("/")
+                .httpOnly(true)
+                .maxAge(maxAge)
+                .secure(true)
+                .sameSite("None")
+                .build();
+    }
+
+    /**
+     * cookieName에 해당하는 쿠키를 제거합니다.
+     *
+     * @param request    HttpServletRequest : 쿠키를 제거할 request
+     * @param response   HttpServletResponse : 쿠키를 제거할 response
+     * @param cookieName String : 제거할 쿠키의 이름
+     * @return Optional<ResponseCookie> : 쿠키가 존재하면 제거된 쿠키를, 존재하지 않으면 Optional.empty()를 반환합니다.
+     */
+    public Optional<ResponseCookie> deleteCookie(HttpServletRequest request, HttpServletResponse response, String cookieName) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookieName.equals(cookie.getName()))
+                .findAny()
+                .map(cookie -> createCookie(cookieName, "", 0));
+    }
+}
+

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotEmoji.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotEmoji.java
@@ -1,0 +1,29 @@
+package kr.co.pennyway.api.common.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * 어노테이션된 요소는 반드시 이모지가 포함되어서는 안 됩니다. <br/>
+ * 단, null인 경우 true를 반환합니다.
+ *
+ * @author Yang JaeSeo
+ */
+@Documented
+@Constraint(validatedBy = {NotEmojiValidator.class})
+@Target({FIELD})
+@Retention(RUNTIME)
+public @interface NotEmoji {
+    String message() default "특수기호는 허용되지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotEmojiValidator.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotEmojiValidator.java
@@ -1,0 +1,24 @@
+package kr.co.pennyway.api.common.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NotEmojiValidator implements ConstraintValidator<NotEmoji, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
+
+        return !hasEmoji(value);
+    }
+
+    private boolean hasEmoji(String value) {
+        return value.codePoints().anyMatch(
+                codePoint -> codePoint == 0x0 || codePoint == 0x9 || codePoint == 0xA || codePoint == 0xD
+                        || (codePoint >= 0x20 && codePoint <= 0xD7FF)
+                        || (codePoint >= 0xE000 && codePoint <= 0xFFFD)
+                        || (codePoint >= 0x10000 && codePoint <= 0x10FFFF)
+        );
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotWhiteSpace.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotWhiteSpace.java
@@ -1,0 +1,23 @@
+package kr.co.pennyway.api.common.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Constraint(validatedBy = {NotWhiteSpaceValidator.class})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+public @interface NotWhiteSpace {
+    String message() default "공백 문자는 허용되지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotWhiteSpace.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotWhiteSpace.java
@@ -12,7 +12,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * 어노테이션된 요소는 반드시 공백문자가 포함되어서는 안 됩니다. <br/>
- * 단, null인 경우 true를 반환합니다.
+ * 단, null인 경우 false를 반환합니다.
  *
  * @author Yang JaeSeo
  * @see Character#isWhitespace(char)

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotWhiteSpace.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotWhiteSpace.java
@@ -10,6 +10,13 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+/**
+ * 어노테이션된 요소는 반드시 공백문자가 포함되어서는 안 됩니다. <br/>
+ * 단, null인 경우 true를 반환합니다.
+ *
+ * @author Yang JaeSeo
+ * @see Character#isWhitespace(char)
+ */
 @Documented
 @Constraint(validatedBy = {NotWhiteSpaceValidator.class})
 @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotWhiteSpaceValidator.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/NotWhiteSpaceValidator.java
@@ -1,0 +1,18 @@
+package kr.co.pennyway.api.common.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NotWhiteSpaceValidator implements ConstraintValidator<NotWhiteSpace, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        return !hasWhiteSpace(value);
+    }
+
+    private boolean hasWhiteSpace(String value) {
+        return value.chars().anyMatch(Character::isWhitespace);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/Password.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/Password.java
@@ -1,0 +1,29 @@
+package kr.co.pennyway.api.common.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * 어노테이션된 요소는 반드시 8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해야 합니다. <br/>
+ * 적어도 하나 이상의 소문자 알파벳과 숫자가 포함되어야 합니다.
+ *
+ * @author Yang JaeSeo
+ */
+@Documented
+@Constraint(validatedBy = {PasswordValidator.class})
+@Target({FIELD})
+@Retention(RUNTIME)
+public @interface Password {
+    String message() default "8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해주세요.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/PasswordValidator.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/validator/PasswordValidator.java
@@ -1,0 +1,15 @@
+package kr.co.pennyway.api.common.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.regex.Pattern;
+
+public class PasswordValidator implements ConstraintValidator<Password, String> {
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile("^(?=.*[a-z])(?=.*\\d)[A-Za-z\\d@$!%*?&]{8,16}$");
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value != null && PASSWORD_PATTERN.matcher(value).matches();
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/AuthControllerValidationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/AuthControllerValidationTest.java
@@ -1,0 +1,190 @@
+package kr.co.pennyway.api.apis.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.auth.controller.AuthController;
+import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
+import kr.co.pennyway.api.apis.auth.usecase.AuthUseCase;
+import kr.co.pennyway.api.common.security.jwt.Jwts;
+import kr.co.pennyway.api.common.util.CookieUtil;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = {AuthController.class})
+@ActiveProfiles("local")
+public class AuthControllerValidationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthUseCase authUseCase;
+
+    @MockBean
+    private CookieUtil cookieUtil;
+
+    @DisplayName("[1] 아이디, 이름, 비밀번호, 전화번호, 인증번호 필수 입력")
+    @Test
+    void requiredInputError() throws Exception {
+        // given
+        SignUpReq.General request = new SignUpReq.General("", "", "", "", "");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.fieldErrors.username").exists())
+                .andExpect(jsonPath("$.fieldErrors.name").exists())
+                .andExpect(jsonPath("$.fieldErrors.password").exists())
+                .andExpect(jsonPath("$.fieldErrors.phone").exists())
+                .andExpect(jsonPath("$.fieldErrors.code").exists())
+                .andDo(print());
+    }
+
+    @DisplayName("[2] 아이디는 5~20자의 영문 소문자, -, _, . 만 사용 가능합니다.")
+    @Test
+    void idValidError() throws Exception {
+        // given
+        SignUpReq.General request = new SignUpReq.General("#pennyway", "페니웨이", "pennyway1234", "010-1234-5678", "123456");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.fieldErrors.username").value("5~20자의 영문 소문자, -, _, . 만 사용 가능합니다."))
+                .andDo(print());
+    }
+
+    @DisplayName("[3] 이름은 2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
+    @Test
+    void nameValidError() throws Exception {
+        // given
+        SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이1", "pennyway1234", "010-1234-5678", "123456");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.fieldErrors.name").value("2~20자의 한글, 영문 대/소문자만 사용 가능합니다."))
+                .andDo(print());
+    }
+
+    @DisplayName("[4] 비밀번호는 8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해주세요. (적어도 하나의 영문 소문자, 숫자 포함)")
+    @Test
+    void passwordValidError() throws Exception {
+        // given
+        SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이", "pennyway", "010-1234-5678", "123456");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.fieldErrors.password").value("8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해주세요. (적어도 하나의 영문 소문자, 숫자 포함)"))
+                .andDo(print());
+    }
+
+    @DisplayName("[5] 전화번호는 010 혹은 011로 시작하는, 010-0000-0000 형식이어야 합니다.")
+    @Test
+    void phoneValidError() throws Exception {
+        // given
+        SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이", "pennyway1234", "01012345673", "123456");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.fieldErrors.phone").value("전화번호 형식이 올바르지 않습니다."))
+                .andDo(print());
+    }
+
+    @DisplayName("[6] 인증번호는 6자리 숫자여야 합니다.")
+    @Test
+    void codeValidError() throws Exception {
+        // given
+        SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이", "pennyway1234", "010-1234-5678", "12345");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.fieldErrors.code").value("인증번호는 6자리 숫자여야 합니다."))
+                .andDo(print());
+    }
+
+    @DisplayName("[7] 정상적인 회원가입 요청 - 쿠키/인증 헤더와 회원 pk 반환")
+    @Test
+    void signUp() throws Exception {
+        // given
+        SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이", "pennyway1234", "010-1234-5678", "123456");
+        given(authUseCase.signUp(request))
+                .willReturn(Pair.of(1L, Jwts.of("accessToken", "refreshToken")));
+        given(cookieUtil.createCookie("refreshToken", "refreshToken", 60 * 60 * 24 * 7))
+                .willReturn(ResponseCookie.from("refreshToken", "refreshToken").maxAge(60 * 60 * 24 * 7).httpOnly(true).path("/").build());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/auth/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Set-Cookie"))
+                .andExpect(header().string("Authorization", "accessToken"))
+                .andExpect(jsonPath("$.data.user.id").value(1))
+                .andDo(print());
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/common/response/SuccessResponseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/common/response/SuccessResponseTest.java
@@ -1,6 +1,5 @@
-package kr.co.pennyway.common.response;
+package kr.co.pennyway.api.common.response;
 
-import kr.co.pennyway.api.common.response.SuccessResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/common/security/jwt/access/AccessTokenProviderTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/common/security/jwt/access/AccessTokenProviderTest.java
@@ -1,11 +1,9 @@
-package kr.co.pennyway.common.security.jwt.access;
+package kr.co.pennyway.api.common.security.jwt.access;
 
 import kr.co.infra.common.exception.JwtErrorCode;
 import kr.co.infra.common.exception.JwtErrorException;
 import kr.co.infra.common.jwt.JwtClaims;
 import kr.co.infra.common.jwt.JwtProvider;
-import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
-import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
@@ -6,9 +6,6 @@ import lombok.Getter;
 import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
-import org.springframework.data.redis.core.TimeToLive;
-
-import java.util.concurrent.TimeUnit;
 
 @RedisHash("refreshToken")
 @Getter
@@ -17,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 public class RefreshToken {
     @Id
     private final Long userId;
-    @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private final long ttl;
     private String token;
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
@@ -7,13 +7,15 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
+import java.util.concurrent.TimeUnit;
+
 @RedisHash("refreshToken")
 @Getter
 @ToString(of = {"userId", "token", "ttl"})
 public class RefreshToken {
     @Id
     private final Long userId;
-    @TimeToLive
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private final long ttl;
     private String token;
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
@@ -1,0 +1,38 @@
+package kr.co.pennyway.domain.common.redis.refresh;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@RedisHash("refreshToken")
+@Getter
+@ToString(of = {"userId", "token", "ttl"})
+public class RefreshToken {
+    @Id
+    private final Long userId;
+    @TimeToLive
+    private final long ttl;
+    private String token;
+
+    @Builder
+    private RefreshToken(String token, Long userId, long ttl) {
+        this.token = token;
+        this.userId = userId;
+        this.ttl = ttl;
+    }
+
+    public static RefreshToken of(Long userId, String token, long ttl) {
+        return RefreshToken.builder()
+                .userId(userId)
+                .token(token)
+                .ttl(ttl)
+                .build();
+    }
+
+    protected void rotation(String token) {
+        this.token = token;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.domain.common.redis.refresh;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import org.springframework.data.annotation.Id;
@@ -12,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 @RedisHash("refreshToken")
 @Getter
 @ToString(of = {"userId", "token", "ttl"})
+@EqualsAndHashCode(of = {"userId", "token"})
 public class RefreshToken {
     @Id
     private final Long userId;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenRepository.java
@@ -1,0 +1,6 @@
+package kr.co.pennyway.domain.common.redis.refresh;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenService.java
@@ -1,0 +1,31 @@
+package kr.co.pennyway.domain.common.redis.refresh;
+
+public interface RefreshTokenService {
+    /**
+     * refresh token을 redis에 저장한다.
+     *
+     * @param refreshToken : {@link RefreshToken}
+     */
+    void save(RefreshToken refreshToken);
+
+    /**
+     * 사용자가 보낸 refresh token으로 기존 refresh token과 비교 검증 후, 새로운 refresh token으로 저장한다.
+     *
+     * @param userId          : 토큰 주인 pk
+     * @param oldRefreshToken : 사용자가 보낸 refresh token
+     * @param newRefreshToken : 교체할 refresh token
+     * @return {@link RefreshToken}
+     * @throws IllegalArgumentException : userId에 해당하는 refresh token이 없을 경우
+     * @throws IllegalStateException    : 요청한 토큰과 저장된 토큰이 다르다면 토큰이 탈취되었다고 판단하여 값 삭제
+     */
+    RefreshToken refresh(Long userId, String oldRefreshToken, String newRefreshToken) throws IllegalArgumentException, IllegalStateException;
+
+    /**
+     * access token 으로 refresh token을 찾아서 제거 (로그아웃)
+     *
+     * @param userId       : 토큰 주인 pk
+     * @param refreshToken : 검증용 refresh token
+     * @throws IllegalArgumentException : userId에 해당하는 refresh token이 없을 경우
+     */
+    void delete(Long userId, String refreshToken) throws IllegalArgumentException;
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceImpl.java
@@ -1,0 +1,69 @@
+package kr.co.pennyway.domain.common.redis.refresh;
+
+import kr.co.pennyway.common.annotation.DomainService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@DomainService
+@RequiredArgsConstructor
+public class RefreshTokenServiceImpl implements RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+    
+    @Override
+    public void save(RefreshToken refreshToken) {
+        refreshTokenRepository.save(refreshToken);
+        log.debug("리프레시 토큰 저장 : {}", refreshToken);
+    }
+
+    @Override
+    public RefreshToken refresh(Long userId, String oldRefreshToken, String newRefreshToken) throws IllegalArgumentException, IllegalStateException {
+        RefreshToken refreshToken = findOrElseThrow(userId);
+
+        validateToken(oldRefreshToken, refreshToken);
+
+        refreshToken.rotation(newRefreshToken);
+        refreshTokenRepository.save(refreshToken);
+
+        log.info("사용자 {}의 리프레시 토큰 갱신", userId);
+        return refreshToken;
+    }
+
+    @Override
+    public void delete(Long userId, String refreshToken) throws IllegalArgumentException {
+        RefreshToken token = findOrElseThrow(userId);
+        refreshTokenRepository.delete(token);
+        log.info("사용자 {}의 리프레시 토큰 삭제", userId);
+    }
+
+    private RefreshToken findOrElseThrow(Long userId) {
+        return refreshTokenRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("refresh token not found"));
+    }
+
+    /**
+     * @param requestRefreshToken  String : 사용자가 보낸 refresh token
+     * @param expectedRefreshToken String : Redis에 저장된 refresh token
+     * @throws IllegalStateException : 요청한 토큰과 저장된 토큰이 다르다면 토큰이 탈취되었다고 판단하여 값 삭제
+     */
+    private void validateToken(String requestRefreshToken, RefreshToken expectedRefreshToken) throws IllegalStateException {
+        if (isTakenAway(requestRefreshToken, expectedRefreshToken.getToken())) {
+            log.warn("리프레시 토큰 불일치(탈취). expected : {}, actual : {}", requestRefreshToken, expectedRefreshToken.getToken());
+            refreshTokenRepository.delete(expectedRefreshToken);
+            log.info("사용자 {}의 리프레시 토큰 삭제", expectedRefreshToken.getUserId());
+
+            throw new IllegalStateException("refresh token mismatched");
+        }
+    }
+
+    /**
+     * 토큰 탈취 여부 확인
+     *
+     * @param requestRefreshToken  String : 사용자가 보낸 refresh token
+     * @param expectedRefreshToken String : Redis에 저장된 refresh token
+     * @return boolean : 탈취되었다면 true, 아니면 false
+     */
+    private boolean isTakenAway(String requestRefreshToken, String expectedRefreshToken) {
+        return !requestRefreshToken.equals(expectedRefreshToken);
+    }
+}


### PR DESCRIPTION
## 작업 이유
> 805줄이지만 테스트 코드만 216줄이고, 대부분 유효성 검사 때문에 뻥튀기 된 겁니다.
- 회원 가입 시, 요청 DTO 유효성 Application 레벨 validation check
- RTR 기법 적용 및 redis 저장을 위한 refresh token 관련 클래스 정의 (도메인, 도메인 서비스, 레포지토리 정의)
- 3가지 커스텀 Validator 어노테이션 작성
- 쿠키 유틸 작성

<br/>

## 작업 사항
### 1️⃣ `RefreshToken` 관련 클래스
- RedisHash를 사용하여 RefreshToken Entity 정의
- RefreshTokenService 3가지 공개 메서드 제공 (저장, 리프레시, 삭제) 

### 2️⃣ 3가지 커스텀 Validator 
- `@NotWhiteSpace`: 어노테이션된 요소는 반드시 공백문자가 포함되어서는 안 됩니다. (단, null인 경우 true를 반환합니다.)
- `@NotEmoji`: 어노테이션된 요소는 반드시 이모지가 포함되어서는 안 됩니다. (단, null인 경우 true를 반환합니다.)
- `@Password`: 어노테이션된 요소는 반드시 8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해야 합니다. 적어도 하나 이상의 소문자 알파벳과 숫자가 포함되어야 합니다.

### 3️⃣ Cookie Util
- cookie 확인, 수정, 삭제를 위한 유틸입니다.
- 인증 파트 말고 사용할 일 거의 없겠지만, 궁금하신 부분은 질문 주시면 답변해드리겠습니다.

### 4️⃣ 회원가입 관련 Dto 유효성 검증
- username: 5~20자, 영문 소문자, 특수기호 `-`, `_`, `.` (그외 특수기호, 공백 사용 불가)
- name: 한글, 영문 대/소문자 (특수기호, 공백 사용 불가)
- password: 8~16자의 영문 대/소문, 숫자, 특수문자 (이모티콘, 공백 사용 불가)
- profile_image_url: `https://~` 접두사 부분 반드시 pennyway의 S3 서버에 해당하는 경우만 (?)
- phone: 11자리 정수 문자열, 앞 3자리는 `010`, `011`만 허용 (ex. "01011112222")

**🟡 실패 응답 7가지 및 성공 응답 1가지 테스트**

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/2766422e-0d3e-4705-baa4-b1dfa4766704", width="700px"/>
</div>

- 7가지 경우에 대해 테스트했고 모두 성공함을 확인했습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 일단 유효성 실패 시, 반환 문자열 임의로 작성했는데 문구 어떻게 할 지 디자인팀이랑 이야기 해보는 게 좋을 것 같음.
- 정규 표현식 쓰다보니 `@NotWhiteSpace`와 `@NotEmoji` 쓸 일이 없음. 그래도 혹시나 싶어 남겨두긴 했는데, 필요해보이는 지 확인 바람.
- 회원가입 시나리오에서 인증번호 확인하는 부분은 주석으로 처리해둔 상태
- api 접근 시 `anonymous`만 요청 가능하도록 추후 수정 필요함.
- 유효성 검사 시나리오가 너무 많아서 모두 테스트 해보지는 못 했습니다. 추가로 검증 필요하다고 느끼시는 부분 말씀해주시면 추가하겠습니다.

<br/>

## 발견한 이슈
- `@NotEmpty`와 별도 어노테이션(ex. `@Pattern`)의 유효성에 모두 걸리는 경우, 응답값이 랜덤으로 결정되는 현상이 있음.
   - 예를 들어, 유저 이름을 빈 문자열로 넘기면 `@NotEmpty`의 메시지가 나오거나 `@Pattern`의 메시지가 랜덤으로 반환됨.
- 현재 테스트 시나리오 시, profile을 `local`로 잡았는데 `test` 환경 추가 구성해야 할 것 같음.

