### PR TITLE
🐛 Google id token issuer mismatch 이슈 해결

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/OauthOidcHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/OauthOidcHelper.java
@@ -48,7 +48,7 @@ public class OauthOidcHelper {
         OauthOidcClientProperties properties = oauthOidcClients.get(provider).values().iterator().next();
         OidcPublicKeyResponse response = client.getOidcPublicKey();
 
-        return getPayloadFromIdToken(idToken, properties.getJwksUri(), properties.getSecret(), null, response);
+        return getPayloadFromIdToken(idToken, properties.getIssuer(), properties.getSecret(), null, response);
     }
 
     /**

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcClientProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcClientProperties.java
@@ -4,4 +4,6 @@ public interface OauthOidcClientProperties {
     String getJwksUri();
 
     String getSecret();
+
+    String getIssuer();
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
@@ -89,7 +89,6 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
      */
     private Jws<Claims> getOIDCTokenJws(String token, String modulus, String exponent) {
         try {
-            log.info("token : {}", token);
             return Jwts.parser()
                     .verifyWith(getRSAPublicKey(modulus, exponent))
                     .build()

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/AppleOidcProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/AppleOidcProperties.java
@@ -11,4 +11,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class AppleOidcProperties implements OauthOidcClientProperties {
     private final String jwksUri;
     private final String secret;
+
+    @Override
+    public String getIssuer() {
+        throw new UnsupportedOperationException("Not supported");
+    }
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/AppleOidcProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/AppleOidcProperties.java
@@ -14,6 +14,6 @@ public class AppleOidcProperties implements OauthOidcClientProperties {
 
     @Override
     public String getIssuer() {
-        throw new UnsupportedOperationException("Not supported");
+        return jwksUri;
     }
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/GoogleOidcProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/GoogleOidcProperties.java
@@ -11,4 +11,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class GoogleOidcProperties implements OauthOidcClientProperties {
     private final String jwksUri;
     private final String secret;
+    private final String issuer;
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/KakaoOidcProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/KakaoOidcProperties.java
@@ -11,4 +11,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class KakaoOidcProperties implements OauthOidcClientProperties {
     private final String jwksUri;
     private final String secret;
+
+    @Override
+    public String getIssuer() {
+        throw new UnsupportedOperationException("Not supported");
+    }
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/KakaoOidcProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/KakaoOidcProperties.java
@@ -14,6 +14,6 @@ public class KakaoOidcProperties implements OauthOidcClientProperties {
 
     @Override
     public String getIssuer() {
-        throw new UnsupportedOperationException("Not supported");
+        return jwksUri;
     }
 }

--- a/pennyway-infra/src/main/resources/application-infra.yml
+++ b/pennyway-infra/src/main/resources/application-infra.yml
@@ -28,14 +28,17 @@ oauth2:
   client:
     provider:
       kakao:
-        jwks-uri: ${KAKAO_JWKS_URI:https://kauth.kakao.com}
+        jwks-uri: ${KAKAO_JWKS_URI:https://kakao.com}
         secret: ${KAKAO_CLIENT_SECRET:liuhil5068l2j5o0912}
+        issuer: ${KAKAO_ISSUER:https://kakao}
       google:
-        jwks-uri: ${GOOGLE_JWKS_URI:https://www.googleapis.com}
+        jwks-uri: ${GOOGLE_JWKS_URI:https://google.com}
         secret: ${GOOGLE_CLIENT_SECRET:123456789012-67hm9vokrt6ukmiwtvd8ak67oflecm.apps.googleusercontent.com}
+        issuer: ${GOOGLE_ISSUER:https://google.com}
       apple:
-        jwks-uri: ${APPLE_JWKS_URI:https://appleid.apple.com}
+        jwks-uri: ${APPLE_JWKS_URI:https://apple.com}
         secret: ${APPLE_CLIENT_SECRET:pennyway-jayang-was}
+        issuer: ${APPLE_ISSUER:https://apple.com}
 
 ---
 spring:

--- a/pennyway-infra/src/main/resources/application-infra.yml
+++ b/pennyway-infra/src/main/resources/application-infra.yml
@@ -30,7 +30,6 @@ oauth2:
       kakao:
         jwks-uri: ${KAKAO_JWKS_URI:https://kakao.com}
         secret: ${KAKAO_CLIENT_SECRET:liuhil5068l2j5o0912}
-        issuer: ${KAKAO_ISSUER:https://kakao}
       google:
         jwks-uri: ${GOOGLE_JWKS_URI:https://google.com}
         secret: ${GOOGLE_CLIENT_SECRET:123456789012-67hm9vokrt6ukmiwtvd8ak67oflecm.apps.googleusercontent.com}
@@ -38,7 +37,6 @@ oauth2:
       apple:
         jwks-uri: ${APPLE_JWKS_URI:https://apple.com}
         secret: ${APPLE_CLIENT_SECRET:pennyway-jayang-was}
-        issuer: ${APPLE_ISSUER:https://apple.com}
 
 ---
 spring:


### PR DESCRIPTION
## 작업 이유
- google id token payload의 `iss` 불일치 문제 

<br/>

## 작업 사항
- apple, kakao와 달리 google은 `jwks_uri`와 `issuer`가 다름.
- google의 issure을 추가로 등록
- 로컬에서 모두 정상적으로 검증되는 것 확인했습니다!

![image](https://github.com/CollaBu/pennyway-was/assets/96044622/05734ecc-6ad3-46cf-a8a3-11c58af6566c)
![image](https://github.com/CollaBu/pennyway-was/assets/96044622/a4acf13b-b590-47b5-963d-c8c301e2e1a7)
![image](https://github.com/CollaBu/pennyway-was/assets/96044622/b5a3f3ac-1e52-413b-a8a7-967982a0aa51)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 환경 변수로 `GOOGLE_ISSUER`가 추가되었고, 노션 업데이트 해두었습니다. 

<br/>

## 발견한 이슈
- 파싱 실패시 `500 Error` 발생하는 것 수정
   - 기존에는 `jjwt` 유틸을 사용해서 헤더의 `kid`를 가져왔는데, 자체적으로 decode 했더니 `aud`, `iss` 비교 실패 시 서버 에러 응답으로 반환되고 있었음.

![image](https://github.com/CollaBu/pennyway-was/assets/96044622/70349441-e875-43b5-9f42-28abaf0fe07d)

