### PR TITLE
📝 Swagger 예외 응답 문서 개선

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
@@ -1,0 +1,174 @@
+package kr.co.pennyway.api.apis.auth.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
+import kr.co.pennyway.api.apis.auth.dto.SignInReq;
+import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "[인증 API]")
+public interface AuthApi {
+    @Operation(summary = "[1] 일반 회원가입 인증번호 전송", description = "전화번호로 인증번호를 전송합니다. 미인증 사용자만 가능합니다.")
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "발신 성공", value = """
+                    {
+                        "code": "2000",
+                        "data": {
+                            "sms": {
+                                "to": "010-1234-5678",
+                                "sendAt": "2024-04-04 00:31:57",
+                                "expiresAt": "2024-04-04 00:36:57"
+                            }
+                        }
+                    }
+                    """)
+    }))
+    ResponseEntity<?> sendCode(@RequestBody @Validated PhoneVerificationDto.PushCodeReq request);
+
+    @Operation(summary = "[2] 일반 회원가입 인증번호 검증", description = "인증번호를 검증합니다. 미인증 사용자만 가능합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "검증 성공 - 기존에 등록한 소셜 계정 없음", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "sms": {
+                                        "code": true,
+                                        "oauth": false
+                                    }
+                                }
+                            }
+                            """),
+                    @ExampleObject(name = "검증 성공 - 기존에 등록한 소셜 계정 있음", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "sms": {
+                                        "code": true,
+                                        "oauth": true,
+                                        "username": "pennyway"
+                                    }
+                                }
+                            }
+                            """)
+            })),
+            @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "검증 실패", value = """
+                            {
+                                "code": "4010",
+                                "message": "인증번호가 일치하지 않습니다."
+                            }
+                            """)
+            })),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "검증 실패 - 인증번호 만료", value = """
+                            {
+                                "code": "4042",
+                                "message": "만료되었거나 등록되지 않은 휴대폰 정보입니다."
+                            }
+                            """)
+            }))
+    })
+    ResponseEntity<?> verifyCode(@RequestBody @Validated PhoneVerificationDto.VerifyCodeReq request);
+
+    @Operation(summary = "[3-1] 일반 회원가입", description = "일반 회원가입을 진행합니다. 미인증 사용자만 가능합니다.")
+    @ApiResponse(responseCode = "200", description = "로그인 성공",
+            headers = {
+                    @Header(name = "Set-Cookie", description = "리프레시 토큰", schema = @Schema(type = "string"), required = true),
+                    @Header(name = "Authorization", description = "액세스 토큰", schema = @Schema(type = "string", format = "jwt"), required = true)
+            },
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "성공", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "user": {
+                                        "id": 1
+                                    }
+                                }
+                            }
+                            """)
+            }))
+    ResponseEntity<?> signUp(@RequestBody @Validated SignUpReq.General request);
+
+    @Operation(summary = "[3-2] 기존 소셜 계정에 일반 계정을 연동하는 회원가입", description = "소셜 계정과 연동할 일반 계정 정보를 입력합니다. 미인증 사용자만 가능합니다.")
+    @ApiResponse(responseCode = "200", description = "로그인 성공",
+            headers = {
+                    @Header(name = "Set-Cookie", description = "리프레시 토큰", schema = @Schema(type = "string"), required = true),
+                    @Header(name = "Authorization", description = "액세스 토큰", schema = @Schema(type = "string", format = "jwt"), required = true)
+            },
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "성공", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "user": {
+                                        "id": 1
+                                    }
+                                }
+                            }
+                            """)
+            }))
+    ResponseEntity<?> linkOauth(@RequestBody @Validated SignUpReq.SyncWithOauth request);
+
+    @Operation(summary = "[4] 일반 로그인", description = "아이디와 비밀번호로 로그인합니다. 미인증 사용자만 가능합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    headers = {
+                            @Header(name = "Set-Cookie", description = "리프레시 토큰", schema = @Schema(type = "string"), required = true),
+                            @Header(name = "Authorization", description = "액세스 토큰", schema = @Schema(type = "string", format = "jwt"), required = true)
+                    },
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "성공", value = """
+                                    {
+                                        "code": "2000",
+                                        "data": {
+                                            "user": {
+                                                "id": 1
+                                            }
+                                        }
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "401", description = "로그인 실패", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "실패 - 유효하지 않은 아이디/비밀번호", value = """
+                            {
+                                "code": "4010",
+                                "message": "유효하지 않은 아이디 또는 비밀번호입니다."
+                            }
+                            """)
+            }))
+    })
+    ResponseEntity<?> signIn(@RequestBody @Validated SignInReq.General request);
+
+    @Operation(summary = "[5] 토큰 갱신", description = "리프레시 토큰을 이용해 액세스 토큰과 리프레시 토큰을 갱신합니다.")
+    @ApiResponse(responseCode = "200", description = "로그인 성공",
+            headers = {
+                    @Header(name = "Set-Cookie", description = "리프레시 토큰", schema = @Schema(type = "string"), required = true),
+                    @Header(name = "Authorization", description = "액세스 토큰", schema = @Schema(type = "string", format = "jwt"), required = true)
+            },
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "성공", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "user": {
+                                        "id": 1
+                                    }
+                                }
+                            }
+                            """)
+            }))
+    ResponseEntity<?> refresh(@CookieValue("refreshToken") @Valid String refreshToken);
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
@@ -39,7 +39,7 @@ public interface AuthApi {
     @Operation(summary = "[2] 일반 회원가입 인증번호 검증", description = "인증번호를 검증합니다. 미인증 사용자만 가능합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "검증 성공 - 기존에 등록한 소셜 계정 없음", value = """
+                    @ExampleObject(name = "검증 성공 - 기존에 등록한 소셜 계정 없음 - [3-1]로 진행", value = """
                             {
                                 "code": "2000",
                                 "data": {
@@ -50,7 +50,7 @@ public interface AuthApi {
                                 }
                             }
                             """),
-                    @ExampleObject(name = "검증 성공 - 기존에 등록한 소셜 계정 있음", value = """
+                    @ExampleObject(name = "검증 성공 - 기존에 등록한 소셜 계정 있음 - [3-2]로 진행", value = """
                             {
                                 "code": "2000",
                                 "data": {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
@@ -89,7 +89,7 @@ public interface OauthApi {
                                 "data": {
                                     "sms": {
                                         "code": true,
-                                        "existUser": true,
+                                        "existsUser": true,
                                         "username": "pennyway"
                                     }
                                 }
@@ -101,7 +101,7 @@ public interface OauthApi {
                                 "data": {
                                     "sms": {
                                         "code": true,
-                                        "existUser": false
+                                        "existsUser": false
                                     }
                                 }
                             }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
@@ -1,8 +1,7 @@
 package kr.co.pennyway.api.apis.auth.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import kr.co.pennyway.api.apis.auth.api.AuthApi;
 import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
 import kr.co.pennyway.api.apis.auth.dto.SignInReq;
 import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
@@ -24,50 +23,43 @@ import java.time.Duration;
 import java.util.Map;
 
 @Slf4j
-@Tag(name = "[인증 API]")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/auth")
-public class AuthController {
+public class AuthController implements AuthApi {
     private final AuthUseCase authUseCase;
     private final CookieUtil cookieUtil;
 
-    @Operation(summary = "일반 회원가입 인증번호 전송")
     @PostMapping("/phone")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> sendCode(@RequestBody @Validated PhoneVerificationDto.PushCodeReq request) {
         return ResponseEntity.ok(SuccessResponse.from("sms", authUseCase.sendCode(request)));
     }
 
-    @Operation(summary = "일반 회원가입 인증번호 검증")
     @PostMapping("/phone/verification")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> verifyCode(@RequestBody @Validated PhoneVerificationDto.VerifyCodeReq request) {
         return ResponseEntity.ok(SuccessResponse.from("sms", authUseCase.verifyCode(request)));
     }
 
-    @Operation(summary = "일반 회원가입")
     @PostMapping("/sign-up")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signUp(@RequestBody @Validated SignUpReq.General request) {
         return createAuthenticatedResponse(authUseCase.signUp(request.toInfo()));
     }
 
-    @Operation(summary = "기존 소셜 계정에 일반 계정을 연동하는 회원가입")
     @PostMapping("/link-oauth")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> linkOauth(@RequestBody @Validated SignUpReq.SyncWithOauth request) {
         return createAuthenticatedResponse(authUseCase.signUp(request.toInfo()));
     }
 
-    @Operation(summary = "일반 로그인")
     @PostMapping("/sign-in")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> signIn(@RequestBody @Validated SignInReq.General request) {
         return createAuthenticatedResponse(authUseCase.signIn(request));
     }
 
-    @Operation(summary = "토큰 갱신", description = "리프레시 토큰을 이용해 액세스 토큰과 리프레시 토큰을 갱신합니다.")
     @GetMapping("/refresh")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> refresh(@CookieValue("refreshToken") @Valid String refreshToken) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneVerificationDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneVerificationDto.java
@@ -47,7 +47,7 @@ public class PhoneVerificationDto {
 
     @Schema(title = "인증번호 검증 DTO", description = "전화번호로 인증번호 검증 요청을 위한 DTO")
     public record VerifyCodeReq(
-            @Schema(description = "전화번호", example = "01012345678")
+            @Schema(description = "전화번호", example = "010-1234-5678")
             @NotBlank(message = "전화번호는 필수입니다.")
             @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
             String phone,

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/ErrorResponse.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/ErrorResponse.java
@@ -1,7 +1,9 @@
 package kr.co.pennyway.api.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
 import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.pennyway.api.common.swagger.CustomJsonView;
 import kr.co.pennyway.common.exception.ReasonCode;
 import kr.co.pennyway.common.exception.StatusCode;
 import lombok.AccessLevel;
@@ -15,15 +17,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Getter
-@Schema(description = "API 응답 - 실패 및 에러")
+@Schema(title = "API 응답 - 실패 및 에러")
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse {
-    @Schema(description = "응답 코드", defaultValue = "4000")
+    @Schema(description = "응답 코드", example = "4자리 정수형 문자열 (상태 코드(3자리) + 에러 코드(1자리))", pattern = "\\d{4}")
+    @JsonView(CustomJsonView.Common.class)
     private String code;
     @Schema(description = "응답 메시지", example = "에러 이유")
+    @JsonView(CustomJsonView.Common.class)
     private String message;
     @Schema(description = "에러 상세", example = "{\"field\":\"reason\"}")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonView(CustomJsonView.Hidden.class)
     private Object fieldErrors;
 
     @Builder

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/swagger/CustomJsonView.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/swagger/CustomJsonView.java
@@ -1,0 +1,9 @@
+package kr.co.pennyway.api.common.swagger;
+
+public class CustomJsonView {
+    public static class Common {
+    }
+
+    public static class Hidden extends Common {
+    }
+}


### PR DESCRIPTION
## 작업 이유
- Oauth 전화번호 검증 응답 문서 오류 수정
- Auth Controller 문서 주석 분리
- Error 응답 문서 개선

<br/>

## 작업 사항
### 1️⃣ Oauth 전화번호 검증 응답 문서 오류 수정

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/55b9e852-e57f-4e92-b3fd-cf6766ad6f41" width="700px"/>
</div>

- `existsUser`를 `existUser`로 오기입한 부분 수정

<br/>

### 2️⃣ Auth Controller 문서 주석 분리
- `AuthApi` 인터페이스로 문서 주석 분리
- 이전보다 상세하게 응답 포맷 명시

<br/>

### 3️⃣ Error 응답 문서 개선
**🔴 As-is**

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/a2ef83c2-6ce2-4d4d-8477-db4db5a05976" width="700px"/>
</div>

- Error와 Fail을 모두 ErrorResponse로 관리하다보니, 422에러만 나타나는 `fieldErrors`가 모든 응답에서 표기됨
- `hidden = true` 옵션을 주면 모든 응답에서 보이지 않게 되므로, 이 방법 또한 적절하지 않음.

<br/>

**🟢 To-be**

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/f93a4ad5-b4d0-4bb0-85df-af581716a098" width="700px"/>
</div>

```java
public class CustomJsonView {
    public static class Common {
    }

    public static class Hidden extends Common {
    }
}
```
- `@JsonView`를 사용하면 동일한 POJO 오브젝트에서 선택적으로 서로 다른 property가 조합된 JSON 문자열을 생성할 수 있음.
- `CustomJsonView` 클래스와 `@JsonView` 어노테이션을 활용하여 선택적으로 보여질 필드를 조정함.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- AuthApi 문서 응답에 오탈자 혹은 잘못된 응답이 있는지?

<br/>

## 발견한 이슈
- ControllerAdvice에 의해 특정 API에서 발생하지 않는 예외까지 모두 포함되고 있음.
  - ex. `permitAll()` 요청에 해당하는 닉네임 중복 검사 API 조차 `403 Forbidden` 에러가 보여지는 상
- `@ResponseState`를 명시하면 Swagger가 알아서 자동 응답으로 만들어준다고 하는데, 될 때도 있고 안 될 때도 있음. (이유를 못 찾음..)