### PR TITLE
✨ 사용자 본인 프로필 조회 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -55,4 +55,7 @@ public interface UserAccountApi {
                     """)
     }))
     ResponseEntity<?> deleteDevice(@RequestParam("token") @Validated @NotBlank String token, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "사용자 계정 조회", description = "사용자 본인의 계정 정보를 조회합니다.")
+    ResponseEntity<?> getMyAccount(@AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -5,11 +5,14 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -55,5 +58,6 @@ public interface UserAccountApi {
     ResponseEntity<?> deleteDevice(@RequestParam("token") @Validated @NotBlank String token, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "사용자 계정 조회", description = "사용자 본인의 계정 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "user", schema = @Schema(implementation = UserProfileDto.class))))
     ResponseEntity<?> getMyAccount(@AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "사용자 계정 관리 API", description = "사용자 본인의 계정 관리를 위한 Usecase를 제공합니다.")
-@SecurityRequirement(name = "access-token")
 public interface UserAccountApi {
     @Operation(summary = "디바이스 등록", description = "사용자의 디바이스 정보를 등록(originToken == newToken)하거나 갱신(originToken != newToken)합니다.")
     @ApiResponses({

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -33,4 +33,10 @@ public class UserAccountController implements UserAccountApi {
         userAccountUseCase.unregisterDevice(user.getUserId(), token);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
+
+    @GetMapping("")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getMyAccount(@AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(SuccessResponse.from("user", userAccountUseCase.getMyAccount(user.getUserId())));
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
@@ -1,5 +1,8 @@
 package kr.co.pennyway.api.apis.users.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
 import kr.co.pennyway.domain.domains.user.domain.User;
@@ -18,6 +21,8 @@ public record UserProfileDto(
         @Schema(description = "사용자 이름", example = "홍길동")
         String name,
         @Schema(description = "비밀번호 변경 일시", example = "2024-04-22 00:00:00")
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime passwordUpdatedAt,
         @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
         String profileImageUrl,
@@ -30,6 +35,8 @@ public record UserProfileDto(
         @Schema(description = "알림 설정 정보")
         NotifySetting notifySetting,
         @Schema(description = "계정 생성 일시", example = "2024-04-22 00:00:00")
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt
 ) {
     public static UserProfileDto from(User user) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
@@ -1,0 +1,49 @@
+package kr.co.pennyway.api.apis.users.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "사용자 프로필 정보")
+public record UserProfileDto(
+        @Schema(description = "사용자 ID", example = "1")
+        Long id,
+        @Schema(description = "사용자 아이디", example = "user1")
+        String username,
+        @Schema(description = "사용자 이름", example = "홍길동")
+        String name,
+        @Schema(description = "비밀번호 변경 일시", example = "2024-04-22 00:00:00")
+        LocalDateTime passwordUpdatedAt,
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImageUrl,
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        String phone,
+        @Schema(description = "프로필 공개 여부", example = "PUBLIC")
+        ProfileVisibility profileVisibility,
+        @Schema(description = "계정 잠금 여부", example = "false")
+        Boolean locked,
+        @Schema(description = "알림 설정 정보")
+        NotifySetting notifySetting,
+        @Schema(description = "계정 생성 일시", example = "2024-04-22 00:00:00")
+        LocalDateTime createdAt
+) {
+    public static UserProfileDto from(User user) {
+        return UserProfileDto.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .name(user.getName())
+                .passwordUpdatedAt(user.getPasswordUpdatedAt())
+                .profileImageUrl(user.getProfileImageUrl())
+                .phone(user.getPhone())
+                .profileVisibility(user.getProfileVisibility())
+                .locked(user.getLocked())
+                .notifySetting(user.getNotifySetting())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.users.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,6 +11,7 @@ import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Builder
 @Schema(description = "사용자 프로필 정보")
@@ -21,6 +23,7 @@ public record UserProfileDto(
         @Schema(description = "사용자 이름", example = "홍길동")
         String name,
         @Schema(description = "비밀번호 변경 일시", example = "2024-04-22 00:00:00")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime passwordUpdatedAt,
@@ -39,13 +42,25 @@ public record UserProfileDto(
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt
 ) {
+    public UserProfileDto {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(username);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(profileImageUrl);
+        Objects.requireNonNull(phone);
+        Objects.requireNonNull(profileVisibility);
+        Objects.requireNonNull(locked);
+        Objects.requireNonNull(notifySetting);
+        Objects.requireNonNull(createdAt);
+    }
+
     public static UserProfileDto from(User user) {
         return UserProfileDto.builder()
                 .id(user.getId())
                 .username(user.getUsername())
                 .name(user.getName())
                 .passwordUpdatedAt(user.getPasswordUpdatedAt())
-                .profileImageUrl(user.getProfileImageUrl())
+                .profileImageUrl(Objects.toString(user.getProfileImageUrl(), ""))
                 .phone(user.getPhone())
                 .profileVisibility(user.getProfileVisibility())
                 .locked(user.getLocked())

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
@@ -22,7 +22,9 @@ public record UserProfileDto(
         String username,
         @Schema(description = "사용자 이름", example = "홍길동")
         String name,
-        @Schema(description = "비밀번호 변경 일시", nullable = true, type = "string", example = "yyyy-MM-dd HH:mm:ss")
+        @Schema(description = "Oauth 계정 여부. 일반 회원가입 계정이 있으면 true, 없으면 false", example = "false")
+        boolean isOauthAccount,
+        @Schema(description = "비밀번호 변경 일시. isOauthAccount가 true면 존재하지 않는 필드", nullable = true, type = "string", example = "yyyy-MM-dd HH:mm:ss")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -65,6 +67,7 @@ public record UserProfileDto(
                 .profileVisibility(user.getProfileVisibility())
                 .locked(user.getLocked())
                 .notifySetting(user.getNotifySetting())
+                .isOauthAccount(user.getPassword() == null)
                 .createdAt(user.getCreatedAt())
                 .build();
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Builder
-@Schema(description = "사용자 프로필 정보")
+@Schema(title = "사용자 프로필 정보 응답")
 public record UserProfileDto(
         @Schema(description = "사용자 ID", example = "1")
         Long id,
@@ -22,7 +22,7 @@ public record UserProfileDto(
         String username,
         @Schema(description = "사용자 이름", example = "홍길동")
         String name,
-        @Schema(description = "비밀번호 변경 일시", example = "2024-04-22 00:00:00")
+        @Schema(description = "비밀번호 변경 일시", nullable = true, type = "string", example = "yyyy-MM-dd HH:mm:ss")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -37,7 +37,7 @@ public record UserProfileDto(
         Boolean locked,
         @Schema(description = "알림 설정 정보")
         NotifySetting notifySetting,
-        @Schema(description = "계정 생성 일시", example = "2024-04-22 00:00:00")
+        @Schema(description = "계정 생성 일시", type = "string", example = "yyyy-MM-dd HH:mm:ss")
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.users.usecase;
 
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
 import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.device.domain.Device;
@@ -46,5 +47,14 @@ public class UserAccountUseCase {
         );
 
         deviceService.deleteDevice(device);
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfileDto getMyAccount(Long userId) {
+        User user = userService.readUser(userId).orElseThrow(
+                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
+        );
+
+        return UserProfileDto.from(user);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/type/ProfileVisibility.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/type/ProfileVisibility.java
@@ -18,9 +18,13 @@ public enum ProfileVisibility implements LegacyCommonType {
         return code;
     }
 
-    @JsonValue
     public String getType() {
         return type;
+    }
+
+    @JsonValue
+    public String createJson() {
+        return name();
     }
 
     @Override


### PR DESCRIPTION
## 작업 이유
- 사용자는 본인의 프로필 정보를 조회할 수 있다.

<br/>

## 작업 사항
- 요청 `/v2/users/me`
    ```json
    {
      "user": {
        "id": 1,
        "username": "user1",
        "name": "홍길동",
        "isOauthAccount": false,
        "passwordUpdatedAt": "yyyy-MM-dd HH:mm:ss",
        "profileImageUrl": "https://example.com/profile.jpg",
        "phone": "010-1234-5678",
        "profileVisibility": "PUBLIC",
        "locked": false,
        "notifySetting": {
          "accountBookNotify": true,
          "feedNotify": true,
          "chatNotify": true
        },
        "createdAt": "yyyy-MM-dd HH:mm:ss"
      }
    }
   ```
- 현재 계정이 소셜 계정인지, 일반 회원가입이 된 유저인지 판단용으로 `isOauthAccount` 필드 제공
   - 이렇게 안 하면 소셜 계정은 `passwordUpdatedAt`을 null로 반환하거나, null일 땐 응답 필드에서 제외해야 하는데 프론트 측에서 예외 핸들링하기 귀찮아짐.
   - 소셜 계정인 경우 `isOauthAccount`가 `ture`고 `passwordUpdatedAt`은 응답 필드에서 제외
- 필드명 그대로 반환하는데, 수정할 필요가 있을까요??

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 간단한 기능이라 딱히 없음.

<br/>

## 발견한 이슈
- `@Schema`의 대상 필드 타입이 `LocalDateTime`인 경우 `example`의 값이 먹히지 않는 이슈 존재함.
   - `type = "string", example = "yyyy-MM-dd HH:mm:ss"`을 추가하면 원하는 형식으로 응답 포맷으로 보임.
- 테스트 케이스를 별도로 작성하지 않았는데, 작성할까요?

