### PR TITLE
✨ Jwt 인증 필터

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
 import kr.co.pennyway.api.apis.auth.dto.SignInReq;
 import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
@@ -17,10 +18,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
 import java.util.Map;
@@ -67,6 +65,13 @@ public class AuthController {
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signIn(@RequestBody @Validated SignInReq.General request) {
         return createAuthenticatedResponse(authUseCase.signIn(request));
+    }
+
+    @Operation(summary = "토큰 갱신", description = "리프레시 토큰을 이용해 액세스 토큰과 리프레시 토큰을 갱신합니다.")
+    @GetMapping("/refresh")
+    @PreAuthorize("isAnonymous()")
+    public ResponseEntity<?> refresh(@CookieValue("refreshToken") @Valid String refreshToken) {
+        return createAuthenticatedResponse(authUseCase.refresh(refreshToken));
     }
 
     private ResponseEntity<?> createAuthenticatedResponse(Pair<Long, Jwts> userInfo) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
@@ -5,15 +5,18 @@ import kr.co.pennyway.api.common.annotation.RefreshTokenStrategy;
 import kr.co.pennyway.api.common.security.jwt.Jwts;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
 import kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaim;
+import kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaimKeys;
 import kr.co.pennyway.common.annotation.Helper;
 import kr.co.pennyway.domain.common.redis.refresh.RefreshToken;
 import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.infra.common.jwt.JwtProvider;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Slf4j
 @Helper
@@ -45,6 +48,18 @@ public class JwtAuthHelper {
 
         refreshTokenService.save(RefreshToken.of(user.getId(), refreshToken, toSeconds(refreshTokenProvider.getExpiryDate(refreshToken))));
         return Jwts.of(accessToken, refreshToken);
+    }
+
+    public Pair<Long, Jwts> refresh(String refreshToken) {
+        Map<String, ?> claims = refreshTokenProvider.getJwtClaimsFromToken(refreshToken).getClaims();
+
+        Long userId = Long.parseLong((String) claims.get(RefreshTokenClaimKeys.USER_ID.getValue()));
+        String role = (String) claims.get(RefreshTokenClaimKeys.ROLE.getValue());
+
+        String newAccessToken = accessTokenProvider.generateToken(AccessTokenClaim.of(userId, role));
+        RefreshToken newRefreshToken = refreshTokenService.refresh(userId, refreshToken, refreshTokenProvider.generateToken(RefreshTokenClaim.of(userId, role)));
+
+        return Pair.of(userId, Jwts.of(newAccessToken, newRefreshToken.getToken()));
     }
 
     private long toSeconds(LocalDateTime expiryTime) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthUseCase.java
@@ -61,6 +61,10 @@ public class AuthUseCase {
         return Pair.of(user.getId(), jwtAuthHelper.createToken(user));
     }
 
+    public Pair<Long, Jwts> refresh(String refreshToken) {
+        return jwtAuthHelper.refresh(refreshToken);
+    }
+
     private Pair<Boolean, String> checkOauthUserNotGeneralSignUp(String phone) {
         Pair<Boolean, String> isGeneralSignUpAllowed = userSyncMapper.isGeneralSignUpAllowed(phone);
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/annotation/RefreshTokenStrategy.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/annotation/RefreshTokenStrategy.java
@@ -8,6 +8,6 @@ import java.lang.annotation.*;
         ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Qualifier("accessTokenStrategy")
+@Qualifier("refreshTokenStrategy")
 public @interface RefreshTokenStrategy {
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/handler/GlobalExceptionHandler.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/handler/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -154,6 +155,20 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoHandlerFoundException.class)
     protected ErrorResponse handleNoHandlerFoundException(NoHandlerFoundException e) {
         log.warn("handleNoHandlerFoundException : {}", e.getMessage());
+
+        String code = String.valueOf(StatusCode.NOT_FOUND.getCode() * 10 + ReasonCode.INVALID_URL_OR_ENDPOINT.getCode());
+        return ErrorResponse.of(code, e.getMessage());
+    }
+
+    /**
+     * 존재하지 않는 URL 호출 시
+     *
+     * @see NoHandlerFoundException
+     */
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NoResourceFoundException.class)
+    protected ErrorResponse handleNoResourceFoundException(NoResourceFoundException e) {
+        log.warn("handleNoResourceFoundException : {}", e.getMessage());
 
         String code = String.valueOf(StatusCode.NOT_FOUND.getCode() * 10 + ReasonCode.INVALID_URL_OR_ENDPOINT.getCode());
         return ErrorResponse.of(code, e.getMessage());

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/handler/GlobalExceptionHandler.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/handler/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.common.response.handler;
 
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import kr.co.pennyway.api.common.response.ErrorResponse;
+import kr.co.pennyway.common.exception.CausedBy;
 import kr.co.pennyway.common.exception.GlobalErrorException;
 import kr.co.pennyway.common.exception.ReasonCode;
 import kr.co.pennyway.common.exception.StatusCode;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -21,7 +23,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
-import java.nio.file.AccessDeniedException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,7 +55,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AccessDeniedException.class)
     protected ErrorResponse handleAccessDeniedException(AccessDeniedException e) {
         log.warn("handleAccessDeniedException : {}", e.getMessage());
-        return ErrorResponse.of(String.valueOf(StatusCode.FORBIDDEN.getCode()), e.getMessage());
+        CausedBy causedBy = CausedBy.of(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN);
+
+        return ErrorResponse.of(causedBy.getCode(), causedBy.getReason());
     }
 
     /**

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/SecurityUserDetails.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/SecurityUserDetails.java
@@ -81,4 +81,14 @@ public class SecurityUserDetails implements UserDetails {
     public boolean isEnabled() {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public String toString() {
+        return "SecurityUserDetails{" +
+                "userId=" + userId +
+                ", username='" + username + '\'' +
+                ", authorities=" + authorities +
+                ", accountNonLocked=" + accountNonLocked +
+                '}';
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,127 @@
+package kr.co.pennyway.api.common.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.pennyway.api.common.security.authentication.UserDetailServiceImpl;
+import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
+import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
+import kr.co.pennyway.infra.common.exception.JwtErrorCode;
+import kr.co.pennyway.infra.common.exception.JwtErrorException;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT 인증 필터 <br/>
+ * 만약, 유효한 액세스 토큰과 리프레시 토큰이 모두 없다면 익명 사용자로 간주한다. <br/>
+ * 인증된 유저는 SecurityContextHolder에 SecurityUser를 등록하며, Controller에서 @AuthenticationPrincipal 어노테이션을 통해 접근할 수 있다.
+ *
+ * <pre>
+ * {@code
+ *  @GetMapping("/user")
+ *  public ResponseEntity<User> getUser(@AuthenticationPrincipal SecurityUser user) {
+ *      Long userId = user.getId();
+ *      ...
+ *  }
+ * }
+ * </pre>
+ *
+ * @see org.springframework.security.core.annotation.AuthenticationPrincipal
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final UserDetailServiceImpl userDetailServiceImpl;
+    private final ForbiddenTokenService forbiddenTokenService;
+
+    private final JwtProvider accessTokenProvider;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
+        if (isAnonymousRequest(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = resolveAccessToken(request, response);
+
+        UserDetails userDetails = getUserDetails(accessToken);
+        authenticateUser(userDetails, request);
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * AccessToken과 RefreshToken이 모두 없는 경우, 익명 사용자로 간주한다.
+     */
+    private boolean isAnonymousRequest(HttpServletRequest request) {
+        String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String refreshToken = request.getHeader(HttpHeaders.SET_COOKIE);
+
+        return accessToken == null && refreshToken == null;
+    }
+
+    /**
+     * @throws ServletException : Authorization 헤더가 없거나, 금지된 토큰이거나, 토큰이 만료된 경우 예외 발생
+     */
+    private String resolveAccessToken(HttpServletRequest request, HttpServletResponse response) throws ServletException {
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        String token = accessTokenProvider.resolveToken(authHeader);
+
+        if (!StringUtils.hasText(token)) {
+            handleAuthException(JwtErrorCode.EMPTY_ACCESS_TOKEN);
+        }
+
+        if (forbiddenTokenService.isForbidden(token)) {
+            handleAuthException(JwtErrorCode.FORBIDDEN_ACCESS_TOKEN);
+        }
+
+        if (accessTokenProvider.isTokenExpired(token)) {
+            handleAuthException(JwtErrorCode.EXPIRED_TOKEN);
+        }
+
+        return token;
+    }
+
+    /**
+     * UserDetailsService를 통해 SecurityUser를 가져오는 메서드
+     */
+    private UserDetails getUserDetails(final String accessToken) {
+        Long userId = (Long) accessTokenProvider.getJwtClaimsFromToken(accessToken).getClaims().get(AccessTokenClaimKeys.USER_ID.getValue());
+        return userDetailServiceImpl.loadUserByUsername(userId.toString());
+    }
+
+    /**
+     * SecurityContextHolder에 SecurityUser를 등록하는 메서드
+     */
+    private void authenticateUser(UserDetails userDetails, HttpServletRequest request) {
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities()
+        );
+
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.info("Authenticated user: {}", userDetails.getUsername());
+    }
+
+    /**
+     * 인증 예외가 발생했을 때, 로그를 남기고 예외를 던지는 메서드
+     */
+    private void handleAuthException(JwtErrorCode errorCode) throws ServletException {
+        log.warn("AuthErrorException(code={}, message={})", errorCode.name(), errorCode.getExplainError());
+        JwtErrorException exception = new JwtErrorException(errorCode);
+        throw new ServletException(exception);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
@@ -8,6 +8,7 @@ import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
 import kr.co.pennyway.infra.common.exception.JwtErrorCode;
 import kr.co.pennyway.infra.common.exception.JwtErrorException;
+import kr.co.pennyway.infra.common.jwt.JwtClaims;
 import kr.co.pennyway.infra.common.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -99,8 +100,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      * UserDetailsService를 통해 SecurityUser를 가져오는 메서드
      */
     private UserDetails getUserDetails(final String accessToken) {
-        Long userId = (Long) accessTokenProvider.getJwtClaimsFromToken(accessToken).getClaims().get(AccessTokenClaimKeys.USER_ID.getValue());
-        return userDetailService.loadUserByUsername(userId.toString());
+        JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
+        String userId = (String) claims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue());
+
+        return userDetailService.loadUserByUsername(userId);
     }
 
     /**

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
@@ -4,7 +4,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import kr.co.pennyway.api.common.security.authentication.UserDetailServiceImpl;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
 import kr.co.pennyway.infra.common.exception.JwtErrorCode;
@@ -17,6 +16,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -43,7 +43,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    private final UserDetailServiceImpl userDetailServiceImpl;
+    private final UserDetailsService userDetailService;
     private final ForbiddenTokenService forbiddenTokenService;
 
     private final JwtProvider accessTokenProvider;
@@ -100,7 +100,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      */
     private UserDetails getUserDetails(final String accessToken) {
         Long userId = (Long) accessTokenProvider.getJwtClaimsFromToken(accessToken).getClaims().get(AccessTokenClaimKeys.USER_ID.getValue());
-        return userDetailServiceImpl.loadUserByUsername(userId.toString());
+        return userDetailService.loadUserByUsername(userId.toString());
     }
 
     /**

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
@@ -99,7 +99,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     /**
      * UserDetailsService를 통해 SecurityUser를 가져오는 메서드
      */
