### PR TITLE
✏️ OAuth 계정 연동 실패 해결 및 테스트 케이스 추가

### DIFF
--- a/pennyway-app-external-api/build.gradle
+++ b/pennyway-app-external-api/build.gradle
@@ -36,4 +36,5 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:1.19.7"
     testImplementation "org.testcontainers:mysql:1.19.7"
     testImplementation "com.redis.testcontainers:testcontainers-redis-junit:1.6.4"
+    testImplementation "org.springframework.cloud:spring-cloud-contract-wiremock:4.1.2"
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
@@ -63,6 +63,14 @@ public interface AuthApi {
                             }
                             """)
             })),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "일반 회원가입 계정이 이미 존재함", value = """
+                            {
+                                "code": "4004",
+                                "message": "이미 회원가입한 유저입니다."
+                            }
+                            """)
+            })),
             @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(name = "검증 실패", value = """
                             {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
@@ -107,6 +107,14 @@ public interface OauthApi {
                             }
                             """)
             })),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "해당 provider로 로그인한 이력이 이미 존재함", value = """
+                            {
+                                "code": "4004",
+                                "message": "이미 해당 제공자로 가입된 사용자입니다."
+                            }
+                            """)
+            })),
             @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(name = "인증코드 불일치", value = """
                             {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
@@ -3,8 +3,10 @@ package kr.co.pennyway.api.apis.auth.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -138,11 +140,45 @@ public interface OauthApi {
     @Parameter(name = "provider", description = "소셜 제공자", examples = {
             @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
     }, required = true, in = ParameterIn.QUERY)
+    @ApiResponse(responseCode = "200", description = "로그인 성공",
+            headers = {
+                    @Header(name = "Set-Cookie", description = "리프레시 토큰", schema = @Schema(type = "string"), required = true),
+                    @Header(name = "Authorization", description = "액세스 토큰", schema = @Schema(type = "string", format = "jwt"), required = true)
+            },
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "성공", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "user": {
+                                        "id": 1
+                                    }
+                                }
+                            }
+                            """)
+            }))
     ResponseEntity<?> linkAuth(@RequestParam Provider provider, @RequestBody @Validated SignUpReq.SyncWithAuth request);
 
     @Operation(summary = "[4-2] 소셜 회원가입", description = "회원 정보 입력 후 회원가입")
     @Parameter(name = "provider", description = "소셜 제공자", examples = {
             @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
     }, required = true, in = ParameterIn.QUERY)
+    @ApiResponse(responseCode = "200", description = "로그인 성공",
+            headers = {
+                    @Header(name = "Set-Cookie", description = "리프레시 토큰", schema = @Schema(type = "string"), required = true),
+                    @Header(name = "Authorization", description = "액세스 토큰", schema = @Schema(type = "string", format = "jwt"), required = true)
+            },
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "성공", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "user": {
+                                        "id": 1
+                                    }
+                                }
+                            }
+                            """)
+            }))
     ResponseEntity<?> signUp(@RequestParam Provider provider, @RequestBody @Validated SignUpReq.Oauth request);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/mapper/UserOauthSignMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/mapper/UserOauthSignMapper.java
