### PR TITLE
✏️ User name 필드 유효성 검사 기준 변경

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -51,7 +51,7 @@ public class SignUpReq {
             String username,
             @Schema(description = "이름", example = "페니웨이")
             @NotBlank(message = "이름을 입력해주세요")
-            @Pattern(regexp = "^[가-힣a-zA-Z]{2,20}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
+            @Pattern(regexp = "^[가-힣]{1,6}|[a-zA-Z]{1,10}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
             String name,
             @Schema(description = "비밀번호", example = "pennyway1234")
             @NotBlank(message = "비밀번호를 입력해주세요")
@@ -98,7 +98,7 @@ public class SignUpReq {
             String idToken,
             @Schema(description = "이름", example = "페니웨이")
             @NotBlank(message = "이름을 입력해주세요")
-            @Pattern(regexp = "^[가-힣a-zA-Z]{2,20}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
+            @Pattern(regexp = "^[가-힣]{1,6}|[a-zA-Z]{1,10}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
             String name,
             @Schema(description = "아이디", example = "pennyway")
             @NotBlank(message = "아이디를 입력해주세요")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -51,7 +51,7 @@ public class SignUpReq {
             String username,
             @Schema(description = "이름", example = "페니웨이")
             @NotBlank(message = "이름을 입력해주세요")
-            @Pattern(regexp = "^[가-힣]{1,6}|[a-zA-Z]{1,10}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
+            @Pattern(regexp = "^[가-힣a-z]{1,8}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
             String name,
             @Schema(description = "비밀번호", example = "pennyway1234")
             @NotBlank(message = "비밀번호를 입력해주세요")
@@ -98,7 +98,7 @@ public class SignUpReq {
             String idToken,
             @Schema(description = "이름", example = "페니웨이")
             @NotBlank(message = "이름을 입력해주세요")
-            @Pattern(regexp = "^[가-힣]{1,6}|[a-zA-Z]{1,10}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
+            @Pattern(regexp = "^[가-힣a-z]{1,8}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
             String name,
             @Schema(description = "아이디", example = "pennyway")
             @NotBlank(message = "아이디를 입력해주세요")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -51,7 +51,7 @@ public class SignUpReq {
             String username,
             @Schema(description = "이름", example = "페니웨이")
             @NotBlank(message = "이름을 입력해주세요")
-            @Pattern(regexp = "^[가-힣a-z]{1,8}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
+            @Pattern(regexp = "^[가-힣a-z]{2,8}$", message = "2~8자의 한글, 영문 소문자만 사용 가능합니다.")
             String name,
             @Schema(description = "비밀번호", example = "pennyway1234")
             @NotBlank(message = "비밀번호를 입력해주세요")
@@ -98,7 +98,7 @@ public class SignUpReq {
             String idToken,
             @Schema(description = "이름", example = "페니웨이")
             @NotBlank(message = "이름을 입력해주세요")
-            @Pattern(regexp = "^[가-힣a-z]{1,8}$", message = "2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
+            @Pattern(regexp = "^[가-힣a-z]{2,8}$", message = "2~8자의 한글, 영문 소문자만 사용 가능합니다.")
             String name,
             @Schema(description = "아이디", example = "pennyway")
             @NotBlank(message = "아이디를 입력해주세요")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
@@ -35,7 +35,7 @@ public class OauthUseCase {
 
     public Pair<Long, Jwts> signIn(Provider provider, SignInReq.Oauth request) {
         OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken());
-        log.info("payload : {}", payload);
+        log.debug("payload : {}", payload);
 
         if (!request.oauthId().equals(payload.sub()))
             throw new OauthException(OauthErrorCode.NOT_MATCHED_OAUTH_ID);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthControllerValidationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthControllerValidationTest.java
@@ -97,7 +97,7 @@ public class AuthControllerValidationTest {
                 .andDo(print());
     }
 
-    @DisplayName("[3] 이름은 2~20자의 한글, 영문 대/소문자만 사용 가능합니다.")
+    @DisplayName("[3] 이름은 2~8자의 한글, 영문 소문자만 사용 가능합니다.")
     @Test
     void nameValidError() throws Exception {
         // given
@@ -114,7 +114,7 @@ public class AuthControllerValidationTest {
         // then
         resultActions
                 .andExpect(status().isUnprocessableEntity())
-                .andExpect(jsonPath("$.fieldErrors.name").value("2~20자의 한글, 영문 대/소문자만 사용 가능합니다."))
+                .andExpect(jsonPath("$.fieldErrors.name").value("2~8자의 한글, 영문 소문자만 사용 가능합니다."))
                 .andDo(print());
     }
 

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
@@ -69,6 +69,9 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
             Assert.isTrue(payload.get("iss").equals(iss), "iss is not matched. expected : " + iss + ", actual : " + payload.get("iss"));
 
             return Map.of("header", header, "payload", payload);
+        } catch (IllegalArgumentException e) {
+            log.warn("getUnsignedTokenClaims : Error - {},  {}", e.getClass(), e.getMessage());
+            throw new JwtErrorException(JwtErrorCode.FAILED_AUTHENTICATION);
         } catch (JsonProcessingException e) {
             log.warn("getUnsignedTokenClaims : Error - {},  {}", e.getClass(), e.getMessage());
             throw new RuntimeException(e);


### PR DESCRIPTION
## 작업 이유
- User Entity의 name 도메인 변경에 의한 유효성 검사 변경

<br/>

## 작업 사항
- name 필드 정규 표현식 수정 (2~8자의 한글, 영문 소문자만 사용 가능합니다.)
- 하는 김에 거슬렸던 로그 레벨 수정 하나랑, 지난 번에 빠트리고 push 안 했던 예외 처리도 살짝쿵...ㅎㅎ

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 정규 표현식 오류 있는지?

<br/>

## 발견한 이슈
- 없음

