### PR TITLE
✨ 로그인 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.auth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
+import kr.co.pennyway.api.apis.auth.dto.SignInReq;
 import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
 import kr.co.pennyway.api.apis.auth.usecase.AuthUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
@@ -52,6 +53,20 @@ public class AuthController {
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signUp(@RequestBody @Validated SignUpReq.General request) {
         Pair<Long, Jwts> jwts = authUseCase.signUp(request);
+        ResponseCookie cookie = cookieUtil.createCookie("refreshToken", jwts.getValue().refreshToken(), Duration.ofDays(7).toSeconds());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .header(HttpHeaders.AUTHORIZATION, jwts.getValue().accessToken())
+                .body(SuccessResponse.from("user", Map.of("id", jwts.getKey())))
+                ;
+    }
+
+    @Operation(summary = "일반 로그인")
+    @PostMapping("/sign-in")
+    @PreAuthorize("isAnonymous()")
+    public ResponseEntity<?> signIn(@RequestBody @Validated SignInReq.General request) {
+        Pair<Long, Jwts> jwts = authUseCase.signIn(request);
         ResponseCookie cookie = cookieUtil.createCookie("refreshToken", jwts.getValue().refreshToken(), Duration.ofDays(7).toSeconds());
 
         return ResponseEntity.ok()

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
@@ -1,0 +1,23 @@
+package kr.co.pennyway.api.apis.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import kr.co.pennyway.api.common.validator.Password;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SignInReq {
+    public record General(
+            @Schema(description = "아이디", example = "pennyway")
+            @NotBlank(message = "아이디를 입력해주세요")
+            @Pattern(regexp = "^[a-z-_.]{5,20}$", message = "5~20자의 영문 소문자, -, _, . 만 사용 가능합니다.")
+            String username,
+            @Schema(description = "비밀번호", example = "pennyway1234")
+            @NotBlank(message = "비밀번호를 입력해주세요")
+            @Password(message = "8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해주세요. (적어도 하나의 영문 소문자, 숫자 포함)")
+            String password
+    ) {
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
@@ -2,8 +2,6 @@ package kr.co.pennyway.api.apis.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import kr.co.pennyway.api.common.validator.Password;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -12,11 +10,9 @@ public class SignInReq {
     public record General(
             @Schema(description = "아이디", example = "pennyway")
             @NotBlank(message = "아이디를 입력해주세요")
-            @Pattern(regexp = "^[a-z-_.]{5,20}$", message = "5~20자의 영문 소문자, -, _, . 만 사용 가능합니다.")
             String username,
             @Schema(description = "비밀번호", example = "pennyway1234")
             @NotBlank(message = "비밀번호를 입력해주세요")
-            @Password(message = "8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해주세요. (적어도 하나의 영문 소문자, 숫자 포함)")
             String password
     ) {
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/UserSyncHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/UserSyncHelper.java
@@ -9,12 +9,16 @@ import kr.co.pennyway.domain.domains.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Helper
 @RequiredArgsConstructor
 public class UserSyncHelper {
     private final UserService userService;
+
+    private final PasswordEncoder bCryptPasswordEncoder;
 
     /**
      * 일반 회원가입 시 이미 가입된 회원인지 확인
@@ -39,5 +43,26 @@ public class UserSyncHelper {
         }
 
         return Pair.of(Boolean.TRUE, user.getUsername());
+    }
+
+    /**
+     * 로그인 시 유저가 존재하고 비밀번호가 일치하는지 확인
+     */
+    @Transactional(readOnly = true)
+    public User readUserIfValid(String username, String password) {
+        User user;
+
+        try {
+            user = userService.readUserByUsername(username);
+
+            if (!bCryptPasswordEncoder.matches(password, user.getPassword())) {
+                throw new UserErrorException(UserErrorCode.NOT_MATCHED_PASSWORD);
+            }
+        } catch (UserErrorException e) {
+            log.warn("request not valid : {} : {}", username, e.getExplainError());
+            throw new UserErrorException(UserErrorCode.INVALID_USERNAME_OR_PASSWORD);
+        }
+
+        return user;
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthUseCase.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.auth.usecase;
 
 import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
+import kr.co.pennyway.api.apis.auth.dto.SignInReq;
 import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
 import kr.co.pennyway.api.apis.auth.helper.UserSyncHelper;
 import kr.co.pennyway.api.apis.auth.mapper.JwtAuthMapper;
@@ -28,6 +29,7 @@ public class AuthUseCase {
     private final PhoneVerificationMapper phoneVerificationMapper;
     private final PhoneVerificationService phoneVerificationService;
 
+
     public PhoneVerificationDto.PushCodeRes sendCode(PhoneVerificationDto.PushCodeReq request) {
         return phoneVerificationMapper.sendCode(request, PhoneVerificationType.SIGN_UP);
     }
@@ -47,6 +49,13 @@ public class AuthUseCase {
         // phoneVerificationHelper.verify(request.phone(), request.code());
 
         User user = userService.createUser(request.toEntity());
+
+        return Pair.of(user.getId(), jwtAuthMapper.createToken(user));
+    }
+
+    @Transactional(readOnly = true)
+    public Pair<Long, Jwts> signIn(SignInReq.General request) {
+        User user = userSyncHelper.readUserIfValid(request.username(), request.password());
 
         return Pair.of(user.getId(), jwtAuthMapper.createToken(user));
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
@@ -12,6 +12,7 @@ public enum UserErrorCode implements BaseErrorCode {
     ALREADY_SIGNUP(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "이미 회원가입한 유저입니다."),
 
     /* 401 UNAUTHORIZED */
+    NOT_MATCHED_PASSWORD(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS, "비밀번호가 일치하지 않습니다."),
     INVALID_USERNAME_OR_PASSWORD(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS, "유효하지 않은 아이디 또는 비밀번호입니다."),
 
     /* 403 FORBIDDEN */

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/repository/UserRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhone(String phone);
+
+    Optional<User> findByUsername(String username);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/service/UserService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/service/UserService.java
@@ -29,6 +29,11 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
+    public User readUserByUsername(String username) {
+        return userRepository.findByUsername(username).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
     public boolean isExistUser(Long id) {
         return userRepository.existsById(id);
     }


### PR DESCRIPTION
## 작업 이유
- 사용자 로그인 API 개발

<br/>

## 작업 사항
### 1️⃣ API 스펙
**📨 요청**
- url : `/v1/auth/sign-in`
- parameter: 없음
- pre-condition: 인증되지 않은 유저만 허용
- body
   ```json
   {
        "username": "", // 회원가입 때와 같은 유효성을 검사합니다.
        "password": ""  // 회원가입 때와 같은 유효성을 검사합니다.
   }
   ```   

<br/>

**📢 응답**
- header
   - `Set-Cookie`: refresh token 정보
   - `Authorization`: access token 정보
- body
   ```json
   {
       "code": "2000",
       "data": {
           "user": {
               "id": 1 // 로그인한 사용자 pk
           }
       }
   }
   ```
- error
   - username이 틀린 경우, password가 틀린 경우, 일반 회원가입 유저가 아닌 경우 모두 같은 응답을 반환합니다.
    ```json
    // 401_UNAUTHORIZED
    {
        "code": "4010",
        "message": "유효하지 않은 아이디 또는 비밀번호입니다."
    }
    ```

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/23feeb1b-b4a8-4e93-878e-bce511c36ded" width="500px"/>
</div>

<br/>

### 2️⃣ UserSyncHelper 테스트 케이스 3가지 추가
- 로그인 시, 유저가 존재하고 비밀번호가 일치하면 User를 반환한다.
- 로그인 시, username에 해당하는 유저가 존재하지 않으면 UserErrorException을 발생시킨다.
- 로그인 시, 비밀번호가 일치하지 않으면 UserErrorException을 발생시킨다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- `UserSyncHelper` 클래스에서 유저 존재 여부와 비밀번호 검증을 처리하는데, 다소 아름답지 못한 방법인 것 같아 의견이 궁금합니다.

<br/>

## 발견한 이슈
- 회원가입 API가 사용자 비밀번호를 암호화하지 않아서 로그인 테스트에 실패하는 중입니다.
   - Jwt 인증 필터 적용 후 개선하겠습니다.

