### PR TITLE
🐛 OAuth Provider 필드 Conveter 누락 수정

### DIFF
--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.domain.domains.oauth.domain;
 
 import jakarta.persistence.*;
+import kr.co.pennyway.domain.common.converter.ProviderConverter;
 import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import lombok.AccessLevel;
@@ -29,6 +30,7 @@ public class Oauth {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Convert(converter = ProviderConverter.class)
     private Provider provider;
     private String oauthId;
 


### PR DESCRIPTION
## 작업 이유
- Oauth Entity DB 조회 실패

<br/>

## 작업 사항
- Provider 타입에 `@Converter` 선언

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음

<br/>

## 발견한 이슈
- 없음