-    private UserDetails getUserDetails(final String accessToken) {
+    private UserDetails getUserDetails(String accessToken) {
         JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
         String userId = (String) claims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue());
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtExceptionFilter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtExceptionFilter.java
@@ -25,8 +25,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (Exception e) {
+            log.warn("Exception caught in JwtExceptionFilter: {}", e.getMessage());
             JwtErrorException exception = JwtErrorCodeUtil.determineAuthErrorException(e);
-            log.warn("Exception caught in JwtExceptionFilter: {}", exception.getMessage());
 
             sendAuthError(response, exception);
         }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtExceptionFilter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,42 @@
+package kr.co.pennyway.api.common.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.pennyway.api.common.response.ErrorResponse;
+import kr.co.pennyway.infra.common.exception.JwtErrorException;
+import kr.co.pennyway.infra.common.util.JwtErrorCodeUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            JwtErrorException exception = JwtErrorCodeUtil.determineAuthErrorException(e);
+            log.warn("Exception caught in JwtExceptionFilter: {}", exception.getMessage());
+
+            sendAuthError(response, exception);
+        }
+    }
+
+    private void sendAuthError(HttpServletResponse response, JwtErrorException e) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(e.getErrorCode().getStatusCode().getCode());
+
+        ErrorResponse errorResponse = ErrorResponse.of(e.causedBy().getCode(), e.causedBy().getReason());
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/handler/JwtAccessDeniedHandler.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/handler/JwtAccessDeniedHandler.java
@@ -22,7 +22,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        log.error("handle error: {}", accessDeniedException.getMessage());
+        log.warn("handle error: {}", accessDeniedException.getMessage());
         CausedBy causedBy = CausedBy.of(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN);
 
         response.setContentType("application/json;charset=UTF-8");

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/handler/JwtAccessDeniedHandler.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package kr.co.pennyway.api.common.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.pennyway.api.common.response.ErrorResponse;
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.ReasonCode;
+import kr.co.pennyway.common.exception.StatusCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.error("handle error: {}", accessDeniedException.getMessage());
+        CausedBy causedBy = CausedBy.of(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN);
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(causedBy.statusCode().getCode());
+        ErrorResponse errorResponse = ErrorResponse.of(causedBy.getCode(), causedBy.getReason());
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/handler/JwtAuthenticationEntryPoint.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package kr.co.pennyway.api.common.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.pennyway.api.common.response.ErrorResponse;
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.ReasonCode;
+import kr.co.pennyway.common.exception.StatusCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.error("commence error: {}", authException.getMessage());
+        CausedBy causedBy = CausedBy.of(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS);
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(causedBy.statusCode().getCode());
+        ErrorResponse errorResponse = ErrorResponse.of(causedBy.getCode(), causedBy.getReason());
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/handler/JwtAuthenticationEntryPoint.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/handler/JwtAuthenticationEntryPoint.java
@@ -22,7 +22,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        log.error("commence error: {}", authException.getMessage());
+        log.warn("commence error: {}", authException.getMessage());
         CausedBy causedBy = CausedBy.of(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS);
 
         response.setContentType("application/json;charset=UTF-8");

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/JwtSecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/JwtSecurityConfig.java
@@ -1,0 +1,23 @@
+package kr.co.pennyway.api.config.security;
+
+import kr.co.pennyway.api.common.security.filter.JwtAuthenticationFilter;
+import kr.co.pennyway.api.common.security.filter.JwtExceptionFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+    private final JwtExceptionFilter jwtExceptionFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -1,6 +1,8 @@
 package kr.co.pennyway.api.config.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.common.security.filter.JwtAuthenticationFilter;