@@ -42,7 +42,6 @@ public class UserOauthSignMapper {
         if (isSignUpUser.getLeft().equals(Boolean.TRUE)) {
             user = userService.readUserByUsername(isSignUpUser.getRight())
                     .orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
-            Oauth.of(provider, oauthId, user);
         } else {
             user = User.builder()
                     .username(request.username())
@@ -51,8 +50,10 @@ public class UserOauthSignMapper {
                     .role(Role.USER)
                     .profileVisibility(ProfileVisibility.PUBLIC).build();
             userService.createUser(user);
-            Oauth.of(provider, oauthId, user);
         }
+
+        Oauth oauth = Oauth.of(provider, oauthId, user);
+        oauthService.createOauth(oauth);
 
         return user;
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/mapper/UserSyncMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/mapper/UserSyncMapper.java
@@ -57,19 +57,16 @@ public class UserSyncMapper {
     public Pair<Boolean, String> isOauthSignUpAllowed(Provider provider, String phone) {
         Optional<User> user = userService.readUserByPhone(phone);
 
-        // user 정보 없으면 Pair.of(Boolean.FALSE, null) 반환
         if (user.isEmpty()) {
             log.info("회원가입 이력이 없는 사용자입니다. phone: {}", phone);
             return Pair.of(Boolean.FALSE, null);
         }
 
-        // 같은 provider로 가입한 정보가 있는지 확인
         if (oauthService.isExistOauthAccount(user.get().getId(), provider)) {
             log.info("이미 동일한 Provider로 가입된 사용자입니다. phone: {}, provider: {}", phone, provider);
             return null;
         }
 
-        // user 정보 있으면 Pair.of(Boolean.TRUE, user.get().getUsername()) 반환
         return Pair.of(Boolean.TRUE, user.get().getUsername());
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
@@ -63,6 +63,9 @@ public class OauthUseCase {
         phoneVerificationMapper.isValidCode(PhoneVerificationDto.VerifyCodeReq.from(request), PhoneVerificationType.getOauthSignUpTypeByProvider(provider));
         Pair<Boolean, String> isSignUpUser = checkSignUpUserNotOauthByProvider(provider, request.phone());
 
+        if (isSignUpUser.getLeft().equals(Boolean.FALSE) && request.username() == null)
+            throw new OauthException(OauthErrorCode.INVALID_OAUTH_SYNC_REQUEST);
+
         OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken());
         User user = userOauthSignMapper.saveUser(request, isSignUpUser, provider, payload.sub());
         phoneVerificationService.delete(request.phone(), PhoneVerificationType.getOauthSignUpTypeByProvider(provider));

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
@@ -65,6 +65,8 @@ public class OauthUseCase {
 
         if (isSignUpUser.getLeft().equals(Boolean.FALSE) && request.username() == null)
             throw new OauthException(OauthErrorCode.INVALID_OAUTH_SYNC_REQUEST);
+        if (isSignUpUser.getLeft().equals(Boolean.TRUE) && request.username() != null)
+            throw new OauthException(OauthErrorCode.INVALID_OAUTH_SYNC_REQUEST);
 
         OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken());
         User user = userOauthSignMapper.saveUser(request, isSignUpUser, provider, payload.sub());

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
@@ -1,0 +1,64 @@
+package kr.co.pennyway.api.apis.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.auth.helper.OauthOidcHelper;
+import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
+import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@ExternalApiIntegrationTest
+@AutoConfigureMockMvc
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @SpyBean
+    private OauthOidcHelper oauthOidcHelper;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .defaultRequest(post("/**").with(csrf()))
+                .build();
+    }
+
+    @Nested
+    @Order(1)
+    @DisplayName("[1] 소셜 로그인")
+    class OauthSignInTest {
+
+    }
+
+    @Nested
+    @Order(2)
+    @DisplayName("[3] 소셜 회원가입 전화번호 인증")
+    class OauthSignUpPhoneVerificationTest {
+
+    }
+
+    @Nested
+    @Order(3)
+    @DisplayName("[4-1] 소셜 회원가입 계정 연동")
+    class OauthSignUpAccountLinkingTest {
+
+    }
+
+    @Nested
+    @Order(4)
+    @DisplayName("[4-2] 소셜 회원가입")
+    class OauthSignUpTest {
+
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -433,7 +434,9 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(header().exists("Authorization"))
                     .andExpect(jsonPath("$.data.user.id").value(user.getId()))
                     .andDo(print());
-            assertEquals(oauthService.readOauthByOauthIdAndProvider(expectedOauthId, provider).get().getUser().getId(), user.getId());
+            Oauth savedOauth = oauthService.readOauthByOauthIdAndProvider(expectedOauthId, provider).get();
+            assertEquals(savedOauth.getUser().getId(), user.getId());
+            System.out.println("oauth : " + savedOauth);
         }
 
         @Test
@@ -461,7 +464,9 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(header().exists("Authorization"))
                     .andExpect(jsonPath("$.data.user.id").value(user.getId()))
                     .andDo(print());
-            assertEquals(oauthService.readOauthByOauthIdAndProvider(expectedOauthId, provider).get().getUser().getId(), user.getId());
+            Oauth savedOauth = oauthService.readOauthByOauthIdAndProvider(expectedOauthId, provider).get();
+            assertEquals(savedOauth.getUser().getId(), user.getId());
+            System.out.println("oauth : " + savedOauth);
         }
 
         @Test
@@ -544,7 +549,9 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(header().exists("Authorization"))
                     .andExpect(jsonPath("$.data.user.id").isNumber())
                     .andDo(print());
-            System.out.println("oauth : " + oauthService.readOauthByOauthIdAndProvider(expectedOauthId, provider).get());
+            Oauth savedOauth = oauthService.readOauthByOauthIdAndProvider(expectedOauthId, provider).get();
+            assertNotNull(savedOauth.getUser().getId());
+            System.out.println("oauth : " + savedOauth);
         }
 
         @Test

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
@@ -1,10 +1,15 @@
 package kr.co.pennyway.api.apis.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
 import kr.co.pennyway.api.apis.auth.dto.SignInReq;
+import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
 import kr.co.pennyway.api.apis.auth.helper.OauthOidcHelper;
+import kr.co.pennyway.api.common.exception.PhoneVerificationErrorCode;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
+import kr.co.pennyway.domain.common.redis.phone.PhoneVerificationService;
+import kr.co.pennyway.domain.common.redis.phone.PhoneVerificationType;
 import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
 import kr.co.pennyway.domain.domains.oauth.exception.OauthErrorCode;
 import kr.co.pennyway.domain.domains.oauth.service.OauthService;
@@ -18,6 +23,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -35,6 +41,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -52,12 +59,16 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
     private final String expectedOauthId = "testOauthId";
     private final String expectedIdToken = "testIdToken";
+    private final String expectedPhone = "010-1234-5678";
+    private final String expectedCode = "123456";
     @Autowired
     private MockMvc mockMvc;
     @Autowired
     private ObjectMapper objectMapper;
     @MockBean
     private OauthOidcHelper oauthOidcHelper;
+    @SpyBean
+    private PhoneVerificationService phoneVerificationService;
     @Autowired
     private UserService userService;
     @Autowired
@@ -247,14 +258,266 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
     @Order(2)
     @DisplayName("[3] 소셜 회원가입 전화번호 인증")
     class OauthSignUpPhoneVerificationTest {
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("기존의 일반 회원가입 이력이 있으면, existsUser가 true고 username이 반환된다.")
+        void signUpWithGeneralSignedUser() throws Exception {
+            // given
+            Provider provider = Provider.KAKAO;
+            User user = createGeneralSignedUser();
 
+            userService.createUser(user);
+            phoneVerificationService.create(expectedPhone, expectedCode, PhoneVerificationType.getOauthSignUpTypeByProvider(provider));
+
+            // when
+            ResultActions result = performOauthSignUpPhoneVerification(provider, expectedCode);
+
+            // then
+            result
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("2000"))
+                    .andExpect(jsonPath("$.data.sms.code").value(true))
+                    .andExpect(jsonPath("$.data.sms.existsUser").value(true))
+                    .andExpect(jsonPath("$.data.sms.username").value(expectedUsername))
+                    .andDo(print());
+        }
+
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("기존의 다른 provider OAuth 회원가입 이력이 있으면, existsUser가 true고 username이 반환된다.")
+        void signUpWithDifferentProvider() throws Exception {
+            // given
+            Provider provider = Provider.KAKAO;
+            User user = createOauthSignedUser();
+            Oauth oauth = createOauthAccount(user, Provider.GOOGLE);
+
+            userService.createUser(user);
+            oauthService.createOauth(oauth);
+            phoneVerificationService.create(expectedPhone, expectedCode, PhoneVerificationType.getOauthSignUpTypeByProvider(Provider.KAKAO));
+
+            // when
+            ResultActions result = performOauthSignUpPhoneVerification(provider, expectedCode);
+
+            // then
+            result
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("2000"))
+                    .andExpect(jsonPath("$.data.sms.code").value(true))
+                    .andExpect(jsonPath("$.data.sms.existsUser").value(true))
+                    .andExpect(jsonPath("$.data.sms.username").value(expectedUsername))
+                    .andDo(print());
+        }
+
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("기존의 회원가입 이력이 없으면 existsUser가 false고 username 필드가 없다.")
+        void signUpWithNoSignedUser() throws Exception {
+            // given
+            Provider provider = Provider.KAKAO;
+            phoneVerificationService.create(expectedPhone, expectedCode, PhoneVerificationType.getOauthSignUpTypeByProvider(provider));
+
+            // when
+            ResultActions result = performOauthSignUpPhoneVerification(provider, expectedCode);
+
+            // then
+            result
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("2000"))
+                    .andExpect(jsonPath("$.data.sms.code").value(true))
+                    .andExpect(jsonPath("$.data.sms.existsUser").value(false))
+                    .andExpect(jsonPath("$.data.sms.username").doesNotExist())
+                    .andDo(print());
+        }
+
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("같은 provider로 OAuth 회원가입 이력이 있으면 400 에러가 발생한다.")
+        void signUpWithSameProvider() throws Exception {
+            // given
+            Provider provider = Provider.KAKAO;
+            User user = createOauthSignedUser();
+            Oauth oauth = createOauthAccount(user, provider);
+
+            userService.createUser(user);
+            oauthService.createOauth(oauth);
+            phoneVerificationService.create(expectedPhone, expectedCode, PhoneVerificationType.getOauthSignUpTypeByProvider(provider));
+
+            // when
+            ResultActions result = performOauthSignUpPhoneVerification(provider, expectedCode);
+
+            // then
+            result
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(OauthErrorCode.ALREADY_SIGNUP_OAUTH.causedBy().getCode()))
+                    .andExpect(jsonPath("$.message").value(OauthErrorCode.ALREADY_SIGNUP_OAUTH.getExplainError()))
+                    .andDo(print());
+        }
+
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("인증 코드를 요청한 provider와 다른 provider로 인증 코드를 입력하면 404 에러가 발생한다.")
+        void signUpWithDifferentProviderCode() throws Exception {
+            // given
+            phoneVerificationService.create(expectedPhone, expectedCode, PhoneVerificationType.getOauthSignUpTypeByProvider(Provider.KAKAO));
+
+            // when
+            ResultActions result = performOauthSignUpPhoneVerification(Provider.GOOGLE, expectedCode);
+
+            // then
+            result
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(PhoneVerificationErrorCode.EXPIRED_OR_INVALID_PHONE.causedBy().getCode()))
+                    .andExpect(jsonPath("$.message").value(PhoneVerificationErrorCode.EXPIRED_OR_INVALID_PHONE.getExplainError()))
+                    .andDo(print());
+        }
+
+
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("인증 코드가 틀리면 401 에러가 발생한다.")
+        void signUpWithInvalidCode() throws Exception {
+            // given
+            Provider provider = Provider.KAKAO;
+            phoneVerificationService.create(expectedPhone, expectedCode, PhoneVerificationType.getOauthSignUpTypeByProvider(provider));
+
+            // when
+            ResultActions result = performOauthSignUpPhoneVerification(provider, "123457");
+
+            // then
+            result
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value(PhoneVerificationErrorCode.IS_NOT_VALID_CODE.causedBy().getCode()))
+                    .andExpect(jsonPath("$.message").value(PhoneVerificationErrorCode.IS_NOT_VALID_CODE.getExplainError()))
+                    .andDo(print());
+        }
+
+        private ResultActions performOauthSignUpPhoneVerification(Provider provider, String code) throws Exception {
+            PhoneVerificationDto.VerifyCodeReq request = new PhoneVerificationDto.VerifyCodeReq(expectedPhone, code);
+            return mockMvc.perform(post("/v1/auth/oauth/phone/verification")
+                    .param("provider", provider.name())
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(request)));
+        }
     }
 
     @Nested
     @Order(3)
     @DisplayName("[4-1] 소셜 회원가입 계정 연동")
     class OauthSignUpAccountLinkingTest {
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("기존의 일반 회원가입 이력이 있으면, 해당 user entity에 OAuth 정보가 추가되고 로그인에 성공한다.")
+        void signUpWithGeneralSignedUser() throws Exception {
+            // given
+            Provider provider = Provider.KAKAO;
+            User user = createGeneralSignedUser();
 
+            userService.createUser(user);
+            phoneVerificationService.create(expectedPhone, expectedCode, PhoneVerificationType.getOauthSignUpTypeByProvider(provider));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+
+            // when
+            ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode);
+
+            // then
+            result
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("Set-Cookie"))
+                    .andExpect(header().exists("Authorization"))
+                    .andExpect(jsonPath("$.data.user.id").value(user.getId()))
+                    .andDo(print());
+            assertEquals(oauthService.readOauthByOauthIdAndProvider(expectedOauthId, provider).get().getUser().getId(), user.getId());
+        }
+
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("기존의 다른 provider OAuth 회원가입 이력이 있으면, user entity에 OAuth 정보가 추가되고 로그인에 성공한다.")
+        void signUpWithDifferentProvider() throws Exception {
+            // given
+            Provider provider = Provider.KAKAO;
+            User user = createOauthSignedUser();
+            Oauth oauth = createOauthAccount(user, Provider.GOOGLE);
+
+            userService.createUser(user);
+            oauthService.createOauth(oauth);
+            phoneVerificationService.create(expectedPhone, expectedCode, PhoneVerificationType.getOauthSignUpTypeByProvider(provider));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+
+            // when
+            ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode);
+
+            // then
+            result
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("Set-Cookie"))
+                    .andExpect(header().exists("Authorization"))
+                    .andExpect(jsonPath("$.data.user.id").value(user.getId()))
+                    .andDo(print());
+            assertEquals(oauthService.readOauthByOauthIdAndProvider(expectedOauthId, provider).get().getUser().getId(), user.getId());
+        }
+
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("기존의 회원가입 이력이 없으면, 동기화 요청 실패 후 400 에러가 발생한다.")
+        void signUpWithNoSignedUser() throws Exception {
+            // given
+            Provider provider = Provider.KAKAO;
+            phoneVerificationService.create(expectedPhone, expectedCode, PhoneVerificationType.getOauthSignUpTypeByProvider(provider));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+
+            // when
+            ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode);
+
+            // then
+            result
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(OauthErrorCode.INVALID_OAUTH_SYNC_REQUEST.causedBy().getCode()))
+                    .andExpect(jsonPath("$.message").value(OauthErrorCode.INVALID_OAUTH_SYNC_REQUEST.getExplainError()))
+                    .andDo(print());
+        }
+
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("같은 provider로 OAuth 회원가입 이력이 있으면 400 에러가 발생한다.")
+        void signUpWithSameProvider() throws Exception {
+            // given
+            Provider provider = Provider.KAKAO;
+            User user = createOauthSignedUser();
+            Oauth oauth = createOauthAccount(user, provider);
+
+            userService.createUser(user);
+            oauthService.createOauth(oauth);
+            phoneVerificationService.create(expectedPhone, expectedCode, PhoneVerificationType.getOauthSignUpTypeByProvider(provider));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+
+            // when
+            ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode);
+
+            // then
+            result
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(OauthErrorCode.ALREADY_SIGNUP_OAUTH.causedBy().getCode()))
+                    .andExpect(jsonPath("$.message").value(OauthErrorCode.ALREADY_SIGNUP_OAUTH.getExplainError()))
+                    .andDo(print());
+        }
+
+        private ResultActions performOauthSignUpAccountLinking(Provider provider, String code) throws Exception {
+            SignUpReq.SyncWithAuth request = new SignUpReq.SyncWithAuth(expectedIdToken, expectedPhone, code);
+            return mockMvc.perform(post("/v1/auth/oauth/link-auth")
+                    .param("provider", provider.name())
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(request)));
+        }
     }
 
     @Nested

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
@@ -1,44 +1,156 @@
 package kr.co.pennyway.api.apis.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.auth.dto.SignInReq;
 import kr.co.pennyway.api.apis.auth.helper.OauthOidcHelper;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
