### PR TITLE
✨ 닉네임 중복검사 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthCheckController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthCheckController.java
@@ -24,7 +24,7 @@ public class AuthCheckController {
 
     @Operation(summary = "닉네임 중복 검사")
     @GetMapping("/username")
-    @PreAuthorize("isAnonymous()")
+    @PreAuthorize("permitAll()")
     public ResponseEntity<?> checkUsername(@RequestParam @Validated String username) {
         return ResponseEntity.ok(SuccessResponse.from("isDuplicate", authCheckUseCase.checkUsernameDuplicate(username)));
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthCheckController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthCheckController.java
@@ -1,0 +1,31 @@
+package kr.co.pennyway.api.apis.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.apis.auth.usecase.AuthCheckUseCase;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "[계정 검사 API]")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/duplicate")
+public class AuthCheckController {
+    private final AuthCheckUseCase authCheckUseCase;
+
+    @Operation(summary = "닉네임 중복 검사")
+    @GetMapping("/username")
+    @PreAuthorize("isAnonymous()")
+    public ResponseEntity<?> checkUsername(@RequestParam @Validated String username) {
+        return ResponseEntity.ok(SuccessResponse.from("isDuplicate", authCheckUseCase.checkUsernameDuplicate(username)));
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
@@ -32,14 +32,14 @@ public class AuthController {
     private final AuthUseCase authUseCase;
     private final CookieUtil cookieUtil;
 
-    @Operation(summary = "인증번호 전송")
+    @Operation(summary = "일반 회원가입 인증번호 전송")
     @PostMapping("/phone")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> sendCode(@RequestBody @Validated PhoneVerificationDto.PushCodeReq request) {
         return ResponseEntity.ok(SuccessResponse.from("sms", authUseCase.sendCode(request)));
     }
 
-    @Operation(summary = "인증번호 검증")
+    @Operation(summary = "일반 회원가입 인증번호 검증")
     @PostMapping("/phone/verification")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> verifyCode(@RequestBody @Validated PhoneVerificationDto.VerifyCodeReq request) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthCheckUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthCheckUseCase.java
@@ -13,7 +13,7 @@ public class AuthCheckUseCase {
     private final UserService userService;
 
     @Transactional(readOnly = true)
-    public boolean checkUsernameDuplicate(String nickname) {
-        return userService.isExistUsername(nickname);
+    public boolean checkUsernameDuplicate(String username) {
+        return userService.isExistUsername(username);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthCheckUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthCheckUseCase.java
@@ -1,0 +1,19 @@
+package kr.co.pennyway.api.apis.auth.usecase;
+
+import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class AuthCheckUseCase {
+    private final UserService userService;
+
+    @Transactional(readOnly = true)
+    public boolean checkUsernameDuplicate(String nickname) {
+        return userService.isExistNickname(nickname);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthCheckUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthCheckUseCase.java
@@ -14,6 +14,6 @@ public class AuthCheckUseCase {
 
     @Transactional(readOnly = true)
     public boolean checkUsernameDuplicate(String nickname) {
-        return userService.isExistNickname(nickname);
+        return userService.isExistUsername(nickname);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -26,12 +26,9 @@ import org.springframework.web.cors.CorsConfigurationSource;
 @ConditionalOnDefaultWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {
-            "/favicon.ico",
-            // Swagger
-            "/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",
-    };
-    private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**", "/v1/duplicate/**"};
+    private static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {"/favicon.ico", "/v1/duplicate/**"};
+    private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**"};
+    private static final String[] SWAGGER_ENDPOINTS = {"/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",};
 
     private final SecurityAdapterConfig securityAdapterConfig;
     private final CorsConfigurationSource corsConfigurationSource;
@@ -46,7 +43,7 @@ public class SecurityConfig {
                 .cors((cors) -> cors.configurationSource(corsConfigurationSource))
                 .authorizeHttpRequests(
                         auth -> defaultAuthorizeHttpRequests(auth)
-                                .requestMatchers(READ_ONLY_PUBLIC_ENDPOINTS).permitAll()
+                                .requestMatchers(SWAGGER_ENDPOINTS).permitAll()
                                 .anyRequest().authenticated()
                 ).build();
     }
@@ -81,6 +78,7 @@ public class SecurityConfig {
             AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth) {
         return auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .requestMatchers(HttpMethod.OPTIONS, "*").permitAll()
+                .requestMatchers(HttpMethod.GET, READ_ONLY_PUBLIC_ENDPOINTS).permitAll()
                 .requestMatchers(ANONYMOUS_ENDPOINTS).anonymous();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
             // Swagger
             "/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",
     };
-    private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**"};
+    private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**", "/v1/duplicate/**"};
 
     private final SecurityAdapterConfig securityAdapterConfig;
     private final CorsConfigurationSource corsConfigurationSource;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/repository/UserRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhone(String phone);
 
     Optional<User> findByUsername(String username);
+
+    boolean existsByUsername(String username);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/service/UserService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public boolean isExistNickname(String username) {
+    public boolean isExistUsername(String username) {
         return userRepository.existsByUsername(username);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/service/UserService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/service/UserService.java
@@ -37,4 +37,9 @@ public class UserService {
     public boolean isExistUser(Long id) {
         return userRepository.existsById(id);
     }
+
+    @Transactional(readOnly = true)
+    public boolean isExistNickname(String username) {
+        return userRepository.existsByUsername(username);
+    }
 }


### PR DESCRIPTION
## 작업 이유
- 닉네임 중복 검사용 API 개방

<br/>

## 작업 사항
**📨 요청**
- url : `GET /v1/duplication/username`
- parameter: username=검사하려는 닉네임
- pre-condition: permitAll
- 요청 예시: `/v1/duplication/username?username=jayang`

<br/>

**📢 응답**
- body
   ```json
   {
       "code": "2000",
       "data": {
           "isDuplicate": false // or true
       }
   }
   ```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 닉네임 중복 검사는 범용적으로 쓰일 수 있어서 API를 별도로 분리했습니다.
- 기존의 Security Config에 설정한 Swagger 요청 경로는 분리하고, read only public endpoints를 따로 설정했습니다.

<br/>

## 발견한 이슈
- 없음