+import kr.co.pennyway.api.common.security.filter.JwtExceptionFilter;
 import kr.co.pennyway.api.common.security.handler.JwtAccessDeniedHandler;
 import kr.co.pennyway.api.common.security.handler.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +10,7 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -32,6 +35,9 @@ public class SecurityConfig {
             "/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",
     };
     private final ObjectMapper objectMapper;
+    private final JwtExceptionFilter jwtExceptionFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtSecurityConfig jwtSecurityConfig;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -57,6 +63,9 @@ public class SecurityConfig {
                 .logout(AbstractHttpConfigurer::disable)
                 .sessionManagement((sessionManagement) ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+//                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+//                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .with(jwtSecurityConfig, Customizer.withDefaults())
                 .authorizeHttpRequests(
                         auth -> auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                                 .requestMatchers(HttpMethod.OPTIONS, "*").permitAll()

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -1,5 +1,8 @@
 package kr.co.pennyway.api.config.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.common.security.handler.JwtAccessDeniedHandler;
+import kr.co.pennyway.api.common.security.handler.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -10,7 +13,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -26,10 +31,21 @@ public class SecurityConfig {
             // Swagger
             "/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",
     };
+    private final ObjectMapper objectMapper;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AccessDeniedHandler accessDeniedHandler() {
+        return new JwtAccessDeniedHandler(objectMapper);
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return new JwtAuthenticationEntryPoint(objectMapper);
     }
 
     @Bean

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -62,6 +62,11 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.OPTIONS, "*").permitAll()
                                 .requestMatchers(HttpMethod.GET, publicReadOnlyPublicEndpoints).permitAll()
                                 .anyRequest().permitAll()
+                )
+                .exceptionHandling(
+                        exception -> exception
+                                .accessDeniedHandler(accessDeniedHandler())
+                                .authenticationEntryPoint(authenticationEntryPoint())
                 );
         return http.build();
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityFilterConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityFilterConfig.java
@@ -1,0 +1,33 @@
+package kr.co.pennyway.api.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.common.security.filter.JwtAuthenticationFilter;
+import kr.co.pennyway.api.common.security.filter.JwtExceptionFilter;
+import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Configuration
+public class SecurityFilterConfig {
+    private final UserDetailsService userDetailServiceImpl;
+    private final ForbiddenTokenService forbiddenTokenService;
+
+    private final JwtProvider accessTokenProvider;
+
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public JwtExceptionFilter jwtExceptionFilter() {
+        return new JwtExceptionFilter(objectMapper);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthorizationFilter() {
+        return new JwtAuthenticationFilter(userDetailServiceImpl, forbiddenTokenService, accessTokenProvider);
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/forbidden/ForbiddenToken.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/forbidden/ForbiddenToken.java
@@ -1,0 +1,42 @@
+package kr.co.pennyway.domain.common.redis.forbidden;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash("forbiddenToken")
+public class ForbiddenToken {
+    @Id
+    private final String accessToken;
+    private final Long userId;
+    @TimeToLive
+    private final long ttl;
+
+    @Builder
+    private ForbiddenToken(String accessToken, Long userId, long ttl) {
+        this.accessToken = accessToken;
+        this.userId = userId;
+        this.ttl = ttl;
+    }
+
+    public static ForbiddenToken of(String accessToken, Long userId, long ttl) {
+        return new ForbiddenToken(accessToken, userId, ttl);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ForbiddenToken that)) return false;
+        return accessToken.equals(that.accessToken) && userId.equals(that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = accessToken.hashCode();
+        result = ((1 << 5) - 1) * result + userId.hashCode();
+        return result;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/forbidden/ForbiddenTokenRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/forbidden/ForbiddenTokenRepository.java
@@ -1,0 +1,6 @@
+package kr.co.pennyway.domain.common.redis.forbidden;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ForbiddenTokenRepository extends CrudRepository<ForbiddenToken, String> {
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/forbidden/ForbiddenTokenService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/forbidden/ForbiddenTokenService.java
@@ -1,0 +1,43 @@
+package kr.co.pennyway.domain.common.redis.forbidden;
+
+import kr.co.pennyway.common.annotation.DomainService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@DomainService
+public class ForbiddenTokenService {
+    private final ForbiddenTokenRepository forbiddenTokenRepository;
+
+    /**
+     * 토큰을 블랙 리스트에 등록합니다.
+     *
+     * @param accessToken String : 블랙 리스트에 등록할 액세스 토큰
+     * @param userId      Long : 블랙 리스트에 등록할 유저 아이디
+     * @param expiresAt   LocalDateTime : 블랙 리스트에 등록할 토큰의 만료 시간 (등록할 access token의 만료시간을 추출한 값)
+     */
+    public void createForbiddenToken(String accessToken, Long userId, LocalDateTime expiresAt) {
+        final LocalDateTime now = LocalDateTime.now();
+        final long timeToLive = Duration.between(now, expiresAt).toSeconds();
+
+        log.info("forbidden token ttl : {}", timeToLive);
+
+        ForbiddenToken forbiddenToken = ForbiddenToken.of(accessToken, userId, timeToLive);
+        forbiddenTokenRepository.save(forbiddenToken);
+        log.info("forbidden token registered. about User : {}", forbiddenToken.getUserId());
+    }
+
+    /**
+     * 토큰이 블랙 리스트에 등록되어 있는지 확인합니다.
+     *
+     * @return : 블랙 리스트에 등록되어 있으면 true, 아니면 false
+     */
+    public boolean isForbidden(String accessToken) {
+        return forbiddenTokenRepository.existsById(accessToken);
+    }
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/exception/JwtErrorCode.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/exception/JwtErrorCode.java
@@ -34,6 +34,7 @@ public enum JwtErrorCode implements BaseErrorCode {
      */
     FORBIDDEN_ACCESS_TOKEN(FORBIDDEN, ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "해당 토큰에는 엑세스 권한이 없습니다"),
     SUSPENDED_OR_BANNED_TOKEN(FORBIDDEN, USER_ACCOUNT_SUSPENDED_OR_BANNED, "사용자 계정이 정지되었습니다"),
+    TAKEN_AWAY_TOKEN(FORBIDDEN, TAMPERED_OR_MALFORMED_TOKEN, "탈취당한 토큰입니다. 다시 로그인 해주세요."),
 
     /**
      * 500 INTERNAL_SERVER_ERROR: 서버 내부 에러

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/exception/JwtErrorCode.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/exception/JwtErrorCode.java
@@ -33,8 +33,8 @@ public enum JwtErrorCode implements BaseErrorCode {
      * 403 FORBIDDEN: 인증된 클라이언트가 권한이 없는 자원에 접근
      */
     FORBIDDEN_ACCESS_TOKEN(FORBIDDEN, ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "해당 토큰에는 엑세스 권한이 없습니다"),
+    TAKEN_AWAY_TOKEN(FORBIDDEN, ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "탈취당한 토큰입니다. 다시 로그인 해주세요."),
     SUSPENDED_OR_BANNED_TOKEN(FORBIDDEN, USER_ACCOUNT_SUSPENDED_OR_BANNED, "사용자 계정이 정지되었습니다"),
-    TAKEN_AWAY_TOKEN(FORBIDDEN, TAMPERED_OR_MALFORMED_TOKEN, "탈취당한 토큰입니다. 다시 로그인 해주세요."),
 
     /**
      * 500 INTERNAL_SERVER_ERROR: 서버 내부 에러


### PR DESCRIPTION
## 작업 이유
- Refresh token refresh api 개방
- Jwt 인증 필터 작성
- WebSecurity 인증/인가 예외 핸들러 작성
- MethodSecurity 인증/인가 예외 핸들링

리프레시 기능은 안 했어야 했는데, 자꾸 토큰 만료되는 덕에 테스트가 너무 힘들어서 그만..

<br/>

## 작업 사항
### | 1️⃣ RefreshToken refresh api
**📨 요청**
- url : `/v1/auth/refresh`
- header
   - `Set-Cookie`: refresh token 정보
- pre-condition: 인증되지 않은 유저만 허용

<br/>

**📢 응답**
- header
   - `Set-Cookie`: refresh token 정보
   - `Authorization`: access token 정보
- body
   ```json
   {
       "code": "2000",
       "data": {
           "user": {
               "id": 1 // 로그인한 사용자 pk
           }
       }
   }
   ```

<br/>

**🟡 탈취 시나리오 (RTR)**
- 재현 방법
   1. 로그인을 하고 refresh token 정보 저장
   2. refresh api 호출
   3. 새로 발급받은 refresh 토큰을 (1)의 토큰으로 변경
   4. refresh api 재호출

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/02fb1045-3a86-4bf2-b86a-d24e83a5d1a9" width="600px"/>
</div>

<br/>

### | 2️⃣ Jwt 인증 & 예외 필터

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/c878a645-239f-4a6b-81ef-5b55ad5226ce" width="300px"/>
</div>

- 순서는 `JwtExceptionFilter` → `JwtAuthenticationFilter`로 진행됩니다.
- `Authentication` 헤더가 없는 유저는 SecurityUser 객체를 생성하지 않고 `anonymous` 권한으로 진행합니다.
- `Authentication` 헤더가 존재하면 반드시 인증에 성공해야 필터를 통과할 수 있습니다.

<br/>

**💡 Controller에서 인증된 사용자의 정보를 조회하는 방법**
> ⚠️ 인증 기능을 개발하는 프로그래머 외에 Jwt 관련 유틸 혹은 클래스를 조작할 일이 절대 없습니다.

```java
@GetMapping("/isAuthenticated")
@PreAuthorize("isAuthenticated()")
public ResponseEntity<?> isAuthenticated(@AuthenticationPrincipal SecurityUserDetails user) {
    log.info("user: {}", user);
    return ResponseEntity.ok(SuccessResponse.from("user", user));
}
```

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/f000f6eb-56b7-40d6-90c1-5ecba3aa83d3" width="600px"/>
</div>

- `@AuthenticationPrincipal SecurityUserDetails user`를 사용하면, 요청자의 정보를 조회 가능합니다.
- principal 정보는 `@PreAuthorize`에서 다음과 같이 사용할 수 있습니다.
  ```java
  @PreAuthorize("isAuthenticated() and @managerAuthorize.isManager(principal.userId, #petId) and @memoAuthorize.isValidRootMemoCategory(#rootMemoCategoryId, #petId)")
   public ResponseEntity<?> saveSubMemoCategory(
            @PathVariable("pet_id") Long petId,
            @PathVariable("root_memo_category_id") Long rootMemoCategoryId,
            @RequestBody @Valid SubMemoCategorySaveReq req
    ) {
        ...
    }
  ```


<br/>

### | 3️⃣ WebSecurity 예외 핸들러
- web security 인증에 실패한 경우 `JwtAuthenticationEntryPoint`로 넘어갑니다.
   - 현재는 `JwtExceptionFilter`가 핸들링하므로 사실 여기로 예외가 넘어갈 일이 없습니다.
   - `JwtExceptionFilter` 대신 `JwtAuthenticationEntryPoint`를 사용할 수 있는 방향으로 리팩토링 해볼 예정입니다.
- web security 인가에 실패한 경우 `JwtAccessDeniedHandler`로 넘어갑니다.
   ```java
   http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
   ```

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/bb1a3f96-7641-4a55-969c-5c52d7cc117c" width="600px"/>
</div>

<br/>

### | 4️⃣ MethodSecurity 예외 핸들러
- method security 인가에 실패한 경우 `GlobalExceptionHandler`로 넘어갑니다.
  ```java
  @PreAuthorize("isAuthenticated()")
  ```

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/73191ea7-1143-4b28-a62d-cf50d7cf6567" width="600px"/>
</div>

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- `@AuthenticationPrincipal` 사용 방법 ‼️‼️‼️
- 인증 필터에 개선되어야 할 점이 있는지?

<br/>

## 발견한 이슈
- spring security의 `apply()` 메서드가 6.2 버전부터 deprecated 되었습니다.
```java
// 이전 방식
http.apply(jwtSecurityConfig);

// 현재 방식
http.with(jwtSecurityConfig, Customizer.withDefaults());
```
- 통합 테스트를 안 하니 불안 요소가 상당히 많습니다. 하나하나 다 검증해보지도 못 한 상황이라, 조만간 티켓 등록해야 할 것 같습니다.