+import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
+import kr.co.pennyway.domain.domains.oauth.service.OauthService;
+import kr.co.pennyway.domain.domains.oauth.type.Provider;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
+import kr.co.pennyway.domain.domains.user.type.Role;
+import kr.co.pennyway.infra.common.oidc.OidcDecodePayload;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ResourceUtils;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExternalApiIntegrationTest
 @AutoConfigureMockMvc
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@AutoConfigureWireMock(port = 0)
+@TestPropertySource(properties = "oauth2.client.provider.kakao.jwks-uri=http://localhost:${wiremock.server.port}")
 public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
+    private final String expectedUsername = "jayang";
+
+    private final String expectedOauthId = "testOauthId";
+    private final String expectedIdToken = "testIdToken";
     @Autowired
     private MockMvc mockMvc;
     @Autowired
     private ObjectMapper objectMapper;
-    @SpyBean
+    @MockBean
     private OauthOidcHelper oauthOidcHelper;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private OauthService oauthService;
+
+    /**
+     * 일반 회원가입 유저 생성
+     */
+    private User createGeneralSignedUser() {
+        return User.builder()
+                .name("페니웨이")
+                .username(expectedUsername)
+                .password("dkssudgktpdy1")
+                .phone("010-1234-5678")
+                .role(Role.USER)
+                .profileVisibility(ProfileVisibility.PUBLIC)
+                .build();
+    }
+
+    /**
+     * OAuth로 가입한 유저 생성 (password가 NULL)
+     */
+    private User createOauthSignedUser() {
+        return User.builder()
+                .name("페니웨이")
+                .username(expectedUsername)
+                .phone("010-1234-5678")
+                .role(Role.USER)
+                .profileVisibility(ProfileVisibility.PUBLIC)
+                .build();
+    }
+
+    /**
+     * User에 연결된 Oauth 생성
+     */
+    private Oauth createOauthAccount(User user, Provider provider) {
+        return Oauth.of(provider, expectedOauthId, user);
+    }
 
     @BeforeEach
