### PR TITLE
✨ Device Token 등록/수정/삭제 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -33,14 +33,6 @@ public interface UserAccountApi {
                             }
                             """)
             })),
-            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "originToken에 해당하는 Device 정보 불일치", value = """
-                            {
-                                "code": "4004",
-                                "message": "토큰의 디바이스 정보와 일치하지 않습니다."
-                            }
-                            """)
-            })),
             @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(name = "수정 요청 시, token에 매칭하는 디바이스 정보가 없는 경우", value = """
                             {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.users.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -1,22 +1,26 @@
 package kr.co.pennyway.api.apis.users.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "사용자 계정 관리 API", description = "사용자 본인의 계정 관리를 위한 Usecase를 제공합니다.")
 @SecurityRequirement(name = "access-token")
 public interface UserAccountApi {
     @Operation(summary = "디바이스 등록", description = "사용자의 디바이스 정보를 등록하거나 갱신합니다.")
-    ResponseEntity<?> registerDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user);
+    ResponseEntity<?> putDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user);
 
-    @Operation(summary = "디바이스 해제", description = "사용자의 디바이스 정보를 제거합니다.")
-    ResponseEntity<?> unregisterDevice(@PathVariable Long deviceId, @AuthenticationPrincipal SecurityUserDetails user);
+    @Operation(summary = "디바이스 토큰 제거", description = "사용자의 디바이스 정보와 토큰을 제거합니다.")
+    @Parameter(name = "token", description = "삭제할 디바이스 토큰", required = true, in = ParameterIn.QUERY)
+    ResponseEntity<?> deleteDevice(@RequestParam("token") @Validated @NotBlank String token, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -3,6 +3,10 @@ package kr.co.pennyway.api.apis.users.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
@@ -17,10 +21,46 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "사용자 계정 관리 API", description = "사용자 본인의 계정 관리를 위한 Usecase를 제공합니다.")
 @SecurityRequirement(name = "access-token")
 public interface UserAccountApi {
-    @Operation(summary = "디바이스 등록", description = "사용자의 디바이스 정보를 등록하거나 갱신합니다.")
+    @Operation(summary = "디바이스 등록", description = "사용자의 디바이스 정보를 등록(originToken == newToken)하거나 갱신(originToken != newToken)합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "디바이스 등록 성공", value = """
+                            {
+                                "device": {
+                                    "id": 1,
+                                    "token": "newToken"
+                                }
+                            }
+                            """)
+            })),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "originToken에 해당하는 Device 정보 불일치", value = """
+                            {
+                                "code": "4004",
+                                "message": "토큰의 디바이스 정보와 일치하지 않습니다."
+                            }
+                            """)
+            })),
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "수정 요청 시, token에 매칭하는 디바이스 정보가 없는 경우", value = """
+                            {
+                                "code": "4040",
+                                "message": "디바이스를 찾을 수 없습니다."
+                            }
+                            """)
+            }))
+    })
     ResponseEntity<?> putDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "디바이스 토큰 제거", description = "사용자의 디바이스 정보와 토큰을 제거합니다.")
     @Parameter(name = "token", description = "삭제할 디바이스 토큰", required = true, in = ParameterIn.QUERY)
+    @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "수정 요청 시, token에 매칭하는 디바이스 정보가 없는 경우", value = """
+                    {
+                        "code": "4040",
+                        "message": "디바이스를 찾을 수 없습니다."
+                    }
+                    """)
+    }))
     ResponseEntity<?> deleteDevice(@RequestParam("token") @Validated @NotBlank String token, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "사용자 계정 관리 API", description = "사용자 본인의 계정 관리를 위한 Usecase를 제공합니다.")
 @SecurityRequirement(name = "access-token")
-public interface UserAccountController {
+public interface UserAccountApi {
     @Operation(summary = "디바이스 등록", description = "사용자의 디바이스 정보를 등록하거나 갱신합니다.")
     ResponseEntity<?> registerDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user);
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountController.java
@@ -1,0 +1,21 @@
+package kr.co.pennyway.api.apis.users.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "사용자 계정 관리 API", description = "사용자 본인의 계정 관리를 위한 Usecase를 제공합니다.")
+@SecurityRequirement(name = "access-token")
+public interface UserAccountController {
+    @Operation(summary = "디바이스 등록", description = "사용자의 디바이스 정보를 등록하거나 갱신합니다.")
+    ResponseEntity<?> registerDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "디바이스 해제", description = "사용자의 디바이스 정보를 제거합니다.")
+    ResponseEntity<?> unregisterDevice(@PathVariable Long deviceId, @AuthenticationPrincipal SecurityUserDetails user);
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -1,5 +1,7 @@
 package kr.co.pennyway.api.apis.users.controller;
 
+import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.api.apis.users.usecase.UserAccountUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -20,14 +22,14 @@ public class UserAccountController {
     @PutMapping("/devices")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> registerDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user) {
-        DeviceDto.RegisterRes response = DeviceDto.RegisterRes.of(userAuthUseCase.registerDevice(user.getUserId(), request));
+        DeviceDto.RegisterRes response = DeviceDto.RegisterRes.of(userAccountUseCase.registerDevice(user.getUserId(), request), request.newToken());
         return ResponseEntity.ok(SuccessResponse.from("device", response)); // response -> {"id": ..}
     }
 
     @DeleteMapping("/devices/{deviceId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> unregisterDevice(@PathVariable Long deviceId, @AuthenticationPrincipal SecurityUserDetails user) {
-        userAuthUseCase.unregisterDevice(user.getUserId(), deviceId);
+        userAccountUseCase.unregisterDevice(user.getUserId(), deviceId);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -1,5 +1,7 @@
 package kr.co.pennyway.api.apis.users.controller;
 
+import jakarta.validation.constraints.NotBlank;
+import kr.co.pennyway.api.apis.users.api.UserAccountApi;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.usecase.UserAccountUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
@@ -16,19 +18,19 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v2/users/me")
-public class UserAccountController {
+public class UserAccountController implements UserAccountApi {
     private final UserAccountUseCase userAccountUseCase;
 
     @PutMapping("/devices")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> registerDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user) {
+    public ResponseEntity<?> putDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from("device", userAccountUseCase.registerDevice(user.getUserId(), request)));
     }
 
-    @DeleteMapping("/devices/{deviceId}")
+    @DeleteMapping("/devices")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> unregisterDevice(@PathVariable Long deviceId, @AuthenticationPrincipal SecurityUserDetails user) {
-        userAccountUseCase.unregisterDevice(user.getUserId(), deviceId);
+    public ResponseEntity<?> deleteDevice(@RequestParam("token") @Validated @NotBlank String token, @AuthenticationPrincipal SecurityUserDetails user) {
+        userAccountUseCase.unregisterDevice(user.getUserId(), token);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -22,8 +22,7 @@ public class UserAccountController {
     @PutMapping("/devices")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> registerDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user) {
-        DeviceDto.RegisterRes response = DeviceDto.RegisterRes.of(userAccountUseCase.registerDevice(user.getUserId(), request), request.newToken());
-        return ResponseEntity.ok(SuccessResponse.from("device", response)); // response -> {"id": ..}
+        return ResponseEntity.ok(SuccessResponse.from("device", userAccountUseCase.registerDevice(user.getUserId(), request)));
     }
 
     @DeleteMapping("/devices/{deviceId}")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -1,0 +1,33 @@
+package kr.co.pennyway.api.apis.users.controller;
+
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/users/me")
+public class UserAccountController {
+    private final UserAccountUseCase userAccountUseCase;
+
+    @PutMapping("/devices")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> registerDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user) {
+        DeviceDto.RegisterRes response = DeviceDto.RegisterRes.of(userAuthUseCase.registerDevice(user.getUserId(), request));
+        return ResponseEntity.ok(SuccessResponse.from("device", response)); // response -> {"id": ..}
+    }
+
+    @DeleteMapping("/devices/{deviceId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> unregisterDevice(@PathVariable Long deviceId, @AuthenticationPrincipal SecurityUserDetails user) {
+        userAuthUseCase.unregisterDevice(user.getUserId(), deviceId);
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
@@ -26,7 +26,7 @@ public class DeviceDto {
         }
 
         public Device toEntity(User user) {
-            return new Device(newToken, model, os, user);
+            return Device.of(newToken, model, os, user);
         }
     }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
@@ -21,7 +21,7 @@ public class DeviceDto {
             @NotBlank(message = "os는 필수입니다.")
             String os
     ) {
-        public boolean isSameToken() {
+        public boolean isInitRequest() {
             return originToken.equals(newToken);
         }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
@@ -24,6 +24,7 @@ public class DeviceDto {
         /**
          * oldToken과 newToken이 같은 경우, 신규 등록 요청으로 판단
          */
+        @Schema(hidden = true)
         public boolean isInitRequest() {
             return originToken.equals(newToken);
         }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
@@ -21,6 +21,9 @@ public class DeviceDto {
             @NotBlank(message = "os는 필수입니다.")
             String os
     ) {
+        /**
+         * oldToken과 newToken이 같은 경우, 신규 등록 요청으로 판단
+         */
         public boolean isInitRequest() {
             return originToken.equals(newToken);
         }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
@@ -1,0 +1,43 @@
+package kr.co.pennyway.api.apis.users.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import kr.co.pennyway.domain.domains.device.domain.Device;
+
+public class DeviceDto {
+    @Schema(title = "디바이스 등록 요청")
+    public record RegisterReq(
+            @Schema(description = "기존 디바이스 토큰", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "originToken은 필수입니다.")
+            String originToken,
+            @Schema(description = "새로운 디바이스 토큰", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "newToken은 필수입니다.")
+            String newToken,
+            @Schema(description = "디바이스 모델명", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "model은 필수입니다.")
+            String model,
+            @Schema(description = "디바이스 OS", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "os는 필수입니다.")
+            String os
+    ) {
+        public boolean isSameToken() {
+            return originToken.equals(newToken);
+        }
+
+        public Device toEntity() {
+            return new Device(newToken, model, os);
+        }
+    }
+
+    @Schema(title = "디바이스 등록 응답")
+    public record RegisterRes(
+            @Schema(title = "디바이스 ID")
+            Long id,
+            @Schema(title = "디바이스 토큰")
+            String token
+    ) {
+        public static RegisterRes of(Long id, String token) {
+            return new RegisterRes(id, token);
+        }
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/DeviceDto.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.users.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import kr.co.pennyway.domain.domains.device.domain.Device;
+import kr.co.pennyway.domain.domains.user.domain.User;
 
 public class DeviceDto {
     @Schema(title = "디바이스 등록 요청")
@@ -24,8 +25,8 @@ public class DeviceDto {
             return originToken.equals(newToken);
         }
 
-        public Device toEntity() {
-            return new Device(newToken, model, os);
+        public Device toEntity(User user) {
+            return new Device(newToken, model, os, user);
         }
     }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
@@ -39,8 +39,8 @@ public class DeviceRegisterService {
         Device device = readDeviceOrThrow(user.getId(), request.originToken());
 
         if (!isMatchOriginDeviceInfo(device, request)) {
-            log.warn("유효하지 않은 요청: 사용자 {} - model {} - os {}", user, request.model(), request.os());
-            throw new DeviceErrorException(DeviceErrorCode.NOT_MATCH_DEVICE);
+            log.warn("사용자 디바이스 정보 변경됨 : 사용자 {} - model {} - os {}", user, request.model(), request.os());
+            device.updateDeviceInfo(request.model(), request.os());
         }
 
         log.info("디바이스 토큰 갱신: 사용자 {} - model {} - os {}", user, request.model(), request.os());

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
@@ -25,7 +25,7 @@ public class DeviceRegisterService {
         Long deviceId;
 
         // 디바이스 토큰이 같은 경우, 신규 등록이라 판단하고 등록
-        if (request.isSameToken()) {
+        if (request.isInitRequest()) {
             log.info("신규 디바이스 등록: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
             Device device = deviceService.createDevice(request.toEntity(user));
             return device;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
@@ -11,8 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -21,37 +19,63 @@ public class DeviceRegisterService {
 
     @Transactional
     public Device createOrUpdateDevice(User user, DeviceDto.RegisterReq request) {
-        Long userId = user.getId();
-        Long deviceId;
-
-        // 디바이스 토큰이 같은 경우, 신규 등록이라 판단하고 등록
         if (request.isInitRequest()) {
-            log.info("신규 디바이스 등록: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
-            Device device = deviceService.createDevice(request.toEntity(user));
-            return device;
+            return createDevice(user, request);
+        } else {
+            return updateExistingDevice(user, request);
+        }
+    }
+
+    private Device createDevice(User user, DeviceDto.RegisterReq request) {
+        log.info("신규 디바이스 등록: 사용자 {} - model {} - os {}", user, request.model(), request.os());
+        Device newDevice = request.toEntity(user);
+        return deviceService.createDevice(newDevice);
+    }
+
+    /**
+     * 기존에 등록된 사용자의 디바이스 토큰을 갱신한다.
+     */
+    private Device updateExistingDevice(User user, DeviceDto.RegisterReq request) {
+        Device device = readDeviceOrThrow(user.getId(), request.originToken());
+
+        if (!isMatchOriginDeviceInfo(device, request)) {
+            log.warn("유효하지 않은 요청: 사용자 {} - model {} - os {}", user, request.model(), request.os());
+            throw new DeviceErrorException(DeviceErrorCode.NOT_MATCH_DEVICE);
         }
 
-        Optional<Device> device = deviceService.readDeviceByUserIdAndToken(userId, request.originToken());
+        log.info("디바이스 토큰 갱신: 사용자 {} - model {} - os {}", user, request.model(), request.os());
+        return updateDeviceToken(device, request.newToken());
+    }
 
-        if (device.isPresent()) { // 기존 디바이스 토큰이 존재하는 경우, 토큰 갱신
-            Device oldDevice = device.get();
+    /**
+     * 사용자 ID와 토큰으로 디바이스 정보를 조회한다.
+     *
+     * @throws DeviceErrorException 사용자 id와 originToken과 매칭되는 디바이스 정보가 없는 경우
+     */
+    private Device readDeviceOrThrow(Long userId, String token) {
+        return deviceService.readDeviceByUserIdAndToken(userId, token)
+                .orElseThrow(() -> new DeviceErrorException(DeviceErrorCode.NOT_FOUND_DEVICE));
+    }
 
-            if (!oldDevice.getOs().equals(request.os()) || !oldDevice.getModel().equals(request.model())) {
-                log.warn("유효하지 않은 요청: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
-                throw new DeviceErrorException(DeviceErrorCode.NOT_MATCH_DEVICE);
-            }
+    /**
+     * 요청한 디바이스 정보가 기존 디바이스 정보와 일치하는지 확인한다.
+     */
+    private boolean isMatchOriginDeviceInfo(Device device, DeviceDto.RegisterReq request) {
+        return device.getOs().equals(request.os()) && device.getModel().equals(request.model());
+    }
 
-            log.info("디바이스 토큰 갱신: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
-            oldDevice.updateToken(request.newToken());
+    /**
+     * 디바이스 토큰을 newToken으로 갱신하고, 만약 비활성화 토큰이라면 활성화 상태로 되돌린다.
+     */
+    private Device updateDeviceToken(Device device, String newToken) {
+        log.debug("디바이스 토큰 갱신: {} -> {}", device.getToken(), newToken);
 
-            if (oldDevice.getActivated().equals(Boolean.FALSE)) {
-                oldDevice.activate();
-            }
+        device.updateToken(newToken);
 
-            return oldDevice;
-        } else { // 기존 디바이스 토큰이 존재하지 않는 경우, 신규 등록
-            log.warn("{}번 사용자의 요청 디바이스 토큰을 찾을 수 없습니다. 요청 토큰 : {}", userId, request.originToken());
-            throw new DeviceErrorException(DeviceErrorCode.NOT_FOUND_DEVICE);
+        if (device.getActivated().equals(Boolean.FALSE)) {
+            device.activate();
         }
+
+        return device;
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
@@ -1,0 +1,59 @@
+package kr.co.pennyway.api.apis.users.service;
+
+import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.domain.domains.device.domain.Device;
+import kr.co.pennyway.domain.domains.device.exception.DeviceErrorCode;
+import kr.co.pennyway.domain.domains.device.exception.DeviceErrorException;
+import kr.co.pennyway.domain.domains.device.service.DeviceService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeviceRegisterService {
+    private final DeviceService deviceService;
+
+    @Transactional
+    public Device createOrUpdateDevice(DeviceDto.RegisterReq request, User user) {
+        Long userId = user.getId();
+        Long deviceId;
+
+        // 디바이스 토큰이 같은 경우, 신규 등록이라 판단하고 등록
+        if (request.isSameToken()) {
+            log.info("신규 디바이스 등록: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
+            Device device = deviceService.createDevice(request.toEntity(user));
+            return device;
+        }
+
+        Optional<Device> device = deviceService.readDeviceByUserIdAndToken(userId, request.originToken());
+
+        if (device.isPresent()) { // 기존 디바이스 토큰이 존재하는 경우, 토큰 갱신
+            Device oldDevice = device.get();
+
+            if (!oldDevice.getOs().equals(request.os()) || !oldDevice.getModel().equals(request.model())) {
+                log.warn("유효하지 않은 요청: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
+                throw new DeviceErrorException(DeviceErrorCode.NOT_MATCH_DEVICE);
+            }
+
+            log.info("디바이스 토큰 갱신: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
+            oldDevice.updateToken(request.newToken());
+
+            if (oldDevice.getActivated().equals(Boolean.FALSE)) {
+                oldDevice.activate();
+            }
+
+            deviceId = oldDevice.getId();
+        } else { // 기존 디바이스 토큰이 존재하지 않는 경우, 신규 등록
+            log.warn("{}번 사용자의 요청 디바이스 토큰을 찾을 수 없습니다. 요청 토큰 : {}", userId, request.originToken());
+            throw new DeviceErrorException(DeviceErrorCode.NOT_FOUND_DEVICE);
+        }
+
+        return device;
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
@@ -20,7 +20,7 @@ public class DeviceRegisterService {
     private final DeviceService deviceService;
 
     @Transactional
-    public Device createOrUpdateDevice(DeviceDto.RegisterReq request, User user) {
+    public Device createOrUpdateDevice(User user, DeviceDto.RegisterReq request) {
         Long userId = user.getId();
         Long deviceId;
 
@@ -48,12 +48,10 @@ public class DeviceRegisterService {
                 oldDevice.activate();
             }
 
-            deviceId = oldDevice.getId();
+            return oldDevice;
         } else { // 기존 디바이스 토큰이 존재하지 않는 경우, 신규 등록
             log.warn("{}번 사용자의 요청 디바이스 토큰을 찾을 수 없습니다. 요청 토큰 : {}", userId, request.originToken());
             throw new DeviceErrorException(DeviceErrorCode.NOT_FOUND_DEVICE);
         }
-
-        return device;
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceRegisterService.java
@@ -72,7 +72,7 @@ public class DeviceRegisterService {
 
         device.updateToken(newToken);
 
-        if (device.getActivated().equals(Boolean.FALSE)) {
+        if (!device.isActivated()) {
             device.activate();
         }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -43,7 +43,7 @@ public class UserAccountUseCase {
             Device oldDevice = device.get();
 
             if (!oldDevice.getOs().equals(request.os()) || !oldDevice.getModel().equals(request.model())) {
-                log.warn("유효하지 않은 요청자", userId, request.model(), request.os());
+                log.warn("유효하지 않은 요청: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
                 // 어떻게?
                 throw new DeviceErrorException(DeviceErrorCode.NOT_MATCH_DEVICE);
             }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -50,12 +50,15 @@ public class UserAccountUseCase {
 
             log.info("디바이스 토큰 갱신: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
             oldDevice.updateToken(request.newToken());
+
+            if (oldDevice.getActivated().equals(Boolean.FALSE)) {
+                oldDevice.activate();
+            }
+
             deviceId = oldDevice.getId();
         } else { // 기존 디바이스 토큰이 존재하지 않는 경우, 신규 등록
-            log.warn("기존 디바이스 토큰 비활성화: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
-            Device newDevice = request.toEntity(user);
-            deviceService.createDevice(newDevice);
-            deviceId = newDevice.getId();
+            log.warn("{}번 사용자의 요청 디바이스 토큰을 찾을 수 없습니다. 요청 토큰 : {}", userId, request.originToken());
+            throw new DeviceErrorException(DeviceErrorCode.NOT_FOUND_DEVICE);
         }
 
         return DeviceDto.RegisterRes.of(deviceId, request.newToken());

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -4,6 +4,9 @@ import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.device.domain.Device;
+import kr.co.pennyway.domain.domains.device.exception.DeviceErrorCode;
+import kr.co.pennyway.domain.domains.device.exception.DeviceErrorException;
+import kr.co.pennyway.domain.domains.device.service.DeviceService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
@@ -17,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserAccountUseCase {
     private final UserService userService;
+    private final DeviceService deviceService;
+
     private final DeviceRegisterService deviceRegisterService;
 
     @Transactional
@@ -31,7 +36,15 @@ public class UserAccountUseCase {
     }
 
     @Transactional
-    public void unregisterDevice(Long userId, Long deviceId) {
+    public void unregisterDevice(Long userId, String token) {
+        User user = userService.readUser(userId).orElseThrow(
+                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
+        );
 
+        Device device = deviceService.readDeviceByUserIdAndToken(user.getId(), token).orElseThrow(
+                () -> new DeviceErrorException(DeviceErrorCode.NOT_FOUND_DEVICE)
+        );
+
+        deviceService.deleteDevice(device);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -1,11 +1,9 @@
 package kr.co.pennyway.api.apis.users.usecase;
 
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.device.domain.Device;
-import kr.co.pennyway.domain.domains.device.exception.DeviceErrorCode;
-import kr.co.pennyway.domain.domains.device.exception.DeviceErrorException;
-import kr.co.pennyway.domain.domains.device.service.DeviceService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
@@ -14,54 +12,22 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class UserAccountUseCase {
     private final UserService userService;
-    private final DeviceService deviceService;
+    private final DeviceRegisterService deviceRegisterService;
 
     @Transactional
     public DeviceDto.RegisterRes registerDevice(Long userId, DeviceDto.RegisterReq request) {
         User user = userService.readUser(userId).orElseThrow(
                 () -> new UserErrorException(UserErrorCode.NOT_FOUND)
         );
-        Long deviceId;
 
-        // 디바이스 토큰이 같은 경우, 신규 등록이라 판단하고 등록
-        if (request.isSameToken()) {
-            log.info("신규 디바이스 등록: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
-            Device device = deviceService.createDevice(request.toEntity(user));
-            return DeviceDto.RegisterRes.of(device.getId(), request.newToken());
-        }
+        Device device = deviceRegisterService.createOrUpdateDevice(request, user);
 
-        Optional<Device> device = deviceService.readDeviceByUserIdAndToken(userId, request.originToken());
-
-        if (device.isPresent()) { // 기존 디바이스 토큰이 존재하는 경우, 토큰 갱신
-            Device oldDevice = device.get();
-
-            if (!oldDevice.getOs().equals(request.os()) || !oldDevice.getModel().equals(request.model())) {
-                log.warn("유효하지 않은 요청: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
-                // 어떻게?
-                throw new DeviceErrorException(DeviceErrorCode.NOT_MATCH_DEVICE);
-            }
-
-            log.info("디바이스 토큰 갱신: 사용자 {} - model {} - os {}", userId, request.model(), request.os());
-            oldDevice.updateToken(request.newToken());
-
-            if (oldDevice.getActivated().equals(Boolean.FALSE)) {
-                oldDevice.activate();
-            }
-
-            deviceId = oldDevice.getId();
-        } else { // 기존 디바이스 토큰이 존재하지 않는 경우, 신규 등록
-            log.warn("{}번 사용자의 요청 디바이스 토큰을 찾을 수 없습니다. 요청 토큰 : {}", userId, request.originToken());
-            throw new DeviceErrorException(DeviceErrorCode.NOT_FOUND_DEVICE);
-        }
-
-        return DeviceDto.RegisterRes.of(deviceId, request.newToken());
+        return DeviceDto.RegisterRes.of(device.getId(), request.newToken());
     }
 
     @Transactional

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -45,4 +45,8 @@ public class UserAccountUseCase {
         }
     }
 
+    @Transactional
+    public void unregisterDevice(Long userId, Long deviceId) {
+        
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -25,7 +25,7 @@ public class UserAccountUseCase {
                 () -> new UserErrorException(UserErrorCode.NOT_FOUND)
         );
 
-        Device device = deviceRegisterService.createOrUpdateDevice(request, user);
+        Device device = deviceRegisterService.createOrUpdateDevice(user, request);
 
         return DeviceDto.RegisterRes.of(device.getId(), request.newToken());
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -1,0 +1,51 @@
+package kr.co.pennyway.api.apis.users.usecase;
+
+import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.domains.device.domain.Device;
+import kr.co.pennyway.domain.domains.device.service.DeviceService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class UserAccountUseCase {
+    private final UserService userService;
+    private final DeviceService deviceService;
+
+    @Transactional
+    public Long registerDevice(Long userId, DeviceDto.RegisterReq request) {
+        User user = userService.readUser(userId).orElseThrow(
+                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
+        );
+
+
+        if (request.isSameToken()) {
+            Device device = deviceService.createDevice(request.toEntity(user));
+            return device.getId();
+        }
+
+        boolean flag = deviceService.isExistDeviceByToken(request.originToken()); // true: newToken으로 업데이트, false: 새로 저장
+
+        if (flag) { // newToken으로 업데이트
+            Device device = deviceService.readDevicesByUserId(userId).stream()
+                    .filter(d -> d.getToken().equals(request.originToken()))
+                    .findFirst()
+                    .orElseThrow();
+            device.updateToken(request.newToken());
+            return device.getId();
+        } else { // newToken으로 새로 저장
+            Device device = request.toEntity(user);
+            deviceService.createDevice(device);
+            return device.getId();
+        }
+    }
+
+
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -1,0 +1,69 @@
+package kr.co.pennyway.api.apis.users.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.api.apis.users.usecase.UserAccountUseCase;
+import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {UserAccountController.class})
+@ActiveProfiles("local")
+public class UserAccountControllerUnitTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserAccountUseCase userAccountUseCase;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .defaultRequest(put("/**").with(csrf()))
+                .defaultRequest(delete("/**").with(csrf()))
+                .build();
+    }
+
+    @DisplayName("[1] 디바이스가 정상적으로 저장되었을 때, 디바이스 pk와 등록된 토큰을 반환한다.")
+    @Test
+    @WithSecurityMockUser
+    void putDeviceSuccess() throws Exception {
+        // given
+        DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("newToken", "newToken", "modelA", "Windows");
+        DeviceDto.RegisterRes expectedResponse = new DeviceDto.RegisterRes(2L, "newToken");
+        given(userAccountUseCase.registerDevice(1L, request)).willReturn(expectedResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(put("/v2/users/me/devices")
+                .contentType("application/json")
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("2000"))
+                .andExpect(jsonPath("$.data.device.id").value(expectedResponse.id()))
+                .andExpect(jsonPath("$.data.device.token").value(expectedResponse.token()))
+                .andDo(print());
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -68,5 +68,19 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
         );
     }
 
+    @Test
+    @Transactional
+    @DisplayName("[2] 기존에 등록된 디바이스 토큰이 있는 경우, 디바이스 토큰을 갱신한다.")
+    void updateDeviceToken() {
+        // given
+        DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("newToken", "newToken", "modelA", "Windows");
+
+        // when
+
+
+        // then
+
+    }
+
 
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -187,4 +187,17 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
         Optional<Device> deletedDevice = deviceService.readDeviceByUserIdAndToken(requestUser.getId(), device.getToken());
         assertNull("디바이스가 삭제되어 있어야 한다.", deletedDevice.orElse(null));
     }
+
+    @Test
+    @Transactional
+    @DisplayName("[5] 사용자 ID와 token에 매칭되는 디바이스가 존재하지 않는 경우 NOT_FOUND_DEVICE 에러를 반환한다.")
+    void unregisterDeviceWhenDeviceIsNotExists() {
+        // given
+        Device device = Device.of("originToken", "modelA", "Windows", requestUser);
+        deviceService.createDevice(device);
+
+        // when - then
+        DeviceErrorException ex = assertThrows(DeviceErrorException.class, () -> userAccountUseCase.unregisterDevice(requestUser.getId(), "notExistsToken"));
+        assertEquals("디바이스 토큰이 존재하지 않으면 Not Found를 반환한다.", DeviceErrorCode.NOT_FOUND_DEVICE, ex.getBaseErrorCode());
+    }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -82,7 +82,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
 
     @Test
     @Transactional
-    @DisplayName("[1-1] originToken에 대한 디바이스가 이미 존재하는 경우, 디바이스 정보 변경 사항만 업데이트하고 기존 디바이스 정보를 반환한다.")
+    @DisplayName("[1-1] 저장 요청에서 originToken에 대한 디바이스가 이미 존재하는 경우, 디바이스 정보 변경 사항만 업데이트하고 기존 디바이스 정보를 반환한다.")
     void registerNewDeviceWhenDeviceIsAlreadyExists() {
         // given
         Device oldDevice = Device.of("originToken", "modelA", "Windows", requestUser);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -25,6 +25,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.util.AssertionErrors.*;
 
@@ -168,5 +170,21 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
         // when - then
         DeviceErrorException ex = assertThrows(DeviceErrorException.class, () -> userAccountUseCase.registerDevice(requestUser.getId(), request));
         assertEquals("디바이스 토큰이 존재하지 않으면 Not Found를 반환한다.", DeviceErrorCode.NOT_FOUND_DEVICE, ex.getBaseErrorCode());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("[4] 사용자 ID와 origin token에 매칭되는 활성 디바이스가 존재하는 경우 디바이스를 삭제한다.")
+    void unregisterDevice() {
+        // given
+        Device device = Device.of("originToken", "modelA", "Windows", requestUser);
+        deviceService.createDevice(device);
+
+        // when
+        userAccountUseCase.unregisterDevice(requestUser.getId(), device.getToken());
+
+        // then
+        Optional<Device> deletedDevice = deviceService.readDeviceByUserIdAndToken(requestUser.getId(), device.getToken());
+        assertNull("디바이스가 삭제되어 있어야 한다.", deletedDevice.orElse(null));
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -113,7 +113,10 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
         // given
         Device oldDevice = Device.of("originToken", "modelA", "Windows", requestUser);
         deviceService.createDevice(oldDevice);
-        em.createQuery("UPDATE Device d SET d.activated = false WHERE d.token = :token").executeUpdate(); // 비활성화 처리
+        em.createQuery("UPDATE Device d SET d.activated = false WHERE d.id = :id AND d.token = :token")
+                .setParameter("id", oldDevice.getId())
+                .setParameter("token", oldDevice.getToken())
+                .executeUpdate(); // 비활성화 처리
 
         System.out.println("oldDevice = " + oldDevice);
         DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelA", "Windows");
@@ -161,10 +164,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
         // given
         DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelA", "Windows");
 
-        // when
-        DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
-
-        // then
+        // when - then
         DeviceErrorException ex = assertThrows(DeviceErrorException.class, () -> userAccountUseCase.registerDevice(requestUser.getId(), request));
         assertEquals("디바이스 토큰이 존재하지 않으면 Not Found를 반환한다.", DeviceErrorCode.NOT_FOUND_DEVICE, ex.getBaseErrorCode());
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -145,7 +145,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
 
     @Test
     @Transactional
-    @DisplayName("[2-2] 사용자가 유효한 토큰을 가지고 있지만 모델명이나 OS가 다른 경우 DEVICE_NOT_MATCH 에러를 반환한다.")
+    @DisplayName("[2-2] 사용자가 유효한 토큰을 가지고 있지만 모델명이나 OS가 다른 경우, 디바이스 정보를 업데이트한다.")
     void notMatchDevice() {
         // given
         Device oldDevice = Device.of("originToken", "modelA", "Windows", requestUser);
@@ -154,10 +154,20 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
         DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelB", "MacOS");
 
         // when
-        DeviceErrorException ex = assertThrows(DeviceErrorException.class, () -> userAccountUseCase.registerDevice(requestUser.getId(), request));
+        userAccountUseCase.registerDevice(requestUser.getId(), request);
 
         // then
-        assertEquals("디바이스 모델명이나 OS가 일치하지 않으면 400 Bad Request를 반환한다.", DeviceErrorCode.NOT_MATCH_DEVICE, ex.getBaseErrorCode());
+        deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
+                device -> {
+                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", request.newToken(), device.getToken());
+                    assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
+                    assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
+                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
+                    assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
+                    System.out.println("device = " + device);
+                },
+                () -> fail("디바이스 토큰이 갱신되어 있어야 한다.")
+        );
     }
 
     @Test

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.users.usecase;
 
 import jakarta.persistence.EntityManager;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.domain.config.JpaConfig;
 import kr.co.pennyway.domain.domains.device.domain.Device;
@@ -29,7 +30,7 @@ import static org.springframework.test.util.AssertionErrors.*;
 
 @ExtendWith(MockitoExtension.class)
 @DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create")
-@ContextConfiguration(classes = {JpaConfig.class, UserAccountUseCase.class, UserService.class, DeviceService.class})
+@ContextConfiguration(classes = {JpaConfig.class, UserAccountUseCase.class, DeviceRegisterService.class, UserService.class, DeviceService.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
 class UserAccountUseCaseTest extends ExternalApiDBTestConfig {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.api.apis.users.usecase;
 
+import jakarta.persistence.EntityManager;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.domain.config.JpaConfig;
@@ -41,6 +42,9 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
     @Autowired
     private UserAccountUseCase userAccountUseCase;
 
+    @Autowired
+    private EntityManager em;
+
     private User requestUser;
 
     @BeforeEach
@@ -51,7 +55,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
 
     @Test
     @Transactional
-    @DisplayName("[1] 기존에 등록된 디바이스 토큰이 없는 경우, 신규 디바이스를 등록한다.")
+    @DisplayName("[1] originToken과 newToken이 같은 경우, 신규 디바이스를 등록한다.")
     void registerNewDevice() {
         // given
         DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("newToken", "newToken", "modelA", "Windows");
@@ -75,11 +79,12 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
 
     @Test
     @Transactional
-    @DisplayName("[2] 기존에 등록된 디바이스 토큰이 있는 경우, 디바이스 토큰을 갱신한다.")
-    void updateDeviceToken() {
+    @DisplayName("[2] 기존에 등록된 활성화 디바이스 토큰이 있고 디바이스 정보가 일치한다면, 디바이스 토큰을 갱신한다.")
+    void updateActivateDeviceToken() {
         // given
         Device oldDevice = Device.of("originToken", "modelA", "Windows", requestUser);
         deviceService.createDevice(oldDevice);
+
         System.out.println("oldDevice = " + oldDevice);
         DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelA", "Windows");
 
@@ -94,6 +99,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
                     assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
                     assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
                     assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
+                    assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
                     System.out.println("device = " + device);
                 },
                 () -> fail("디바이스 토큰이 갱신되어 있어야 한다.")
@@ -102,7 +108,38 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
 
     @Test
     @Transactional
-    @DisplayName("[2-1] 사용자가 유효한 토큰을 가지고 있지만 모델명이나 OS가 다른 경우 DEVICE_NOT_MATCH 에러를 반환한다.")
+    @DisplayName("[2-1] 기존에 등록된 비활성화 디바이스 토큰이 있고 디바이스 정보가 일치한다면, 디바이스 토큰을 갱신하고 활성화로 변경한다.")
+    void updateDeactivateDeviceToken() {
+        // given
+        Device oldDevice = Device.of("originToken", "modelA", "Windows", requestUser);
+        deviceService.createDevice(oldDevice);
+        em.createQuery("UPDATE Device d SET d.activated = false WHERE d.token = :token").executeUpdate(); // 비활성화 처리
+
+        System.out.println("oldDevice = " + oldDevice);
+        DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelA", "Windows");
+
+        // when
+        DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
+
+        // then
+        deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
+                device -> {
+                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
+                    assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
+                    assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
+                    assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
+                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
+                    assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
+                    System.out.println("device = " + device);
+                },
+                () -> fail("디바이스 토큰이 갱신되어 있어야 한다.")
+        );
+    }
+
+
+    @Test
+    @Transactional
+    @DisplayName("[2-2] 사용자가 유효한 토큰을 가지고 있지만 모델명이나 OS가 다른 경우 DEVICE_NOT_MATCH 에러를 반환한다.")
     void notMatchDevice() {
         // given
         Device oldDevice = Device.of("originToken", "modelA", "Windows", requestUser);
@@ -112,12 +149,14 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
 
         // when
         DeviceErrorException ex = assertThrows(DeviceErrorException.class, () -> userAccountUseCase.registerDevice(requestUser.getId(), request));
+
+        // then
         assertEquals("디바이스 모델명이나 OS가 일치하지 않으면 400 Bad Request를 반환한다.", DeviceErrorCode.NOT_MATCH_DEVICE, ex.getBaseErrorCode());
     }
 
     @Test
     @Transactional
-    @DisplayName("[3] 서버에서 토큰을 비활성화 처리하여 존재하지 않는데, 클라이언트가 변경 요청을 보낸 경우 newToken으로 신규 디바이스를 등록한다.")
+    @DisplayName("[3] 토큰 수정 요청에서 oldToken에 대한 디바이스가 존재하지 않는 경우, NOT_FOUND 에러를 반환한다.")
     void registerNewDeviceWhenOldDeviceTokenIsNotExists() {
         // given
         DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelA", "Windows");
@@ -126,16 +165,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
         DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
 
         // then
-        deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
-                device -> {
-                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
-                    assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
-                    assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
-                    assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
-                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
-                    System.out.println("device = " + device);
-                },
-                () -> fail("신규 디바이스가 등록되어 있어야 한다.")
-        );
+        DeviceErrorException ex = assertThrows(DeviceErrorException.class, () -> userAccountUseCase.registerDevice(requestUser.getId(), request));
+        assertEquals("디바이스 토큰이 존재하지 않으면 Not Found를 반환한다.", DeviceErrorCode.NOT_FOUND_DEVICE, ex.getBaseErrorCode());
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -151,7 +151,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
         Device oldDevice = Device.of("originToken", "modelA", "Windows", requestUser);
         deviceService.createDevice(oldDevice);
         System.out.println("oldDevice = " + oldDevice);
-        DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelB", "MacOS");
+        DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelA", "MacOS");
 
         // when
         userAccountUseCase.registerDevice(requestUser.getId(), request);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -78,7 +78,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
     @DisplayName("[2] 기존에 등록된 디바이스 토큰이 있는 경우, 디바이스 토큰을 갱신한다.")
     void updateDeviceToken() {
         // given
-        Device oldDevice = new Device("originToken", "modelA", "Windows", requestUser);
+        Device oldDevice = Device.of("originToken", "modelA", "Windows", requestUser);
         deviceService.createDevice(oldDevice);
         System.out.println("oldDevice = " + oldDevice);
         DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelA", "Windows");
@@ -105,7 +105,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
     @DisplayName("[2-1] 사용자가 유효한 토큰을 가지고 있지만 모델명이나 OS가 다른 경우 DEVICE_NOT_MATCH 에러를 반환한다.")
     void notMatchDevice() {
         // given
-        Device oldDevice = new Device("originToken", "modelA", "Windows", requestUser);
+        Device oldDevice = Device.of("originToken", "modelA", "Windows", requestUser);
         deviceService.createDevice(oldDevice);
         System.out.println("oldDevice = " + oldDevice);
         DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelB", "MacOS");

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -1,0 +1,72 @@
+package kr.co.pennyway.api.apis.users.usecase;
+
+import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
+import kr.co.pennyway.domain.config.JpaConfig;
+import kr.co.pennyway.domain.domains.device.service.DeviceService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
+import kr.co.pennyway.domain.domains.user.type.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.util.AssertionErrors.*;
+
+@ExtendWith(MockitoExtension.class)
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create")
+@ContextConfiguration(classes = {JpaConfig.class, UserAccountUseCase.class, UserService.class, DeviceService.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private DeviceService deviceService;
+
+    @Autowired
+    private UserAccountUseCase userAccountUseCase;
+
+    private Long requestUserId;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder().role(Role.USER).profileVisibility(ProfileVisibility.PUBLIC).build();
+        requestUserId = userService.createUser(user).getId();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("[1] 기존에 등록된 디바이스 토큰이 없는 경우, 신규 디바이스를 등록한다.")
+    void registerNewDevice() {
+        // given
+        DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("newToken", "newToken", "modelA", "Windows");
+
+        // when
+        Long actualDeviceId = userAccountUseCase.registerDevice(requestUserId, request);
+
+        // then
+        deviceService.readDeviceByUserIdAndToken(requestUserId, request.newToken()).ifPresentOrElse(
+                device -> {
+                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", request.newToken(), device.getToken());
+                    assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
+                    assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
+                    assertEquals("디바이스 ID가 일치해야 한다.", actualDeviceId, device.getId());
+                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUserId));
+                },
+                () -> fail("신규 디바이스가 등록되어 있어야 한다.")
+        );
+    }
+
+
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.users.usecase;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.domain.config.JpaConfig;
+import kr.co.pennyway.domain.domains.device.domain.Device;
 import kr.co.pennyway.domain.domains.device.service.DeviceService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.service.UserService;
@@ -37,12 +38,12 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
     @Autowired
     private UserAccountUseCase userAccountUseCase;
 
-    private Long requestUserId;
+    private User requestUser;
 
     @BeforeEach
     void setUp() {
         User user = User.builder().role(Role.USER).profileVisibility(ProfileVisibility.PUBLIC).build();
-        requestUserId = userService.createUser(user).getId();
+        requestUser = userService.createUser(user);
     }
 
     @Test
@@ -53,16 +54,16 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
         DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("newToken", "newToken", "modelA", "Windows");
 
         // when
-        Long actualDeviceId = userAccountUseCase.registerDevice(requestUserId, request);
+        DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
 
         // then
-        deviceService.readDeviceByUserIdAndToken(requestUserId, request.newToken()).ifPresentOrElse(
+        deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
                 device -> {
-                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", request.newToken(), device.getToken());
+                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
                     assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
                     assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
-                    assertEquals("디바이스 ID가 일치해야 한다.", actualDeviceId, device.getId());
-                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUserId));
+                    assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
+                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
                 },
                 () -> fail("신규 디바이스가 등록되어 있어야 한다.")
         );
@@ -73,14 +74,24 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
     @DisplayName("[2] 기존에 등록된 디바이스 토큰이 있는 경우, 디바이스 토큰을 갱신한다.")
     void updateDeviceToken() {
         // given
-        DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("newToken", "newToken", "modelA", "Windows");
+        Device oldDevice = new Device("oldToken", "modelA", "Windows", requestUser);
+        deviceService.createDevice(oldDevice);
+        DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("originToken", "newToken", "modelA", "Windows");
 
         // when
-
+        DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
 
         // then
-
+        deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
+                device -> {
+                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
+                    assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
+                    assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
+                    assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
+                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
+                },
+                () -> fail("디바이스 토큰이 갱신되어 있어야 한다.")
+        );
     }
-
 
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/UserFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/UserFixture.java
@@ -1,0 +1,55 @@
+package kr.co.pennyway.api.config.fixture;
+
+import kr.co.pennyway.api.common.security.authentication.CustomGrantedAuthority;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
+import kr.co.pennyway.domain.domains.user.type.Role;
+
+import java.util.List;
+
+public enum UserFixture {
+    GENERAL_USER(1L, "jayang", "dkssudgktpdy1", "Yang", "abc@abc.com", Role.USER, ProfileVisibility.PUBLIC, false),
+    ;
+
+    private final Long id;
+    private final String username;
+    private final String password;
+    private final String name;
+    private final String phone;
+    private final Role role;
+    private final ProfileVisibility profileVisibility;
+    private final Boolean locked;
+
+    UserFixture(Long id, String username, String password, String name, String phone, Role role, ProfileVisibility profileVisibility, Boolean locked) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.role = role;
+        this.profileVisibility = profileVisibility;
+        this.locked = locked;
+    }
+
+    public static SecurityUserDetails createSecurityUser(Long userId) {
+        return SecurityUserDetails.builder()
+                .userId(userId)
+                .username(GENERAL_USER.username)
+                .authorities(List.of(new CustomGrantedAuthority(GENERAL_USER.role.getType())))
+                .accountNonLocked(false)
+                .build();
+    }
+
+    public User toUser() {
+        return User.builder()
+                .username(username)
+                .password(password)
+                .name(name)
+                .phone(phone)
+                .role(role)
+                .profileVisibility(profileVisibility)
+                .locked(locked)
+                .build();
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/supporter/WithCustomMockUserSecurityContextFactory.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/supporter/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,22 @@
+package kr.co.pennyway.api.config.supporter;
+
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.api.config.fixture.UserFixture;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithSecurityMockUser> {
+    @Override
+    public SecurityContext createSecurityContext(WithSecurityMockUser annotation) {
+        String userId = annotation.userId();
+
+        SecurityUserDetails user = UserFixture.createSecurityUser(Long.parseLong(userId));
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        return context;
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/supporter/WithSecurityMockUser.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/supporter/WithSecurityMockUser.java
@@ -1,0 +1,12 @@
+package kr.co.pennyway.api.config.supporter;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithSecurityMockUser {
+    String userId() default "1";
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
@@ -51,6 +51,11 @@ public class Device extends DateAuditable {
         this.token = token;
     }
 
+    public void updateDeviceInfo(String model, String os) {
+        this.model = model;
+        this.os = os;
+    }
+
     @Override
     public String toString() {
         return "Device{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
@@ -24,22 +24,15 @@ public class Device extends DateAuditable {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public Device(String token, String model, String os) {
+    public Device(String token, String model, String os, User user) {
         this.token = token;
         this.model = model;
         this.os = os;
+        this.user = user;
     }
 
-    public void updateUser(User user) {
-        if (this.user != null) {
-            this.user.getDevices().remove(this);
-        }
-
-        this.user = user;
-
-        if (user != null) {
-            user.getDevices().add(this);
-        }
+    public void updateToken(String token) {
+        this.token = token;
     }
 
     @Override

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
@@ -39,12 +39,16 @@ public class Device extends DateAuditable {
         return new Device(token, model, os, Boolean.TRUE, user);
     }
 
-    public void updateToken(String token) {
-        this.token = token;
-    }
-
     public Boolean isActivated() {
         return activated;
+    }
+
+    public void activate() {
+        this.activated = Boolean.TRUE;
+    }
+
+    public void updateToken(String token) {
+        this.token = token;
     }
 
     @Override

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
@@ -24,6 +24,24 @@ public class Device extends DateAuditable {
     @JoinColumn(name = "user_id")
     private User user;
 
+    public Device(String token, String model, String os) {
+        this.token = token;
+        this.model = model;
+        this.os = os;
+    }
+
+    public void updateUser(User user) {
+        if (this.user != null) {
+            this.user.getDevices().remove(this);
+        }
+
+        this.user = user;
+
+        if (user != null) {
+            user.getDevices().add(this);
+        }
+    }
+
     @Override
     public String toString() {
         return "Device{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
@@ -1,0 +1,35 @@
+package kr.co.pennyway.domain.domains.device.domain;
+
+import jakarta.persistence.*;
+import kr.co.pennyway.domain.common.model.DateAuditable;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "device")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Device extends DateAuditable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String token;
+    private String model;
+    private String os;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Override
+    public String toString() {
+        return "Device{" +
+                "id=" + id +
+                ", token='" + token + '\'' +
+                ", model='" + model + '\'' +
+                ", os='" + os + '}';
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
@@ -43,6 +43,10 @@ public class Device extends DateAuditable {
         this.token = token;
     }
 
+    public Boolean isActivated() {
+        return activated;
+    }
+
     @Override
     public String toString() {
         return "Device{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
@@ -27,7 +27,7 @@ public class Device extends DateAuditable {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public Device(String token, String model, String os, Boolean activated, User user) {
+    private Device(String token, String model, String os, Boolean activated, User user) {
         this.token = token;
         this.model = model;
         this.os = os;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
@@ -6,6 +6,7 @@ import kr.co.pennyway.domain.domains.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -19,16 +20,23 @@ public class Device extends DateAuditable {
     private String token;
     private String model;
     private String os;
+    @ColumnDefault("true")
+    private Boolean activated;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    public Device(String token, String model, String os, User user) {
+    public Device(String token, String model, String os, Boolean activated, User user) {
         this.token = token;
         this.model = model;
         this.os = os;
+        this.activated = activated;
         this.user = user;
+    }
+
+    public static Device of(String token, String model, String os, User user) {
+        return new Device(token, model, os, Boolean.TRUE, user);
     }
 
     public void updateToken(String token) {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/exception/DeviceErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/exception/DeviceErrorCode.java
@@ -1,0 +1,28 @@
+package kr.co.pennyway.domain.domains.device.exception;
+
+import kr.co.pennyway.common.exception.BaseErrorCode;
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.ReasonCode;
+import kr.co.pennyway.common.exception.StatusCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum DeviceErrorCode implements BaseErrorCode {
+    /* 400 BAD_REQUEST */
+    NOT_MATCH_DEVICE(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "토큰의 디바이스 정보와 일치하지 않습니다."),
+    ;
+
+    private final StatusCode statusCode;
+    private final ReasonCode reasonCode;
+    private final String message;
+
+    @Override
+    public CausedBy causedBy() {
+        return CausedBy.of(statusCode, reasonCode);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldError {
+        return message;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/exception/DeviceErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/exception/DeviceErrorCode.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 public enum DeviceErrorCode implements BaseErrorCode {
     /* 400 BAD_REQUEST */
     NOT_MATCH_DEVICE(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "토큰의 디바이스 정보와 일치하지 않습니다."),
-    ;
+
+    /* 404 NOT_FOUND */
+    NOT_FOUND_DEVICE(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "디바이스를 찾을 수 없습니다.");
 
     private final StatusCode statusCode;
     private final ReasonCode reasonCode;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/exception/DeviceErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/exception/DeviceErrorCode.java
@@ -8,9 +8,6 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum DeviceErrorCode implements BaseErrorCode {
-    /* 400 BAD_REQUEST */
-    NOT_MATCH_DEVICE(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "토큰의 디바이스 정보와 일치하지 않습니다."),
-
     /* 404 NOT_FOUND */
     NOT_FOUND_DEVICE(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "디바이스를 찾을 수 없습니다.");
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/exception/DeviceErrorException.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/exception/DeviceErrorException.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.domain.domains.device.exception;
+
+import kr.co.pennyway.common.exception.GlobalErrorException;
+
+public class DeviceErrorException extends GlobalErrorException {
+    private final DeviceErrorCode deviceErrorCode;
+
+    public DeviceErrorException(DeviceErrorCode deviceErrorCode) {
+        super(deviceErrorCode);
+        this.deviceErrorCode = deviceErrorCode;
+    }
+
+    public String getExplainError() {
+        return deviceErrorCode.getExplainError();
+    }
+
+    public String getErrorCode() {
+        return deviceErrorCode.name();
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceRepository.java
@@ -1,0 +1,7 @@
+package kr.co.pennyway.domain.domains.device.repository;
+
+import kr.co.pennyway.domain.domains.device.domain.Device;
+import org.springframework.data.repository.CrudRepository;
+
+public interface DeviceRepository extends CrudRepository<Device, Long> {
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceRepository.java
@@ -1,7 +1,7 @@
 package kr.co.pennyway.domain.domains.device.repository;
 
 import kr.co.pennyway.domain.domains.device.domain.Device;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.ListCrudRepository;
 
-public interface DeviceRepository extends CrudRepository<Device, Long> {
+public interface DeviceRepository extends ListCrudRepository<Device, Long> {
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceRepository.java
@@ -3,5 +3,8 @@ package kr.co.pennyway.domain.domains.device.repository;
 import kr.co.pennyway.domain.domains.device.domain.Device;
 import org.springframework.data.repository.ListCrudRepository;
 
+import java.util.List;
+
 public interface DeviceRepository extends ListCrudRepository<Device, Long> {
+    List<Device> findAllByUser_Id(Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceRepository.java
@@ -4,7 +4,10 @@ import kr.co.pennyway.domain.domains.device.domain.Device;
 import org.springframework.data.repository.ListCrudRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DeviceRepository extends ListCrudRepository<Device, Long> {
+    Optional<Device> findByUser_IdAndToken(Long userId, String token);
+
     List<Device> findAllByUser_Id(Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceService.java
@@ -1,0 +1,37 @@
+package kr.co.pennyway.domain.domains.device.service;
+
+import kr.co.pennyway.common.annotation.DomainService;
+import kr.co.pennyway.domain.domains.device.domain.Device;
+import kr.co.pennyway.domain.domains.device.repository.DeviceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@DomainService
+@RequiredArgsConstructor
+public class DeviceService {
+    private final DeviceRepository deviceRepository;
+
+    @Transactional
+    public void createDevice(Device device) {
+        deviceRepository.save(device);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Device> readDevicesByUserId(Long userId) {
+        return deviceRepository.findAllByUser_Id(userId);
+    }
+
+    @Transactional
+    public void deleteDevice(Long deviceId) {
+        deviceRepository.deleteById(deviceId);
+    }
+
+    @Transactional
+    public void deleteDevice(Device device) {
+        deviceRepository.delete(device);
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceService.java
@@ -16,8 +16,8 @@ public class DeviceService {
     private final DeviceRepository deviceRepository;
 
     @Transactional
-    public void createDevice(Device device) {
-        deviceRepository.save(device);
+    public Device createDevice(Device device) {
+        return deviceRepository.save(device);
     }
 
     @Transactional(readOnly = true)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceService.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @DomainService
@@ -18,6 +19,11 @@ public class DeviceService {
     @Transactional
     public Device createDevice(Device device) {
         return deviceRepository.save(device);
+    }
+
+    @Transactional
+    public Optional<Device> readDeviceByUserIdAndToken(Long userId, String token) {
+        return deviceRepository.findByUser_IdAndToken(userId, token);
     }
 
     @Transactional(readOnly = true)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import kr.co.pennyway.domain.common.converter.ProfileVisibilityConverter;
 import kr.co.pennyway.domain.common.converter.RoleConverter;
 import kr.co.pennyway.domain.common.model.DateAuditable;
+import kr.co.pennyway.domain.domains.device.domain.Device;
 import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
 import kr.co.pennyway.domain.domains.user.type.Role;
 import lombok.AccessLevel;
@@ -16,6 +17,8 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -48,6 +51,9 @@ public class User extends DateAuditable {
     private NotifySetting notifySetting;
     @ColumnDefault("NULL")
     private LocalDateTime deletedAt;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<Device> devices = new ArrayList<>();
 
     @Builder
     private User(String username, String name, String password, LocalDateTime passwordUpdatedAt, String profileImageUrl, String phone, Role role, ProfileVisibility profileVisibility, NotifySetting notifySetting, Boolean locked, LocalDateTime deletedAt) {


### PR DESCRIPTION
## 작업 이유
- 사용자의 Device 정보와 Device Token 저장 API 구현
- 사용자의 Device 정보를 제거 API 구현

<br/>

## 작업 사항
### 📝 Device 정보 등록 플로우
```json
{
    "originToken": "",
    "newToken": "",
    "model": "",
    "os": ""
}
```
1. Client에 캐싱된 token이 없는 경우
    - `originToken == newToken` 요청을 보낸다.
    - 서버는 요청자의 Device로 해당 device 정보를 갱신한다.
2. Client에 캐싱된 token이 존재하여 수정을 요청하는 경우
    - 서버는 `userId`에 매핑된 `originToken` 정보를 탐색한다. (없으면 NOT FOUND)
    - Device 정보를 찾았으나, 모델 정보가 다른 경우 업데이트
    - Device Token을 `newToken`으로 갱신
    - Device Token이 비활성화 상태라면 활성화 상태로 전환

<br/>

**❓ 예상 질문 답변 모음**  

1. Device Token이 `unique` 필드가 아닌 이유
     - 여러 사람이 하나의 기기로 로그인 했을 경우, 서로 다른 User에게 같은 device token 정보가 등록될 수 있기 때문입니다.
2. 기기 정보가 바뀌었을 때, `NOT_MATCH` 에러가 아니라 정보를 수정하는 이유
    - 모델명이 바뀔 일은 잘 모르겠지만, OS는 분명히 달라질 수 있기 때문입니다.
3. 토큰을 삭제하지 않고, 활성화/비활성화 컬럼을 추가한 이유
    - 현재 저희 정책은 Client 측에서도 토큰 유효성 검사를 수행하면서, 추후 Server에서도 토큰 관리를 위한 스케줄러를 구현하게 됩니다.
    - 만약 Client가 Device Token을 발급받아 서버에 저장한 후, 한 달 정도 앱을 실행하지 않은 경우 서버의 스케줄러가 해당 토큰을 비활성화 했을 확률이 높습니다.
    - 이 경우 Client는 수정 요청을 보냈으나, Server는 `originToken`을 식별하지 못 해 요청에 실패하게 됩니다.
    - 따라서 만료된 토큰은 비활성화 처리하여, Client의 수정 요청에 대응하도록 합니다.
4. 토큰 저장 요청(`originToken == newToken`, 예상 질문 4번) 시, 토큰 존재 여부를 먼저 검사하는 이유
    - Server에는 활성/비활성 토큰이 존재하지만, 사용자가 app의 데이터를 제거해버린 경우 발생합니다.
    - 사용자가 앱 데이터를 삭제하고 실행할 때마다 활성화 토큰이 계속해서 저장될 가능성이 있어, 이미 존재하는 경우 model, os 버전만 변경 사항을 반영합니다.

<br/>

### 🟢 테스트 케이스
**1️⃣ Controller Unit Test**

<div align="center">
  <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/ab8f7543-84de-412b-9503-a21a9d88c81a" width="700px"/>
</div>


<br/>

**2️⃣ Service Unit Test**

<div align="center">
  <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/cd31b542-33e1-49ca-b700-9dec23f8946a" width="700px"/>
</div>

<br/>

### 🤔 test에 `fixture`, `supporter`...양재서 너 이 자식, 또 PR 관심사 분리 실패냐?
> 📢 진정하고 제 이야기를 들어보십시오.

**🚨 문제 상황 발생**

<div align="center">
  <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/b9b0f14a-4146-495c-99c1-b97623d46f8b" width="700px"/>
</div>

- Controller Unit Test 시, `isAuthenticated()` 인가 조건에 의해 `@WithMockUser`를 사용했으나 에러 발생

<br/>

<div align="center">
  <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/11383ec8-b8fa-40eb-bc78-064e1cbce288" width="700px"/>
</div>

- `@AuthenticationPrincipal` 어노테이션이 `SecurityUserDetails`를 알지 못 하기 때문에 생기는 이슈

<br/>

**💡 해결 방법**
```java
@Retention(RetentionPolicy.RUNTIME)
@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
public @interface WithSecurityMockUser {
    String userId() default "1";
}
```
- `@WithMockUser` 대신, 제가 만든 커스텀 어노테이션 `@WithSecurityMockUser`를 사용하면 됩니다.
- `@WithMockUser`에 `userId`를 값을 지정하지 않으면, 언제나 userId는 `1`입니다.
- 통합 테스트 환경에선 애초에 MockUser를 사용할 이유가 없으므로, 인가 권한이 `isAuthenticate()`인 Controller Unit Test에만 사용하면 됩니다.
- [해당 블로그](https://thalals.tistory.com/448)에 잘 정리되어 있습니다.

<br/>

**🔪 Fixture는 뭔데?**
- 반쯤 재미삼아 사용해봤습니다...[이 블로그](https://tlatmsrud.tistory.com/85)를 참고하시면 돼요.
- 다만, 디렉토리 경로를 매우 무신경하게 정했기 때문에 재조정이 필요합니다. (애초에 테스트 Convention이 너무 없는 상태)
- 뭔가 편한데 생각보다 사용이 까다로워서, 일단 이번 테스트에만 적용해보고 반응을 보고 싶었습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
1. 비지니스 로직을 담당하는 `DeviceRegisterService`이 설계 원칙을 준수하고 있다고 보는지? (이름, 내부 메서드 등)
2. 시나리오에 문제점이 있거나, 잘못된 테스트 케이스가 있는지?
3. 발견한 이슈 `(2)`번 꼭 확인해주세요!!

<br/>

## 발견한 이슈
1. 현재 서버가 스케줄링을 통해 비활성화 한 토큰을 Client 측에서 제거해버린 경우에 대응하지 못 함. (쓰레기 데이터 누적)
   - 관리 정책을 수립하여 제거할 지, 로직을 수정할 지 모르겠음..
2. 현재 토큰이 바뀌지 않았음에도 Device 정보가 수정되면 `updated_at` 필드가 수정되는 현상이 발생합니다. 이로 인해 FCM 관리 정책이 무의미해질 수 있습니다.
   - 해당 시나리오는 사용자가 app 데이터를 제거하고 디바이스 업데이트 후, 앱을 다시 실행했을 때 발생 가능합니다. (Server에는 여전히 유효한 token이 존재하므로) 
   - Table을 분리할 지, 제 설계 상 문제가 있는지 고민해봐야 할 문제입니다.

