### PR TITLE
✨ User, Oauth Entity Soft Delete 반영

### DIFF
--- a/pennyway-domain/build.gradle
+++ b/pennyway-domain/build.gradle
@@ -42,9 +42,3 @@ tasks.withType(JavaCompile).configureEach {
 clean.doLast {
     file(querydslDir).deleteDir()
 }
-
-configurations.configureEach {
-    exclude group: 'commons-logging', module: 'commons-logging'
-    exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
-    exclude group: 'ch.qos.logback', module: 'logback-classic'
-}

--- a/pennyway-domain/build.gradle
+++ b/pennyway-domain/build.gradle
@@ -19,7 +19,10 @@ dependencies {
 
     /* Redis */
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    testImplementation group: 'org.testcontainers', name: 'testcontainers', version: '1.17.2'
+    testImplementation "org.testcontainers:junit-jupiter:1.19.7"
+    testImplementation "org.testcontainers:testcontainers:1.19.7"
+    testImplementation "org.testcontainers:mysql:1.19.7"
+    testImplementation "com.redis.testcontainers:testcontainers-redis-junit:1.6.4"
 }
 
 def querydslDir = 'src/main/generated'

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -23,7 +23,7 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 @DynamicInsert
 @SQLRestriction("deleted_at IS NULL")
-@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
+@SQLDelete(sql = "UPDATE oauth SET deleted_at = NOW() WHERE id = ?")
 public class Oauth {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -20,6 +22,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @DynamicInsert
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
 public class Oauth {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
@@ -20,6 +22,8 @@ import java.time.LocalDateTime;
 @Table(name = "user")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
 public class User extends DateAuditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
@@ -68,4 +68,15 @@ public class User extends DateAuditable {
         this.password = password;
         this.passwordUpdatedAt = LocalDateTime.now();
     }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", username='" + username + '\'' +
+                ", name='" + name + '\'' +
+                ", role=" + role +
+                ", deletedAt=" + deletedAt +
+                '}';
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/service/UserService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/service/UserService.java
@@ -42,4 +42,9 @@ public class UserService {
     public boolean isExistUsername(String username) {
         return userRepository.existsByUsername(username);
     }
+
+    @Transactional
+    public void deleteUser(User user) {
+        userRepository.delete(user);
+    }
 }

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/config/ContainerMySqlTestConfig.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/config/ContainerMySqlTestConfig.java
@@ -1,0 +1,34 @@
+package kr.co.pennyway.domain.config;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@ActiveProfiles("test")
+public class ContainerMySqlTestConfig {
+    private static final String MYSQL_CONTAINER_IMAGE = "mysql:8.0.26";
+
+    private static final MySQLContainer<?> MYSQL_CONTAINER;
+
+    static {
+        MYSQL_CONTAINER =
+                new MySQLContainer<>(DockerImageName.parse(MYSQL_CONTAINER_IMAGE))
+                        .withDatabaseName("pennyway")
+                        .withUsername("root")
+                        .withPassword("testpass")
+                        .withReuse(true);
+
+        MYSQL_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    public static void setRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", () -> String.format("jdbc:mysql://%s:%s/pennyway?serverTimezone=UTC&characterEncoding=utf8", MYSQL_CONTAINER.getHost(), MYSQL_CONTAINER.getMappedPort(3306)));
+        registry.add("spring.datasource.username", () -> "root");
+        registry.add("spring.datasource.password", () -> "testpass");
+    }
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/user/repository/UserSoftDeleteTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/user/repository/UserSoftDeleteTest.java
@@ -45,6 +45,26 @@ public class UserSoftDeleteTest extends ContainerMySqlTestConfig {
     }
 
     @Test
+    @DisplayName("[명제] em.createNativeQuery를 사용해도 영속성 컨텍스트에 저장된 엔티티를 조회할 수 있다.")
+    @Transactional
+    public void findByEntityMangerUsingNativeQuery() {
+        // given
+        User savedUser = userService.createUser(user);
+        Long userId = savedUser.getId();
+
+        // when
+        Object foundUser = em.createNativeQuery("SELECT * FROM user WHERE id = ?", User.class)
+                .setParameter(1, userId)
+                .getSingleResult();
+
+        // then
+        assertNotNull("foundUser는 nll이 아니어야 한다.", foundUser);
+        assertEquals("동등성 보장에 성공해야 한다.", savedUser, foundUser);
+        assertTrue("동일성 보장에 성공해야 한다.", savedUser == foundUser);
+        System.out.println("foundUser = " + foundUser);
+    }
+
+    @Test
     @DisplayName("유저가 삭제되면 deletedAt이 업데이트된다.")
     @Transactional
     public void deleteUser() {
@@ -78,5 +98,22 @@ public class UserSoftDeleteTest extends ContainerMySqlTestConfig {
         assertFalse("유저가 삭제되면 existsById로 조회할 수 없다. ", userService.isExistUser(userId));
         assertNull("유저가 삭제되면 findById로 조회할 수 없다. ", userService.readUser(userId).orElse(null));
         System.out.println("after delete: savedUser = " + savedUser);
+    }
+
+    @Test
+    @DisplayName("유저가 삭제되지 않으면 findById로 조회할 수 있다.")
+    @Transactional
+    public void findUserNotDeleted() {
+        // given
+        User savedUser = userService.createUser(user);
+        Long userId = savedUser.getId();
+
+        // when
+        User foundUser = userService.readUser(userId).orElse(null);
+
+        // then
+        assertNotNull("foundUser는 null이 아니어야 한다.", foundUser);
+        assertEquals("foundUser는 savedUser와 같아야 한다.", savedUser, foundUser);
+        System.out.println("foundUser = " + foundUser);
     }
 }

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/user/repository/UserSoftDeleteTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/user/repository/UserSoftDeleteTest.java
@@ -1,0 +1,82 @@
+package kr.co.pennyway.domain.domains.user.repository;
+
+import jakarta.persistence.EntityManager;
+import kr.co.pennyway.domain.config.ContainerMySqlTestConfig;
+import kr.co.pennyway.domain.config.JpaConfig;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
+import kr.co.pennyway.domain.domains.user.type.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.util.AssertionErrors.*;
+
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create")
+@ContextConfiguration(classes = {JpaConfig.class, UserService.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public class UserSoftDeleteTest extends ContainerMySqlTestConfig {
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private EntityManager em;
+
+    private User user;
+
+    @BeforeEach
+    public void setUp() {
+        user = User.builder()
+                .username("test")
+                .name("pannyway")
+                .password("test")
+                .phone("01012345678")
+                .role(Role.USER)
+                .profileVisibility(ProfileVisibility.PUBLIC)
+                .build();
+    }
+
+    @Test
+    @DisplayName("유저가 삭제되면 deletedAt이 업데이트된다.")
+    @Transactional
+    public void deleteUser() {
+        // given
+        User savedUser = userService.createUser(user);
+        Long userId = savedUser.getId();
+
+        // when
+        userService.deleteUser(savedUser);
+        Object deletedUser = em.createNativeQuery("SELECT * FROM user WHERE id = ?", User.class)
+                .setParameter(1, userId)
+                .getSingleResult();
+
+        // then
+        assertNotNull("유저가 삭제되면 deletedAt이 업데이트된다. ", ((User) deletedUser).getDeletedAt());
+        System.out.println("deletedUser = " + deletedUser);
+    }
+
+    @Test
+    @DisplayName("유저가 삭제되면 findBy와 existsBy로 조회할 수 없다.")
+    @Transactional
+    public void deleteUserAndFindById() {
+        // given
+        User savedUser = userService.createUser(user);
+        Long userId = savedUser.getId();
+
+        // when
+        userService.deleteUser(savedUser);
+
+        // then
+        assertFalse("유저가 삭제되면 existsById로 조회할 수 없다. ", userService.isExistUser(userId));
+        assertNull("유저가 삭제되면 findById로 조회할 수 없다. ", userService.readUser(userId).orElse(null));
+        System.out.println("after delete: savedUser = " + savedUser);
+    }
+}

--- a/pennyway-domain/src/test/resources/logback-test.xml
+++ b/pennyway-domain/src/test/resources/logback-test.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.springframework" level="INFO"/>
+    <include resource="kr.co.pennyway"/>
+    <logger name="kr.co.pennyway" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
## 작업 이유
- User, Oauth 도메인의 soft delete 정책 반영

<br/>

## 작업 사항
```java
@SQLRestriction("deleted_at IS NULL")
@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
public class User extends DateAuditable {
   ...
}
```
- `@SQLDelete` : JPA에서 `delete` 쿼리가 호출되어야 할 때, 여기서 선언한 쿼리가 대신 호출됨.  
- `@SQLRestriction` : `findBy`, `exists`를 사용할 때, 기본으로 `WHERE deleted_at IS NULL` 조건이 붙음

<br/>

### 테스트

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/0a26e945-2dfe-4ac2-8c38-5827bafdbb7b" width="600px"/>
</div>

1. 유저가 삭제되면 deletedAt이 업데이트된다.
2. 유저가 삭제되면 findBy와 existsBy로 조회할 수 없다.
3. 유저가 삭제되지 않으면 findById로 조회할 수 있다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- SoftDelete를 위한 어노테이션의 용도가 이해가 되었는지?
- 추가로 수행해봐야 할 테스트가 있는지? (테스트 케이스 작성법 자체에 대해서 질문주셔도 좋아요)

<br/>

## 발견한 이슈
> 디코에 먼저 공유한 내용이긴 한데, 워낙 재밌는 내용이기도 하고 admin-api 개발할 때 주의해야 할 거 같아서 공유합니다.

### ✏️ 명제. EntityManager의 NativeQuery를 사용해도 JPA의 영속성 컨테이너를 사용한다.
```java
    @Test
    @DisplayName("[명제] em.createNativeQuery를 사용해도 영속성 컨텍스트에 저장된 엔티티를 조회할 수 있다.")
    @Transactional
    public void findByEntityMangerUsingNativeQuery() {
        // given
        User savedUser = userService.createUser(user);
        Long userId = savedUser.getId();

        // when
        Object foundUser = em.createNativeQuery("SELECT * FROM user WHERE id = ?", User.class)
                .setParameter(1, userId)
                .getSingleResult();

        // then
        assertNotNull("foundUser는 nll이 아니어야 한다.", foundUser);
        assertEquals("동등성 보장에 성공해야 한다.", savedUser, foundUser);
        assertTrue("동일성 보장에 성공해야 한다.", savedUser == foundUser);
        System.out.println("foundUser = " + foundUser);
    }
```
- `@SQLRestriction` 어노테이션으로 인해 일반 쿼리는 `where deleted_at is null`이 자동으로 붙어버려서 네이티브 쿼리를 사용할 예정입니다.
- 보시다시피 nativeQuery를 사용해도 동일성과 동등성을 모두 만족하는 것을 확인할 수 있습니다.

<br/>

### 1️⃣ `SoftDelete` 쿼리문은 (당연하지만) commit이 발생하지 않으면 반영되지 않는다.
```java
    @Test
    @DisplayName("유저가 삭제되면 findById로 조회할 수 없다.")
    @Transactional
    public void deleteUserAndFindById() {
        // given
        User savedUser = userService.createUser(user);
        Long userId = savedUser.getId();

        // when
        userService.deleteUser(savedUser);

        // then
        System.out.println("after delete: savedUser = " + savedUser);
    }
```

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/34383752-271e-442f-8b3f-a41e53aafeac" width="600px"/>
</div>

- `deletedUser()`를 호출했음에도 `saveUser.getDeletedAt()`은 `NULL`임을 확인할 수 있습니다.
- 애초에 delete에 대응하는 update 쿼리가 나가지도 않음.

<br/>

### 2️⃣ 해당 entity를 조회하려고 하니 soft delete가 반영되며, 조회한 entity와 기존 entity의 동일성 검증에 실패한다. (띠용?)
```java
    @Test
    @DisplayName("유저가 삭제되면 deletedAt이 업데이트된다.")
    @Transactional
    public void deleteUser() {
        // given
        User savedUser = userService.createUser(user);
        Long userId = savedUser.getId();

        System.out.println("before delete: savedUser = " + savedUser);

        // when
        userService.deleteUser(savedUser);
        System.out.println("user id = " + savedUser.getId() + ", deletedAt = " + savedUser.getDeletedAt());

        System.out.println("=== savedUser는 아직 deletedAt이 업데이트되지 않았다. ===");

        System.out.println("is exist user = " + userService.isExistUser(savedUser.getId()));

        System.out.println("=== 갑자기 update 쿼리가 실행되어 deletedAt이 업데이트되고, exists 쿼리가 호출(deleted_at is null)되어 실패한다. ===");

        System.out.println("savedUser 정보는 여전히 영속화되어 있음 : " + savedUser);

        Object deletedUser = em.createNativeQuery("SELECT * FROM user WHERE id = ?", User.class) // native query로 deletedAt is null 조건 제거
                .setParameter(1, userId)
                .getSingleResult();
        System.out.println("deletedUser = " + deletedUser);
        System.out.println("동일성 테스트: savedUser == deletedUser : " + (savedUser == deletedUser)); // false
    }
```

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/5116234a-b790-49a6-8d2b-b8d5bddaf016" width="600px"/>
</div>

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/1ad34629-99a5-4d51-b097-8a9adbaa22e2" width="500px"/>
</div>

- 여기서부터 재밌어지는데, savedUser의 pk정보로 user를 조회하는 쿼리를 실행하면 갑자기 `@SQLDelete`에 선언한 쿼리가 호출됨.
- 그리고 기존의 조회 쿼리가 다시 정상적으로 수행되는데 당연히 `@SQLRestriction`에 의해 조회할 수 없음.
- 그런데 nativeQuery를 사용해서 entity를 다시 불러오면, 기존의 entity와 pk가 같은데 동일성 검증에 실패함을 알 수 있음.

<br/>

### 📌 추측
- 비록 우리가 보기엔 `UPDATE` 쿼리를 사용했기에 User entity가 영속화 상태를 유지하고 있을 거라 예상할 겁니다.
- 하지만 실제로 native query를 사용해 동일한 pk 정보의 user entity를 가져와보면 동일성 검증에 실패합니다.
- 아마 `@SQLDelete`는 `delete` 쿼리만 대체할 뿐, **어쨌든 삭제된 entity로 취급**하기 위해 entity를 비영속화 상태로 전환하는 게 아닐까 싶습니다.