-    void setUp(WebApplicationContext webApplicationContext) {
+    void setUp(WebApplicationContext webApplicationContext) throws IOException {
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
                 .defaultRequest(post("/**").with(csrf()))
                 .build();
+        Path path = ResourceUtils.getFile("classpath:payload/oidc-response.json").toPath();
+        stubFor(
+                get(urlPathEqualTo("/.well-known/jwks.json"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(HttpStatus.OK.value())
+                                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(Files.readAllBytes(path))
+                        )
+        );
     }
 
     @Nested
     @Order(1)
     @DisplayName("[1] 소셜 로그인")
     class OauthSignInTest {
+        @Test
+        @WithAnonymousUser
+        @Transactional
+        @DisplayName("provider로 로그인한 소셜 계정이 있으면 로그인에 성공한다.")
+        void signInWithOauth() throws Exception {
+            // given
+            Provider provider = Provider.KAKAO;
+            User user = createOauthSignedUser();
 
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            userService.createUser(user);
+            oauthService.createOauth(createOauthAccount(user, provider));
+
+            // when
+            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken);
+
+            // then
+            result
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("Set-Cookie"))
+                    .andExpect(header().exists("Authorization"))
+                    .andExpect(jsonPath("$.data.user.id").value(1))
+                    .andDo(print());
+        }
+
+        private ResultActions performOauthSignIn(Provider provider, String oauthId, String idToken) throws Exception {
+            SignInReq.Oauth request = new SignInReq.Oauth(oauthId, idToken);
+
+            return mockMvc.perform(post("/v1/auth/oauth/sign-in")
+                    .param("provider", provider.name())
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(request)));
+        }
     }
 
     @Nested

