### PR TITLE
✏️ Swagger + Security 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,8 +55,8 @@ jobs:
       - name: docker build and push
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build -t jinlee1703/pennyway-was .
-          docker push jinlee1703/pennyway-was
+          docker build -t pennyway/pennyway-was .
+          docker push pennyway/pennyway-was
 
       # 5. AWS SSM을 통한 Run-Command (Docker 이미지 pull 후 docker-compose를 통한 실행)
       - name: AWS SSM Send-Command
@@ -71,5 +71,5 @@ jobs:
           command: |
             docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             docker system prune -a -f
-            docker pull jinlee1703/pennyway-was
+            docker pull pennyway/pennyway-was
             docker-compose up -d

--- a/pennyway-app-external-api/build.gradle
+++ b/pennyway-app-external-api/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     /* Swagger */
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
 
+    /* jackson */
+    implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
+
     implementation 'org.springframework.boot:spring-boot-starter-web:3.2.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.2.3'
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SignInReq {
+    @Schema(title = "로그인 요청")
     public record General(
             @Schema(description = "아이디", example = "pennyway")
             @NotBlank(message = "아이디를 입력해주세요")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
@@ -2,12 +2,9 @@ package kr.co.pennyway.api.apis.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SignInReq {
-    @Schema(title = "로그인 요청")
+    @Schema(name = "signInReqGeneral", title = "로그인 요청")
     public record General(
             @Schema(description = "아이디", example = "pennyway")
             @NotBlank(message = "아이디를 입력해주세요")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -40,7 +40,7 @@ public class SignUpReq {
         }
     }
 
-    @Schema(title = "일반 회원가입 요청 DTO")
+    @Schema(name = "signUpReqGeneral", title = "일반 회원가입 요청 DTO")
     public record General(
             @Schema(description = "아이디", example = "pennyway")
             @NotBlank(message = "아이디를 입력해주세요")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/CustomGrantedAuthority.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/CustomGrantedAuthority.java
@@ -1,0 +1,49 @@
+package kr.co.pennyway.api.common.security.authentication;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.util.Assert;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public final class CustomGrantedAuthority implements GrantedAuthority, Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final String role;
+
+    @JsonCreator
+    public CustomGrantedAuthority(@JsonProperty("authority") String role) {
+        Assert.hasText(role, "role must not be empty");
+        this.role = role;
+    }
+
+    @Override
+    public String getAuthority() {
+        return role;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof SimpleGrantedAuthority sga) {
+            return this.role.equals(sga.getAuthority());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.role.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return this.role;
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/CustomGrantedAuthority.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/CustomGrantedAuthority.java
@@ -3,7 +3,6 @@ package kr.co.pennyway.api.common.security.authentication;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.util.Assert;
 
 import java.io.Serial;
@@ -31,8 +30,8 @@ public final class CustomGrantedAuthority implements GrantedAuthority, Serializa
         if (this == obj) {
             return true;
         }
-        if (obj instanceof SimpleGrantedAuthority sga) {
-            return this.role.equals(sga.getAuthority());
+        if (obj instanceof CustomGrantedAuthority cga) {
+            return this.role.equals(cga.getAuthority());
         }
         return false;
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/SecurityUserDetails.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/SecurityUserDetails.java
@@ -2,21 +2,27 @@ package kr.co.pennyway.api.common.security.authentication;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import kr.co.pennyway.domain.domains.user.domain.User;
-import kr.co.pennyway.domain.domains.user.type.Role;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.util.Arrays;
+import java.io.Serial;
 import java.util.Collection;
+import java.util.List;
 
 @Getter
-public class SecurityUserDetails implements UserDetails {
-    private final Long userId;
-    private final String username;
-    private final Collection<? extends GrantedAuthority> authorities;
-    private final boolean accountNonLocked;
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SecurityUserDetails implements UserDetails {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private Long userId;
+    private String username;
+    private Collection<? extends GrantedAuthority> authorities;
+    private boolean accountNonLocked;
 
     @JsonIgnore
     private boolean enabled;
@@ -39,10 +45,7 @@ public class SecurityUserDetails implements UserDetails {
         return SecurityUserDetails.builder()
                 .userId(user.getId())
                 .username(user.getUsername())
-                .authorities(Arrays.stream(Role.values())
-                        .filter(roleType -> roleType == user.getRole())
-                        .map(roleType -> (GrantedAuthority) roleType::getType)
-                        .toList())
+                .authorities(List.of(new CustomGrantedAuthority(user.getRole().getType())))
                 .accountNonLocked(user.getLocked())
                 .build();
     }
@@ -91,4 +94,5 @@ public class SecurityUserDetails implements UserDetails {
                 ", accountNonLocked=" + accountNonLocked +
                 '}';
     }
+
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/JacksonConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/JacksonConfig.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.api.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.RequiredArgsConstructor;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+@RequiredArgsConstructor
+public class JacksonConfig {
+    @Bean
+    Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder() {
+        return new Jackson2ObjectMapperBuilder()
+                .serializationInclusion(JsonInclude.Include.ALWAYS)
+                .modulesToInstall(new JsonNullableModule())
+                .indentOutput(true);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/SwaggerConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/SwaggerConfig.java
@@ -17,8 +17,8 @@ import org.springframework.web.filter.ForwardedHeaderFilter;
 @Configuration
 @OpenAPIDefinition(
         servers = {
-                @Server(url = "${pennyway.domain.local}", description = "Local Server"),
-                @Server(url = "${pennyway.domain.dev}", description = "Develop Server")
+                @Server(url = "${pennyway.server.domain.local}", description = "Local Server"),
+                @Server(url = "${pennyway.server.domain.dev}", description = "Develop Server")
         }
 )
 @RequiredArgsConstructor

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/CorsConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/CorsConfig.java
@@ -1,0 +1,33 @@
+package kr.co.pennyway.api.config.security;
+
+import kr.co.pennyway.infra.common.properties.ServerProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class CorsConfig {
+    private final ServerProperties serverProperties;
+    
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of(serverProperties.getLocal(), serverProperties.getDev()));
+        configuration.setAllowedMethods(List.of("GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.SET_COOKIE));
+        configuration.setMaxAge(3600L);
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityAdapterConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityAdapterConfig.java
@@ -4,6 +4,7 @@ import kr.co.pennyway.api.common.security.filter.JwtAuthenticationFilter;
 import kr.co.pennyway.api.common.security.filter.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.DefaultSecurityFilterChain;
@@ -12,11 +13,14 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @RequiredArgsConstructor
 public class SecurityAdapterConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+    private final DaoAuthenticationProvider daoAuthenticationProvider;
+
     private final JwtExceptionFilter jwtExceptionFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
+        http.authenticationProvider(daoAuthenticationProvider);
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         http.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityAdapterConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityAdapterConfig.java
@@ -11,7 +11,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @RequiredArgsConstructor
-public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+public class SecurityAdapterConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
     private final JwtExceptionFilter jwtExceptionFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityAuthConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityAuthConfig.java
@@ -1,6 +1,9 @@
 package kr.co.pennyway.api.config.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.common.security.authentication.UserDetailServiceImpl;
+import kr.co.pennyway.api.common.security.handler.JwtAccessDeniedHandler;
+import kr.co.pennyway.api.common.security.handler.JwtAuthenticationEntryPoint;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -10,15 +13,28 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
 
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Configuration
-public class SecurityAuthenticationConfig {
+public class SecurityAuthConfig {
     private final UserDetailServiceImpl userDetailsService;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public PasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AccessDeniedHandler accessDeniedHandler() {
+        return new JwtAccessDeniedHandler(objectMapper);
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return new JwtAuthenticationEntryPoint(objectMapper);
     }
 
     @Bean

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityAuthConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityAuthConfig.java
@@ -1,0 +1,36 @@
+package kr.co.pennyway.api.config.security;
+
+import kr.co.pennyway.api.common.security.authentication.UserDetailServiceImpl;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Configuration
+public class SecurityAuthenticationConfig {
+    private final UserDetailServiceImpl userDetailsService;
+
+    @Bean
+    public PasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider daoAuthenticationProvider() {
+        DaoAuthenticationProvider daoAuthenticationProvider = new DaoAuthenticationProvider();
+        daoAuthenticationProvider.setUserDetailsService(userDetailsService);
+        daoAuthenticationProvider.setPasswordEncoder(bCryptPasswordEncoder());
+        return daoAuthenticationProvider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
             "/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",
     };
     private final ObjectMapper objectMapper;
-    private final JwtSecurityConfig jwtSecurityConfig;
+    private final SecurityAdapterConfig securityAdapterConfig;
     private final CorsConfigurationSource corsConfigurationSource;
 
     @Bean
@@ -61,7 +61,7 @@ public class SecurityConfig {
                 .logout(AbstractHttpConfigurer::disable)
                 .sessionManagement((sessionManagement) ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .with(jwtSecurityConfig, Customizer.withDefaults())
+                .with(securityAdapterConfig, Customizer.withDefaults())
                 .authorizeHttpRequests(
                         auth -> auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                                 .requestMatchers(HttpMethod.OPTIONS, "*").permitAll()

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
     private final CorsConfigurationSource corsConfigurationSource;
     private final AccessDeniedHandler accessDeniedHandler;
     private final AuthenticationEntryPoint authenticationEntryPoint;
-    
+
     @Bean
     @Profile({"local", "dev", "test"})
     @Order(SecurityProperties.BASIC_AUTH_ORDER)
@@ -46,7 +46,7 @@ public class SecurityConfig {
                 .cors((cors) -> cors.configurationSource(corsConfigurationSource))
                 .authorizeHttpRequests(
                         auth -> defaultAuthorizeHttpRequests(auth)
-                                .requestMatchers(ANONYMOUS_ENDPOINTS).anonymous()
+                                .requestMatchers(READ_ONLY_PUBLIC_ENDPOINTS).permitAll()
                                 .anyRequest().authenticated()
                 ).build();
     }
@@ -81,6 +81,6 @@ public class SecurityConfig {
             AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth) {
         return auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .requestMatchers(HttpMethod.OPTIONS, "*").permitAll()
-                .requestMatchers(HttpMethod.GET, READ_ONLY_PUBLIC_ENDPOINTS).permitAll();
+                .requestMatchers(ANONYMOUS_ENDPOINTS).anonymous();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -3,7 +3,6 @@ package kr.co.pennyway.api.config.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.common.security.handler.JwtAccessDeniedHandler;
 import kr.co.pennyway.api.common.security.handler.JwtAuthenticationEntryPoint;
-import kr.co.pennyway.infra.common.properties.ServerProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.ConditionalOnDefaultWebSecurity;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
@@ -11,7 +10,6 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -22,11 +20,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
-import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -40,7 +34,7 @@ public class SecurityConfig {
     };
     private final ObjectMapper objectMapper;
     private final JwtSecurityConfig jwtSecurityConfig;
-    private final ServerProperties serverProperties;
+    private final CorsConfigurationSource corsConfigurationSource;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -62,7 +56,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .cors((cors) -> cors.configurationSource(corsConfigurationSource()))
+                .cors((cors) -> cors.configurationSource(corsConfigurationSource))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
                 .sessionManagement((sessionManagement) ->
@@ -81,20 +75,5 @@ public class SecurityConfig {
                 );
 
         return http.build();
-    }
-
-    @Bean
-    CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(serverProperties.getLocal(), serverProperties.getDev()));
-        configuration.setAllowedMethods(List.of("GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"));
-        configuration.setAllowedHeaders(List.of("*"));
-        configuration.setExposedHeaders(List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.SET_COOKIE));
-        configuration.setMaxAge(3600L);
-        configuration.setAllowCredentials(true);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -1,8 +1,5 @@
 package kr.co.pennyway.api.config.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.pennyway.api.common.security.handler.JwtAccessDeniedHandler;
-import kr.co.pennyway.api.common.security.handler.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.ConditionalOnDefaultWebSecurity;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
@@ -19,8 +16,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -37,26 +32,12 @@ public class SecurityConfig {
             "/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",
     };
     private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**"};
-    
-    private final ObjectMapper objectMapper;
+
     private final SecurityAdapterConfig securityAdapterConfig;
     private final CorsConfigurationSource corsConfigurationSource;
-
-    @Bean
-    public PasswordEncoder bCryptPasswordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
-    @Bean
-    public AccessDeniedHandler accessDeniedHandler() {
-        return new JwtAccessDeniedHandler(objectMapper);
-    }
-
-    @Bean
-    public AuthenticationEntryPoint authenticationEntryPoint() {
-        return new JwtAuthenticationEntryPoint(objectMapper);
-    }
-
+    private final AccessDeniedHandler accessDeniedHandler;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+    
     @Bean
     @Profile({"local", "dev", "test"})
     @Order(SecurityProperties.BASIC_AUTH_ORDER)
@@ -91,8 +72,8 @@ public class SecurityConfig {
                 .with(securityAdapterConfig, Customizer.withDefaults())
                 .exceptionHandling(
                         exception -> exception
-                                .accessDeniedHandler(accessDeniedHandler())
-                                .authenticationEntryPoint(authenticationEntryPoint())
+                                .accessDeniedHandler(accessDeniedHandler)
+                                .authenticationEntryPoint(authenticationEntryPoint)
                 );
     }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.config.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.common.security.handler.JwtAccessDeniedHandler;
 import kr.co.pennyway.api.common.security.handler.JwtAuthenticationEntryPoint;
+import kr.co.pennyway.infra.common.properties.ServerProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.ConditionalOnDefaultWebSecurity;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
@@ -10,6 +11,7 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -24,7 +26,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -38,6 +40,7 @@ public class SecurityConfig {
     };
     private final ObjectMapper objectMapper;
     private final JwtSecurityConfig jwtSecurityConfig;
+    private final ServerProperties serverProperties;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -80,13 +83,16 @@ public class SecurityConfig {
         return http.build();
     }
 
-    // TODO: dev, test, prod 환경이 정해지면 수정 필요.
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOrigin("http://localhost:3000");
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"));
+        configuration.setAllowedOrigins(List.of(serverProperties.getLocal(), serverProperties.getDev()));
+        configuration.setAllowedMethods(List.of("GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.SET_COOKIE));
+        configuration.setMaxAge(3600L);
         configuration.setAllowCredentials(true);
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -37,7 +38,7 @@ public class SecurityConfig {
     private final CorsConfigurationSource corsConfigurationSource;
 
     @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+    public PasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
     }
 

--- a/pennyway-app-external-api/src/main/resources/application.yml
+++ b/pennyway-app-external-api/src/main/resources/application.yml
@@ -4,11 +4,6 @@ spring:
       local: common, domain, infra
       dev: common, domain, infra
 
-pennyway:
-  domain:
-    local: ${PENNYWAY_DOMAIN_LOCAL}
-    dev: ${PENNYWAY_DOMAIN_DEV}
-
 jwt:
   secret-key:
     access-token: ${JWT_ACCESS_SECRET_KEY}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/ServerProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/ServerProperties.java
@@ -1,0 +1,13 @@
+package kr.co.pennyway.infra.common.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "pennyway.server.domain")
+public class ServerProperties {
+    private final String local;
+    private final String dev;
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/ConfigurationPropertiesConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/ConfigurationPropertiesConfig.java
@@ -1,0 +1,12 @@
+package kr.co.pennyway.infra.config;
+
+import kr.co.pennyway.infra.common.properties.ServerProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties({
+        ServerProperties.class
+})
+@Configuration
+public class ConfigurationPropertiesConfig {
+}

--- a/pennyway-infra/src/main/resources/application-infra.yml
+++ b/pennyway-infra/src/main/resources/application-infra.yml
@@ -5,9 +5,10 @@ spring:
       dev: common
 
 pennyway:
-  domain:
-    local: ${PENNYWAY_DOMAIN_LOCAL}
-    dev: ${PENNYWAY_DOMAIN_DEV}
+  server:
+    domain:
+      local: ${PENNYWAY_DOMAIN_LOCAL}
+      dev: ${PENNYWAY_DOMAIN_DEV}
 
 ---
 spring:

--- a/pennyway-infra/src/main/resources/application-infra.yml
+++ b/pennyway-infra/src/main/resources/application-infra.yml
@@ -4,6 +4,11 @@ spring:
       local: common
       dev: common
 
+pennyway:
+  domain:
+    local: ${PENNYWAY_DOMAIN_LOCAL}
+    dev: ${PENNYWAY_DOMAIN_DEV}
+
 ---
 spring:
   config:


### PR DESCRIPTION
## 작업 이유
> `/swapfile` 크기 조정하느라, 서버에서 내려주는 Swagger 문서는 아직 테스트는 못 해봤습니다.
- Security Filter 에서 캐싱된 인증 유저가 역직렬화에 실패함.
- Swagger 문서에 일부 DTO가 누락되거나, 잘못된 DTO가 표시됨.
- Swagger 문서에서 요청을 보내면 잘못된 request url이 설정됨.

<br/>

## 작업 사항
### 1️⃣ SecurityUserDetails 역직렬화 문제 해결
```java
@Getter
@NoArgsConstructor(access = AccessLevel.PRIVATE)
public final class SecurityUserDetails implements UserDetails {
    @Serial
    private static final long serialVersionUID = 1L;

    private Long userId;
    private String username;
    private Collection<? extends GrantedAuthority> authorities;
    private boolean accountNonLocked;

    @JsonIgnore
    private boolean enabled;
    @JsonIgnore
    private String password;
    @JsonIgnore
    private boolean credentialsNonExpired;
    @JsonIgnore
    private boolean accountNonExpired;
    ...
}
```
- `GrantedAuthority`를 구현하는 `SimpleGrantedAuthority`를 사용했으나 직렬화/역직렬화 지원 안 함
- 공식 문서를 참고하여 JacksonConfig 설정에 `SimpleGrantedAuthorityMinIn` 클래스를 적용해주었으나 역직렬화 실패
   ```java
   @Configuration
   @RequiredArgsConstructor
   public class JacksonConfig {
       @Bean
       Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder() {
           return new Jackson2ObjectMapperBuilder()
                   .serializationInclusion(JsonInclude.Include.ALWAYS)
                   .modulesToInstall(new JsonNullableModule())
                   .mixIn(SimpleGrantedAuthority.class, SimpleGrantedAuthorityMixin.class)
                   .indentOutput(true);
       }
   }
   ```
- 직렬화가 적용된 커스텀 객체(`CustomGrantedAuthority`)를 사용하여 해결

**🟡 테스트 동작 확인**

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/e0c5f6ac-40f4-4e18-99e0-4c776d89ef74" width="700px"/>
</div>   

<br/>

### 2️⃣ Swagger 문서 request body 정보가 오기입되는 경우 (참고)
- `SignUp.General`과 `SignIn.General` 내부 클래스명이 동일하여 `@Schema` 어노테이션을 정의해도 Swagger 문서에 둘 중 하나만 나오는 이슈 발생
- 최종 클래스명이 같은 경우, 다음과 같이 `name` 속성을 정의하여 명시적으로 구분해주어야 함.
   ```java
   public class SignInReq {
       @Schema(name = "signInReqGeneral", title = "로그인 요청")
       public record General( ... ) {
           ...
       }
   }
   ```

<br/>

### 3️⃣ Swagger 요청 경로 수정
- swagger 내에서 요청 시, `http://127.0.0.1:8080/v3/127.0.0.1:8080/~`으로 요청 경로가 잡히는 문제 발생
- 환경 변수에 서버 도메인 주소를 `127.0.0.1:8080`이 아닌, `http://127.0.0.1:8080`을 입력하면 됨.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
### 🟡 인증/인가 자원 접근 플로우 정리
> 필터가 너무 많아서 궁금하실 수도 있고, 나중에 Security Filter에서 에러가 없을 거라고 100% 보장을 못하므로 정리해두겠습니다.

![SecurityFilterFlow drawio](https://github.com/CollaBu/pennyway-was/assets/96044622/83a892b4-6bda-49af-85bf-26427c9fc1a9)

1. CorsFilter
    - cors 에러 잡기 위한 필터
    - swagger 요청(web 요청..mobile은 따로 적용 안 하면 cors 에러 안 남) 처리를 위함.
    - `local`, `dev`, `test` 환경에서 실행했을 때만 필터가 적용됨.
2. JwtExceptionFilter (커스텀 필터)
    - Jwt 파싱하다 오류 발생하는 경우, 관련 에러 메시지를 응답 포맷에 맞게 반환함.
    - 가끔 Controller단까지 내려가기 전에 에러나는 경우도 해당 필터가 잡아냄. (500에러)
3. JwtAuthenticationFilter (커스텀 필터)
    - 헤더에서 Jwt 파싱하고 인증 객체를 Security에 등록하는 필터
    - Jwt 서명 조작, 만료, 손상인 경우 모두 예외를 던짐. (인증 에러) -> Jwt 예외 필터가 처리
    - `Authorization` 헤더 없으면 Anonymous로 취급. (bypass)
4. AnonymousAuthenticationFilter
    - Jwt 인증 필터에서 bypass한 요청의 경우, 해당 요청자를 anonymous(미인증 유저)로 등록
5. ExceptionTranslationFilter
    - 인증/인가 필터에서 발생할 예외를 핸들링하는 필터
    - `JwtAuthenticationEntryPoint`: 인증 실패 핸들링
    - `JwtAccessDeniedHandler`: 인가 실패 핸들링
6. AuthorizationFilter
    - `SecurityConfig`의 `filterChain`을 보시면 `http.authorizeHttpRequest(...)` 여기에 해당합니다.
    - `.permitAll()`로 매칭된 경로는 모두 접근 가능.
    - `.anonymous()`로 매칭된 경로는 미인증 유저만 접근 가능. (인증된 유저가 접근 시, 인가 에러)
    - `.authenticated()`로 매칭된 경로는 인증된 유저만 접근 가능. (미인가 유저가 접근 시, 인증 에러)
    - 참고로 미인가 유저는 `.permitAll()`, `.anonymous()` 경로 빼곤 모두 막아버렸으므로 `404_NOT_FOUND`를 볼 수 없음.
7. GlobalExceptionHandler
    - 전역 예외 처리.
    - 원래라면 `@PreAuthorize`에서 인가 실패했을 때 발생하는 `AccessDeniedException`을 `(5)`에서 잡아줘야 하는데, 자꾸 이상한 에러가 떠서 여기서도 잡음.
    - `404_NOT_FOUND` 에러도 여기서 잡음
8. MethodSecurity
    - `@PreAuthorize`, `@PostAuthorize`로 적절히 인가 작업 처리

<br/>

## 발견한 이슈
- server 용량 없길래 `/swapfile` 크기 조정하려다가 서버가 터져버린 거 같아요. 😇 진우님 죄송합니다..
