### PR TITLE
🐛 OIDC signature 검증없이 header, payload 추출 로직 수정

### DIFF
--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
@@ -1,11 +1,18 @@
 package kr.co.pennyway.infra.common.oidc;
 
-import io.jsonwebtoken.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import kr.co.pennyway.infra.common.exception.JwtErrorCode;
 import kr.co.pennyway.infra.common.exception.JwtErrorException;
 import kr.co.pennyway.infra.common.util.JwtErrorCodeUtil;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
 
 import java.math.BigInteger;
 import java.security.KeyFactory;
@@ -14,16 +21,19 @@ import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
+import java.util.Map;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class OauthOidcProviderImpl implements OauthOidcProvider {
     private static final String KID = "kid";
     private static final String RSA = "RSA";
+    private final ObjectMapper objectMapper;
 
     @Override
     public String getKidFromUnsignedTokenHeader(String token, String iss, String aud, String nonce) {
-        return (String) getUnsignedTokenClaims(token, iss, aud, nonce).getHeader().get(KID);
+        return getUnsignedTokenClaims(token, iss, aud, nonce).get("header").get(KID);
     }
 
     @Override
@@ -43,19 +53,27 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
      * ID Token의 header와 body를 Base64 방식으로 디코딩하는 메서드 <br/>
      * payload의 iss, aud, exp, nonce를 검증하고, 실패시 예외 처리
      */
-    private Jwt<Header, Claims> getUnsignedTokenClaims(String token, String iss, String aud, String nonce) {
+    private Map<String, Map<String, String>> getUnsignedTokenClaims(String token, String iss, String aud, String nonce) {
+        log.info("getUnsignedTokenClaims : token : {}, iss : {}, aud : {}, nonce : {}", token, iss, aud, nonce);
         try {
-            return Jwts.parser()
-                    .requireAudience(aud)
-                    .requireIssuer(iss)
-//                    .require("nonce", nonce) // 현재는 nonce를 사용하지 않음
-                    .build()
-                    .parseUnsecuredClaims(getUnsignedToken(token)); // TODO: 기존 방식은 parseClaimsJwt(getUnsignedToken(token)); -> 변경한 코드 정상 동작 여부 확인 필요
-        } catch (JwtException e) {
-            final JwtErrorCode errorCode = JwtErrorCodeUtil.determineErrorCode(e, JwtErrorCode.FAILED_AUTHENTICATION);
+            Base64.Decoder decoder = Base64.getUrlDecoder();
 
-            log.warn("getUnsignedTokenClaims : Error code : {}, Error - {},  {}", errorCode, e.getClass(), e.getMessage());
-            throw new JwtErrorException(errorCode);
+            String unsignedToken = getUnsignedToken(token);
+            String headerJson = new String(decoder.decode(unsignedToken.split("\\.")[0]));
+            String payloadJson = new String(decoder.decode(unsignedToken.split("\\.")[1]));
+
+            @SuppressWarnings("unchecked")
+            Map<String, String> header = objectMapper.readValue(headerJson, Map.class);
+            @SuppressWarnings("unchecked")
+            Map<String, String> payload = objectMapper.readValue(payloadJson, Map.class);
+
+            Assert.isTrue(payload.get("aud").equals(aud), "aud is not matched. expected : " + aud + ", actual : " + payload.get("aud"));
+            Assert.isTrue(payload.get("iss").equals(iss), "iss is not matched. expected : " + iss + ", actual : " + payload.get("iss"));
+
+            return Map.of("header", header, "payload", payload);
+        } catch (JsonProcessingException e) {
+            log.warn("getUnsignedTokenClaims : Error - {},  {}", e.getClass(), e.getMessage());
+            throw new RuntimeException(e);
         }
     }
 

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
@@ -53,7 +53,6 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
      * payload의 iss, aud, exp, nonce를 검증하고, 실패시 예외 처리
      */
     private Map<String, Map<String, String>> getUnsignedTokenClaims(String token, String iss, String aud, String nonce) {
-        log.info("getUnsignedTokenClaims : token : {}, iss : {}, aud : {}, nonce : {}", token, iss, aud, nonce);
         try {
             Base64.Decoder decoder = Base64.getUrlDecoder();
 
@@ -82,7 +81,7 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
     private String getUnsignedToken(String token) {
         String[] splitToken = token.split("\\.");
         if (splitToken.length != 3) throw new JwtErrorException(JwtErrorCode.MALFORMED_TOKEN);
-        return splitToken[0] + "." + splitToken[1] + ".";
+        return splitToken[0] + "." + splitToken[1];
     }
 
     /**

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
@@ -54,7 +54,7 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
         } catch (JwtException e) {
             final JwtErrorCode errorCode = JwtErrorCodeUtil.determineErrorCode(e, JwtErrorCode.FAILED_AUTHENTICATION);
 
-            log.warn("Error code : {}, Error - {},  {}", errorCode, e.getClass(), e.getMessage());
+            log.warn("getUnsignedTokenClaims : Error code : {}, Error - {},  {}", errorCode, e.getClass(), e.getMessage());
             throw new JwtErrorException(errorCode);
         }
     }
@@ -81,10 +81,10 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
         } catch (JwtException e) {
             final JwtErrorCode errorCode = JwtErrorCodeUtil.determineErrorCode(e, JwtErrorCode.FAILED_AUTHENTICATION);
 
-            log.warn("Error code : {}, Error - {},  {}", errorCode, e.getClass(), e.getMessage());
+            log.warn("getOIDCTokenJws : Error code : {}, Error - {},  {}", errorCode, e.getClass(), e.getMessage());
             throw new JwtErrorException(errorCode);
         } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-            log.warn("Error - {},  {}", e.getClass(), e.getMessage());
+            log.warn("getOIDCTokenJws : Error - {},  {}", e.getClass(), e.getMessage());
             throw new JwtErrorException(JwtErrorCode.MALFORMED_TOKEN);
         }
     }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
@@ -39,8 +39,7 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
     @Override
     public OidcDecodePayload getOIDCTokenBody(String token, String modulus, String exponent) {
         Claims body = getOIDCTokenJws(token, modulus, exponent).getPayload();
-        String aud = body.getAudience().iterator().next(); // TODO: 이전 버전과 다르게 aud가 Set<String>으로 변경되어 있음. 테스트 필요
-        log.debug("aud : {}", aud);
+        String aud = body.getAudience().iterator().next(); // aud가 여러개일 경우 첫 번째 aud를 사용
 
         return new OidcDecodePayload(
                 body.getIssuer(),


### PR DESCRIPTION
## 작업 이유
- idToken의 `kid` 값을 추출하기 위해 signature 검증 없이 decoding

<br/>

## 작업 사항
### 💡 signature를 무시하는 이유
- provider가 제공하는 keys는 다음과 같은 정보를 포함합니다.
   - kid, kty, alg, se, n, e (해당 정보를 여러 개 제공함)
   - JWS를 복호화하기 위해서는 `n`, `e` 값을 통해 `public key`를 유추해야 합니다.
   ```java
    /**
     * n, e 조합으로 공개키를 생성하는 메서드
     */
    private PublicKey getRSAPublicKey(String modulus, String exponent) throws NoSuchAlgorithmException, InvalidKeySpecException {
        KeyFactory keyFactory = KeyFactory.getInstance(RSA);
        byte[] decodeN = Base64.getUrlDecoder().decode(modulus);
        byte[] decodeE = Base64.getUrlDecoder().decode(exponent);
        BigInteger n = new BigInteger(1, decodeN);
        BigInteger e = new BigInteger(1, decodeE);

        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
        return keyFactory.generatePublic(publicKeySpec);
    }
    ```
- 하지만 provider에서 제공하는 keys는 배열이므로, 어떤 `n`, `e`를 택할 지 판단 기준이 필요합니다.
   - 여러 keys 중에 사용자가 제공한 `idToken` 정보 헤더의 `kid`를 사용합니다.
   - 즉, 여러 keys 중에 `idToken`의 `kid`와 일치하는 `n`, `e` 정보를 통해서 `public key`를 계산할 수 있습니다.
    ```java
    private OidcDecodePayload getPayloadFromIdToken(String idToken, String iss, String aud, String nonce, OidcPublicKeyResponse response) {
        String kid = getKidFromUnsignedIdToken(idToken, iss, aud, nonce);

        OidcPublicKey key = response.getKeys().stream()
                .filter(k -> k.kid().equals(kid))
                .findFirst()
                .orElseThrow(() -> new IllegalArgumentException("No matching key found"));
        return oauthOidcProvider.getOIDCTokenBody(idToken, key.n(), key.e());
    }
    ```

<br/>

### 🔧 바뀐 점
- `jjwt 0.12.5` 버전으로 업그레이드 되면서, 더 이상 `signature` 검증을 무시하고 헤더와 바디를 디코딩하는 방법을 찾을 수 없습니다.
    ```java
    // 예전 방식
    /**
     * ID Token의 header와 body를 Base64 방식으로 디코딩하는 메서드 <br/>
     * payload의 iss, aud, exp, nonce를 검증하고, 실패시 예외 처리
     */
    private Jwt<Header, Claims> getUnsignedTokenClaims(String token, String iss, String aud, String nonce) {
        try {
            return Jwts.parserBuilder()
                    .requireAudience(aud)
                    .requireIssuer(iss)
                    .build()
                    .parseClaimsJwt(getUnsignedToken(token));
        } catch (JwtException e) {
            final JwtErrorCode errorCode = JwtErrorCodeUtil.determineErrorCode(e, JwtErrorCode.FAILED_AUTHENTICATION);

            log.warn("Error code : {}, Error - {},  {}", errorCode, e.getClass(), e.getMessage());
            throw new JwtErrorException(errorCode);
        }
    }
    ```
    - `.parserBuilder`는 아예 remove된 메서드입니다.
    - `.parseClaimsJwt()` 또한 `v1.0` 이후로 제거될 메서드이며, 현재 deprecated 되었습니다.
    - `v0.11.5` 버전과 내부 코드를 비교해본 결과, 호출되는 메서드나 로직이 모두 변경된 상태입니다.
    - parser의 메서드만 수정하면 유효하지 않은 토큰 상태 에러가 발생하고, token의 signature 부분을 함께 넘기면 서명 검증 에러가 발생함.

<br/>

따라서 header와 body 부분을 추출하는 로직은 jjwt를 사용하지 않고, 직접 디코딩합니다.

```java
Base64.Decoder decoder = Base64.getUrlDecoder();

String unsignedToken = getUnsignedToken(token);
String headerJson = new String(decoder.decode(unsignedToken.split("\\.")[0]));
String payloadJson = new String(decoder.decode(unsignedToken.split("\\.")[1]));
```
- `Base64` 디코더를 기반으로 header와 payload를 문자열로 디코딩합니다.

```java
@SuppressWarnings("unchecked")
Map<String, String> header = objectMapper.readValue(headerJson, Map.class);
@SuppressWarnings("unchecked")
Map<String, String> payload = objectMapper.readValue(payloadJson, Map.class);

Assert.isTrue(payload.get("aud").equals(aud), "aud is not matched. expected : " + aud + ", actual : " + payload.get("aud"));
Assert.isTrue(payload.get("iss").equals(iss), "iss is not matched. expected : " + iss + ", actual : " + payload.get("iss"));
```
- object mapper를 사용하여 header와 payload를 각각 Map 자료형에 담습니다.
   - 이때 비검사 경고가 발생하나, token의 정보는 언제나 Map<String, String> 타입임을 보장하므로 명시적으로 경고를 무시합니다.
   - 비검사 경고 무시를 필드 범위가 아닌, 메서드 단위로 잡아도 크게 지장은 없습니다.
- payload 정보에서 `aud`와 `iss`, 즉 provider에 등록한 pennyway 서비스의 `id`와 `토큰 발급 경로`가 일치하지 않으면 실패합니다.

<br/>

### 📝 결과 확인

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/6fca4368-e8d3-44cc-8f5c-072d5540aeec" width="600px"/>
</div>

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- Decoding 작업의 필요성을 이해했으며, 해당 방법이 적절한 해결책이라 생각하는지?
- 작업 사항이 이해가 가지 않는다면, idToken을 발급받아서 [복호화를 해보시면](https://jwt.io/) 보다 명확하게 이해하실 수 있을 겁니다. (그래도 모르겠으면 질문주세요.)
- JWT 종류를 알아두시면 이해가 좀 더 쉬울 것 같아 남겨둡니다.
   - JWT (JSON Web Token) : JWS or JWE
   - JWS (JSON Web Signature) : 서버에서 인증을 증거로 인증 정보를 서버의 private key 로 서명한 것을 Token 화 한것.
   - JWE (JSON Web Encryption) : 서버와 클라이언트 간 암호화된 데이터를 Token 화 한것.
   - JWK (JSON Web Key) : JWE 에서 payload encryption 에 쓰인 키를 token 화 한것. (물론, 키 자체도 암호화되어 있.)

<br/>

## 발견한 이슈
- 딱히 없긴 하지만, 아직 iOS에서 정상적으로 연동이 되는지는 검증해보지 못 함.