--- a/pennyway-app-external-api/src/test/resources/payload/oidc-response.json
+++ b/pennyway-app-external-api/src/test/resources/payload/oidc-response.json
@@ -1,0 +1,20 @@
+{
+  "keys": [
+    {
+      "kid": "3f96980381e451efad0d2ddd30e3d3",
+      "kty": "RSA",
+      "alg": "RS256",
+      "use": "sig",
+      "n": "q8zZ0b_MNaLd6Ny8wd4cjFomilLfFIZcmhNSc1ttx_oQdJJZt5CDHB8WWwPGBUDUyY8AmfglS9Y1qA0_fxxs-ZUWdt45jSbUxghKNYgEwSutfM5sROh3srm5TiLW4YfOvKytGW1r9TQEdLe98ork8-rNRYPybRI3SKoqpci1m1QOcvUg4xEYRvbZIWku24DNMSeheytKUz6Ni4kKOVkzfGN11rUj1IrlRR-LNA9V9ZYmeoywy3k066rD5TaZHor5bM5gIzt1B4FmUuFITpXKGQZS5Hn_Ck8Bgc8kLWGAU8TzmOzLeROosqKE0eZJ4ESLMImTb2XSEZuN1wFyL0VtJw",
+      "e": "AQAB"
+    },
+    {
+      "kid": "9f252dadd5f233f93d2fa528d12fea",
+      "kty": "RSA",
+      "alg": "RS256",
+      "use": "sig",
+      "n": "qGWf6RVzV2pM8YqJ6by5exoixIlTvdXDfYj2v7E6xkoYmesAjp_1IYL7rzhpUYqIkWX0P4wOwAsg-Ud8PcMHggfwUNPOcqgSk1hAIHr63zSlG8xatQb17q9LrWny2HWkUVEU30PxxHsLcuzmfhbRx8kOrNfJEirIuqSyWF_OBHeEgBgYjydd_c8vPo7IiH-pijZn4ZouPsEg7wtdIX3-0ZcXXDbFkaDaqClfqmVCLNBhg3DKYDQOoyWXrpFKUXUFuk2FTCqWaQJ0GniO4p_ppkYIf4zhlwUYfXZEhm8cBo6H2EgukntDbTgnoha8kNunTPekxWTDhE5wGAt6YpT4Yw",
+      "e": "AQAB"
+    }
+  ]
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -59,4 +59,16 @@ public class Oauth {
                 .user(user)
                 .build();
     }
+
+    @Override
+    public String toString() {
+        return "Oauth{" +
+                "id=" + id +
+                ", provider=" + provider +
+                ", oauthId='" + oauthId + '\'' +
+                ", createdAt=" + createdAt +
+                ", deletedAt=" + deletedAt +
+                ", user=" + user +
+                '}';
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/exception/OauthErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/exception/OauthErrorCode.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 public enum OauthErrorCode implements BaseErrorCode {
     /* 400 Bad Request */
     ALREADY_SIGNUP_OAUTH(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "이미 해당 제공자로 가입된 사용자입니다."),
+    INVALID_OAUTH_SYNC_REQUEST(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "Oauth 동기화 요청이 잘못되었습니다."),
 
     /* 401 Unauthorized */
     NOT_MATCHED_OAUTH_ID(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS, "OAuth ID가 일치하지 않습니다."),

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -14,6 +14,11 @@ import java.util.Optional;
 public class OauthService {
     private final OauthRepository oauthRepository;
 
+    @Transactional
+    public void createOauth(Oauth oauth) {
+        oauthRepository.save(oauth);
+    }
+
     @Transactional(readOnly = true)
     public Optional<Oauth> readOauthByOauthIdAndProvider(String oauthId, Provider provider) {
         return oauthRepository.findByOauthIdAndProvider(oauthId, provider);

--- a/pennyway-domain/src/main/resources/application-domain.yml
+++ b/pennyway-domain/src/main/resources/application-domain.yml
@@ -74,7 +74,7 @@ spring:
     generate-ddl: true
     hibernate:
       ddl-auto: create
-    show-sql: false
+    show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect

--- a/pennyway-infra/src/main/resources/application-infra.yml
+++ b/pennyway-infra/src/main/resources/application-infra.yml
@@ -28,14 +28,14 @@ oauth2:
   client:
     provider:
       kakao:
-        jwks-uri: ${KAKAO_JWKS_URI:https://kakao.com}
+        jwks-uri: ${KAKAO_JWKS_URI:http://localhost}
         secret: ${KAKAO_CLIENT_SECRET:liuhil5068l2j5o0912}
       google:
-        jwks-uri: ${GOOGLE_JWKS_URI:https://google.com}
+        jwks-uri: ${GOOGLE_JWKS_URI:http://localhost}
         secret: ${GOOGLE_CLIENT_SECRET:123456789012-67hm9vokrt6ukmiwtvd8ak67oflecm.apps.googleusercontent.com}
         issuer: ${GOOGLE_ISSUER:https://google.com}
       apple:
-        jwks-uri: ${APPLE_JWKS_URI:https://apple.com}
+        jwks-uri: ${APPLE_JWKS_URI:http://localhost}
         secret: ${APPLE_CLIENT_SECRET:pennyway-jayang-was}
 
 ---


### PR DESCRIPTION
## 작업 이유
- #42 OAuth 계정 요청이 200 OK가 뜨지만, DB에 반영되지 않는 이슈
- 통합 Test case를 작성 (관심사 분리가 실패했다고 볼 수 있겠지만, test case를 작성하지 않으면 이번 PR이 성공함을 보장할 수 없었습니다.)
- OAuth Swagger 일부 수정

<br/>

## 작업 사항
### 1️⃣ Oauth 데이터 저장이 안 되는 문제 해결
```java
Oauth oauth = Oauth.of(provider, oauthId, user);
oauthService.createOauth(oauth);
```
- `UserOauthSignMapper`에서 *oauthService.createOauth*()를 추가했습니다.
- User Entity에 역방향 관계가 맺어져 있지 않아서, 영속화된 entity에 Oauth 정보가 주입되지 않아 자동 `insert` 대상으로 식별되지 않는다는 걸 놓쳤던 문제입니다.
- User Entity에서 Oauth 정보를 get 할 일은 거의 없다고 판단하여, 역방향 매핑을 하지 않고 그냥 도메인 서비스를 직접 호출했습니다.

<br/>

### 2️⃣ Oauth [4-1], [4-2] 시나리오 문제점 개선
```java
if (isSignUpUser.getLeft().equals(Boolean.FALSE) && request.username() == null)
    throw new OauthException(OauthErrorCode.INVALID_OAUTH_SYNC_REQUEST);
if (isSignUpUser.getLeft().equals(Boolean.TRUE) && request.username() != null)
    throw new OauthException(OauthErrorCode.INVALID_OAUTH_SYNC_REQUEST);
```
+ Test 하다가 찾은 문젠데..Client를 좀 신뢰해서 느슨하게 가려다가 안 되겠다 싶어서 막았습니다.
   1. `isSignUpUser.getLeft().equals(Boolean.FALSE) && request.username() == null`
        - 기존 사용자 이력이 존재하지 않으면서 *v1/auth/oauth/link-auth*를 시도하는 경우 예외 처리
   2. `isSignUpUser.getLeft().equals(Boolean.TRUE) && request.username() != null`
        - 기존 사용자 이력이 존재하면서 *v1/auth/oauth/sign-up*를 시도하는 경우 예외 처리

<br/>

### 3️⃣ 그리고 무수히 쏟아지는 테스트 케이스...

1. 일반 회원가입, 로그인 테스트 (로그인 테스트는 빼먹은 거 같기도..)

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/9fdaa100-331f-4a92-85ba-1d53d5c35b75" width="700px"/>
</div>

2. 소셜 로그인, 회원가입 테스트

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/57b6fba5-cef1-408a-86e4-e451f2c94518" width="700px"/>
</div>


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 전체 1,008 라인중에 테스트 코드만 937줄입니다. :)
- `oidc-response.json`는 OpenFeign 가짜 응답을 위한 정보긴 한데, 실제 jwks 정보이기도 합니다. 어차피 공개된 값인데다, 주기적으로 바뀌는 정보라 딱히 문제 없을 거 같아서 따로 `.gitignore`하지는 않았어요.
- PR 관심사 분리 실패라고 볼 수 있습니다! 하지만 다음과 같은 목적으로 이번에 테스트 코드를 작성했어요.
   - 이번 PR을 테스트 해보려면 또 iOS팀에게 idToken 정보를 요구해야 해서 너무 번거로웠다.
   - 그렇다고 안 하기엔 정상 동작 여부를 확신할 수 없었다. (똑같은 문제로 계속 issue가 나오는 게 너무 싫어요..)

<br/>

## 발견한 이슈
- openFeign 가짜 응답을 받아오기 위해서 `spring-cloud-contract-wiremock` 의존성을 추가하고 `oidc-response.json`에 예상 응답값을 작성했으나 사용하지 않는 중입니다.
   - 가짜 응답을 받아오는 건 성공했는데, `OauthOidcHelper` 내부에서 idToken을 실제로 파싱하고 있어서 예외가 발생함. (그야 토큰이 아닌 일반 문자열을 보내버렸으니..)
   - 일부 메서드만 `given()`으로 대체하기엔, `OauthOidcHelper`는 하나를 제외하고 모두 `private`로 막아놔서 불가능
   - 그렇다고 진짜 테스트 목적의 `idToken`을 생성하는 코드 작성하는 건 너무 과잉이라고 생각..내가 테스트하고 싶은 관심사와 다름.
   - 따라서 `OauthOidcHelper`를 아예 `MockBean`으로 가져와서 가짜 응답을 받도록 처리함.
- 하지만 나중에 사용할 일이 있을 수도 있고, 혹시 저 부분을 처리해야 한다는 의견이 있을 수도 있어 테스트 코드에 남겨놓은 상태입니다.

