### PR TITLE
✨ 로그인 상태 확인 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.auth.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,6 +19,30 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "[사용자 인증 관리 API]", description = "사용자의 인증과 관련된 UseCase(로그아웃, 소셜 계정 연동/해지 등)를 제공하는 API")
 public interface UserAuthApi {
+    @Operation(summary = "로그인 상태 확인", description = "사용자의 로그인 상태를 확인한다. 단, 유효하지 않은 토큰은 에러 응답이 발생한다.")
+    @Parameter(name = "Authorization", in = ParameterIn.HEADER, hidden = true)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Boolean.class), examples = {
+                    @ExampleObject(name = "인증된 사용자", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "isSignIn": true
+                                }
+                            }
+                            """),
+                    @ExampleObject(name = "인증되지 않은 사용자", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "isSignIn": false
+                                }
+                            }
+                            """, description = "Authorization 헤더가 없거나, Bearer Token이 없는 경우")
+            }))
+    })
+    ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization", required = false, defaultValue = "") String authHeader);
+
     @Operation(summary = "로그아웃", description = """
             사용자의 로그아웃을 수행한다. Access Token과 Refresh Token을 받아서 Access Token을 만료시키고, Refresh Token을 삭제한다. <br>
             Refresh Token이 없는 경우에는 Access Token만 만료시킨다. (만료된 refesh token이면 access token 만료만 수행) <br>

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -1,4 +1,4 @@
-package kr.co.pennyway.api.apis.users.api;
+package kr.co.pennyway.api.apis.auth.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,26 +22,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface UserAuthApi {
     @Operation(summary = "로그인 상태 확인", description = "사용자의 로그인 상태를 확인한다. 단, 유효하지 않은 토큰은 에러 응답이 발생한다.")
     @Parameter(name = "Authorization", in = ParameterIn.HEADER, hidden = true)
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Boolean.class), examples = {
-                    @ExampleObject(name = "인증된 사용자", value = """
-                            {
-                                "code": "2000",
-                                "data": {
-                                    "isSignIn": true
-                                }
-                            }
-                            """),
-                    @ExampleObject(name = "인증되지 않은 사용자", value = """
-                            {
-                                "code": "2000",
-                                "data": {
-                                    "isSignIn": false
-                                }
-                            }
-                            """, description = "Authorization 헤더가 없거나, Bearer Token이 없는 경우")
-            }))
-    })
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuthStateDto.class)))
     ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization", required = false, defaultValue = "") String authHeader);
 
     @Operation(summary = "로그아웃", description = """

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -5,8 +5,6 @@ import kr.co.pennyway.api.apis.auth.usecase.UserAuthUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import kr.co.pennyway.api.common.util.CookieUtil;
-import kr.co.pennyway.infra.common.exception.JwtErrorCode;
-import kr.co.pennyway.infra.common.exception.JwtErrorException;
 import kr.co.pennyway.infra.common.jwt.AuthConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +27,7 @@ public class UserAuthController implements UserAuthApi {
     @PreAuthorize("permitAll()")
     public ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization", required = false, defaultValue = "") String authHeader) {
         if (authHeader.isBlank() || !authHeader.startsWith("Bearer ")) {
-            throw new JwtErrorException(JwtErrorCode.INVALID_HEADER);
+            return ResponseEntity.ok(SuccessResponse.from("isSignIn", false));
         }
         String accessToken = authHeader.substring(AuthConstants.TOKEN_TYPE.getValue().length());
         log.debug("accessToken: {}", accessToken);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -21,7 +21,6 @@ public class UserAuthController implements UserAuthApi {
     private final UserAuthUseCase userAuthUseCase;
     private final CookieUtil cookieUtil;
 
-    // TODO: Security Filter PermitAll url 추가
     @GetMapping("/auth")
     @PreAuthorize("permitAll()")
     public ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization", required = false, defaultValue = "") String authHeader) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -22,7 +22,7 @@ public class UserAuthController implements UserAuthApi {
     private final CookieUtil cookieUtil;
 
     @GetMapping("/auth")
-    @PreAuthorize("permitAll()")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization", required = false, defaultValue = "") String authHeader) {
         return ResponseEntity.ok(SuccessResponse.from("isSignIn", userAuthUseCase.isSignIn(authHeader)));
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -23,8 +23,8 @@ public class UserAuthController implements UserAuthApi {
 
     @GetMapping("/auth")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization", required = false, defaultValue = "") String authHeader) {
-        return ResponseEntity.ok(SuccessResponse.from("isSignIn", userAuthUseCase.isSignIn(authHeader)));
+    public ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization") String authHeader) {
+        return ResponseEntity.ok(SuccessResponse.from("user", userAuthUseCase.isSignIn(authHeader)));
     }
 
     @GetMapping("/sign-out")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -1,7 +1,7 @@
-package kr.co.pennyway.api.apis.users.controller;
+package kr.co.pennyway.api.apis.auth.controller;
 
-import kr.co.pennyway.api.apis.users.api.UserAuthApi;
-import kr.co.pennyway.api.apis.users.usecase.UserAuthUseCase;
+import kr.co.pennyway.api.apis.auth.api.UserAuthApi;
+import kr.co.pennyway.api.apis.auth.usecase.UserAuthUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import kr.co.pennyway.api.common.util.CookieUtil;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/users")
+@RequestMapping("/v1")
 public class UserAuthController implements UserAuthApi {
     private final UserAuthUseCase userAuthUseCase;
     private final CookieUtil cookieUtil;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -32,7 +32,7 @@ public class UserAuthController implements UserAuthApi {
         String accessToken = authHeader.substring(AuthConstants.TOKEN_TYPE.getValue().length());
         log.debug("accessToken: {}", accessToken);
 
-        return ResponseEntity.ok(SuccessResponse.from("isSignIn", userAuthUseCase.isSignedIn(accessToken)));
+        return ResponseEntity.ok(SuccessResponse.from("isSignIn", userAuthUseCase.isSignIn(accessToken)));
     }
 
     @GetMapping("/sign-out")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -5,6 +5,9 @@ import kr.co.pennyway.api.apis.auth.usecase.UserAuthUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import kr.co.pennyway.api.common.util.CookieUtil;
+import kr.co.pennyway.infra.common.exception.JwtErrorCode;
+import kr.co.pennyway.infra.common.exception.JwtErrorException;
+import kr.co.pennyway.infra.common.jwt.AuthConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -24,8 +27,14 @@ public class UserAuthController implements UserAuthApi {
     // TODO: Security Filter PermitAll url 추가
     @GetMapping("/auth")
     @PreAuthorize("permitAll()")
-    public ResponseEntity<?> getAuthState() {
-        return ResponseEntity.ok(SuccessResponse.from("user", userAuthUseCase.isSignedIn()));
+    public ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization", required = false, defaultValue = "") String authHeader) {
+        if (authHeader.isBlank() || !authHeader.startsWith("Bearer ")) {
+            throw new JwtErrorException(JwtErrorCode.INVALID_HEADER);
+        }
+        String accessToken = authHeader.substring(AuthConstants.TOKEN_TYPE.getValue().length());
+        log.debug("accessToken: {}", accessToken);
+
+        return ResponseEntity.ok(SuccessResponse.from("isSignIn", userAuthUseCase.isSignedIn(accessToken)));
     }
 
     @GetMapping("/sign-out")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -5,7 +5,6 @@ import kr.co.pennyway.api.apis.auth.usecase.UserAuthUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import kr.co.pennyway.api.common.util.CookieUtil;
-import kr.co.pennyway.infra.common.jwt.AuthConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -26,13 +25,7 @@ public class UserAuthController implements UserAuthApi {
     @GetMapping("/auth")
     @PreAuthorize("permitAll()")
     public ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization", required = false, defaultValue = "") String authHeader) {
-        if (authHeader.isBlank() || !authHeader.startsWith("Bearer ")) {
-            return ResponseEntity.ok(SuccessResponse.from("isSignIn", false));
-        }
-        String accessToken = authHeader.substring(AuthConstants.TOKEN_TYPE.getValue().length());
-        log.debug("accessToken: {}", accessToken);
-
-        return ResponseEntity.ok(SuccessResponse.from("isSignIn", userAuthUseCase.isSignIn(accessToken)));
+        return ResponseEntity.ok(SuccessResponse.from("isSignIn", userAuthUseCase.isSignIn(authHeader)));
     }
 
     @GetMapping("/sign-out")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/AuthStateDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/AuthStateDto.java
@@ -1,0 +1,21 @@
+package kr.co.pennyway.api.apis.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AuthStateDto(
+        @Schema(description = "로그인 여부", example = "true")
+        boolean isSignIn,
+        @Schema(description = "사용자 pk", example = "1")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Long userId
+) {
+    public static AuthStateDto of(boolean isSignIn) {
+        return new AuthStateDto(isSignIn, null);
+    }
+
+    public static AuthStateDto of(boolean isSignIn, Long userId) {
+        assert userId != null;
+        return new AuthStateDto(isSignIn, userId);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/AuthStateDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/AuthStateDto.java
@@ -1,21 +1,18 @@
 package kr.co.pennyway.api.apis.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Objects;
+
 public record AuthStateDto(
-        @Schema(description = "로그인 여부", example = "true")
-        boolean isSignIn,
         @Schema(description = "사용자 pk. isSignIn이 false인 경우에는 존재하지 않는 속성", example = "1")
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        Long userId
+        Long id
 ) {
-    public static AuthStateDto of(boolean isSignIn) {
-        return new AuthStateDto(isSignIn, null);
+    public AuthStateDto {
+        Objects.requireNonNull(id);
     }
 
-    public static AuthStateDto of(boolean isSignIn, Long userId) {
-        assert userId != null;
-        return new AuthStateDto(isSignIn, userId);
+    public static AuthStateDto of(Long userId) {
+        return new AuthStateDto(userId);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/AuthStateDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/AuthStateDto.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 
 public record AuthStateDto(
-        @Schema(description = "사용자 pk. isSignIn이 false인 경우에는 존재하지 않는 속성", example = "1")
+        @Schema(description = "로그인한 사용자의 pk", example = "1")
         Long id
 ) {
     public AuthStateDto {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/AuthStateDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/AuthStateDto.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record AuthStateDto(
         @Schema(description = "로그인 여부", example = "true")
         boolean isSignIn,
-        @Schema(description = "사용자 pk", example = "1")
+        @Schema(description = "사용자 pk. isSignIn이 false인 경우에는 존재하지 않는 속성", example = "1")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         Long userId
 ) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.api.apis.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
@@ -24,5 +25,23 @@ public class SignInReq {
             @NotBlank(message = "OIDC 토큰은 필수 입력값입니다.")
             String idToken
     ) {
+    }
+
+    @Schema(title = "로그인 상태 확인")
+    public record State(
+            @Schema(description = "로그인 여부", example = "true")
+            boolean isSignIn,
+            @Schema(description = "사용자 pk", example = "1")
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Long userId
+    ) {
+        public static State of(boolean isSignIn) {
+            return new State(isSignIn, null);
+        }
+
+        public static State of(boolean isSignIn, Long userId) {
+            assert userId != null;
+            return new State(isSignIn, userId);
+        }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
@@ -1,6 +1,5 @@
 package kr.co.pennyway.api.apis.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
@@ -25,23 +24,5 @@ public class SignInReq {
             @NotBlank(message = "OIDC 토큰은 필수 입력값입니다.")
             String idToken
     ) {
-    }
-
-    @Schema(title = "로그인 상태 확인")
-    public record State(
-            @Schema(description = "로그인 여부", example = "true")
-            boolean isSignIn,
-            @Schema(description = "사용자 pk", example = "1")
-            @JsonInclude(JsonInclude.Include.NON_NULL)
-            Long userId
-    ) {
-        public static State of(boolean isSignIn) {
-            return new State(isSignIn, null);
-        }
-
-        public static State of(boolean isSignIn, Long userId) {
-            assert userId != null;
-            return new State(isSignIn, userId);
-        }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
@@ -42,6 +42,11 @@ public class JwtAuthHelper {
         this.forbiddenTokenService = forbiddenTokenService;
     }
 
+    /**
+     * JwtClaims에서 key에 해당하는 값을 반환하는 메서드
+     *
+     * @return key에 해당하는 값이 없거나, 타입이 일치하지 않을 경우 null을 반환한다.
+     */
     @SuppressWarnings("unchecked")
     public <T> T getClaimValue(JwtClaims claims, String key, Class<T> type) {
         Object value = claims.getClaims().get(key);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
@@ -120,7 +120,7 @@ public class JwtAuthHelper {
 
     private void deleteRefreshToken(Long userId, JwtClaims jwtClaims, String refreshToken) {
         Long refreshTokenUserId = Long.parseLong((String) jwtClaims.getClaims().get(RefreshTokenClaimKeys.USER_ID.getValue()));
-        log.info("로그아웃 요청 refresh token userId : {}", refreshTokenUserId);
+        log.info("로그아웃 요청 refresh token id : {}", refreshTokenUserId);
 
         if (!userId.equals(refreshTokenUserId)) {
             throw new JwtErrorException(JwtErrorCode.WITHOUT_OWNERSHIP_REFRESH_TOKEN);
@@ -129,7 +129,7 @@ public class JwtAuthHelper {
         try {
             refreshTokenService.delete(refreshTokenUserId, refreshToken);
         } catch (IllegalArgumentException e) {
-            log.warn("refresh token not found. userId : {}", userId);
+            log.warn("refresh token not found. id : {}", userId);
         }
     }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
@@ -42,6 +42,15 @@ public class JwtAuthHelper {
         this.forbiddenTokenService = forbiddenTokenService;
     }
 
+    @SuppressWarnings("unchecked")
+    public <T> T getClaimValue(JwtClaims claims, String key, Class<T> type) {
+        Object value = claims.getClaims().get(key);
+        if (value != null && type.isAssignableFrom(value.getClass())) {
+            return (T) value;
+        }
+        return null;
+    }
+
     /**
      * 사용자 정보 기반으로 access token과 refresh token을 생성하는 메서드 <br/>
      * refresh token은 redis에 저장된다.

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.function.Function;
 
 @Slf4j
 @Helper
@@ -52,6 +53,20 @@ public class JwtAuthHelper {
         Object value = claims.getClaims().get(key);
         if (value != null && type.isAssignableFrom(value.getClass())) {
             return (T) value;
+        }
+        return null;
+    }
+
+    /**
+     * JwtClaims에서 valueConverter를 이용하여 key에 해당하는 값을 반환하는 메서드
+     *
+     * @param valueConverter : String 타입의 값을 T 타입으로 변환하는 함수
+     * @return key에 해당하는 값이 없을 경우 null을 반환한다.
+     */
+    public <T> T getClaimsValue(JwtClaims claims, String key, Function<String, T> valueConverter) {
+        Object value = claims.getClaims().get(key);
+        if (value != null) {
+            return valueConverter.apply((String) value);
         }
         return null;
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -15,7 +15,13 @@ public class UserAuthUseCase {
     private final JwtAuthHelper jwtAuthHelper;
     private final JwtProvider accessTokenProvider;
 
-    public boolean isSignIn(String accessToken) {
+    public boolean isSignIn(String authHeader) {
+        String accessToken = accessTokenProvider.resolveToken(authHeader);
+        log.debug("accessToken: {}", accessToken);
+
+        if (accessToken.isBlank())
+            return false;
+
         if (accessTokenProvider.isTokenExpired(accessToken))
             throw new JwtErrorException(JwtErrorCode.EXPIRED_TOKEN);
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -18,17 +18,13 @@ public class UserAuthUseCase {
 
     public AuthStateDto isSignIn(String authHeader) {
         String accessToken = accessTokenProvider.resolveToken(authHeader);
-        log.debug("accessToken: {}", accessToken);
-
-        if (accessToken.isBlank())
-            return AuthStateDto.of(false);
 
         JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
         Long userId = jwtAuthHelper.getClaimValue(claims, AccessTokenClaimKeys.USER_ID.getValue(), Long.class);
 
         log.debug("auth_id: {}", claims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue()));
 
-        return AuthStateDto.of(true, userId);
+        return AuthStateDto.of(userId);
     }
 
     public void signOut(Long userId, String authHeader, String refreshToken) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -1,9 +1,9 @@
 package kr.co.pennyway.api.apis.auth.usecase;
 
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
+import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.common.annotation.UseCase;
-import kr.co.pennyway.infra.common.exception.JwtErrorCode;
-import kr.co.pennyway.infra.common.exception.JwtErrorException;
+import kr.co.pennyway.infra.common.jwt.JwtClaims;
 import kr.co.pennyway.infra.common.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,8 +22,8 @@ public class UserAuthUseCase {
         if (accessToken.isBlank())
             return false;
 
-        if (accessTokenProvider.isTokenExpired(accessToken))
-            throw new JwtErrorException(JwtErrorCode.EXPIRED_TOKEN);
+        JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
+        log.debug("auth_id: {}", claims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue()));
 
         return true;
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -2,6 +2,8 @@ package kr.co.pennyway.api.apis.auth.usecase;
 
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
 import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.infra.common.exception.JwtErrorCode;
+import kr.co.pennyway.infra.common.exception.JwtErrorException;
 import kr.co.pennyway.infra.common.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +16,10 @@ public class UserAuthUseCase {
     private final JwtProvider accessTokenProvider;
 
     public boolean isSignedIn(String accessToken) {
+        if (accessTokenProvider.isTokenExpired(accessToken))
+            throw new JwtErrorException(JwtErrorCode.EXPIRED_TOKEN);
 
+        return true;
     }
 
     public void signOut(Long userId, String authHeader, String refreshToken) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -1,4 +1,4 @@
-package kr.co.pennyway.api.apis.users.usecase;
+package kr.co.pennyway.api.apis.auth.usecase;
 
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
 import kr.co.pennyway.common.annotation.UseCase;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -22,8 +22,7 @@ public class UserAuthUseCase {
         JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
         Long userId = jwtAuthHelper.getClaimValue(claims, AccessTokenClaimKeys.USER_ID.getValue(), Long.class);
 
-        log.debug("auth_id: {}", claims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue()));
-        log.info("auth_id: {}", userId);
+        log.info("auth_id {} 사용자는 로그인 중입니다.", userId);
 
         return AuthStateDto.of(userId);
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.auth.usecase;
 
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
 import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -10,6 +11,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UserAuthUseCase {
     private final JwtAuthHelper jwtAuthHelper;
+    private final JwtProvider accessTokenProvider;
+
+    public boolean isSignedIn(String accessToken) {
+
+    }
 
     public void signOut(Long userId, String authHeader, String refreshToken) {
         jwtAuthHelper.removeAccessTokenAndRefreshToken(userId, authHeader, refreshToken);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -18,9 +18,8 @@ public class UserAuthUseCase {
 
     public AuthStateDto isSignIn(String authHeader) {
         String accessToken = accessTokenProvider.resolveToken(authHeader);
-
         JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
-        Long userId = jwtAuthHelper.getClaimValue(claims, AccessTokenClaimKeys.USER_ID.getValue(), Long.class);
+        Long userId = jwtAuthHelper.getClaimsValue(claims, AccessTokenClaimKeys.USER_ID.getValue(), Long::parseLong);
 
         log.info("auth_id {} 사용자는 로그인 중입니다.", userId);
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -23,6 +23,7 @@ public class UserAuthUseCase {
         Long userId = jwtAuthHelper.getClaimValue(claims, AccessTokenClaimKeys.USER_ID.getValue(), Long.class);
 
         log.debug("auth_id: {}", claims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue()));
+        log.info("auth_id: {}", userId);
 
         return AuthStateDto.of(userId);
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -15,7 +15,7 @@ public class UserAuthUseCase {
     private final JwtAuthHelper jwtAuthHelper;
     private final JwtProvider accessTokenProvider;
 
-    public boolean isSignedIn(String accessToken) {
+    public boolean isSignIn(String accessToken) {
         if (accessTokenProvider.isTokenExpired(accessToken))
             throw new JwtErrorException(JwtErrorCode.EXPIRED_TOKEN);
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.api.apis.auth.usecase;
 
+import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.common.annotation.UseCase;
@@ -15,17 +16,19 @@ public class UserAuthUseCase {
     private final JwtAuthHelper jwtAuthHelper;
     private final JwtProvider accessTokenProvider;
 
-    public boolean isSignIn(String authHeader) {
+    public AuthStateDto isSignIn(String authHeader) {
         String accessToken = accessTokenProvider.resolveToken(authHeader);
         log.debug("accessToken: {}", accessToken);
 
         if (accessToken.isBlank())
-            return false;
+            return AuthStateDto.of(false);
 
         JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
+        Long userId = jwtAuthHelper.getClaimValue(claims, AccessTokenClaimKeys.USER_ID.getValue(), Long.class);
+
         log.debug("auth_id: {}", claims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue()));
 
-        return true;
+        return AuthStateDto.of(true, userId);
     }
 
     public void signOut(Long userId, String authHeader, String refreshToken) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAuthController.java
@@ -21,6 +21,13 @@ public class UserAuthController implements UserAuthApi {
     private final UserAuthUseCase userAuthUseCase;
     private final CookieUtil cookieUtil;
 
+    // TODO: Security Filter PermitAll url 추가
+    @GetMapping("/auth")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<?> getAuthState() {
+        return ResponseEntity.ok(SuccessResponse.from("user", userAuthUseCase.isSignedIn()));
+    }
+
     @GetMapping("/sign-out")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> signOut(

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/SecurityUserDetails.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/SecurityUserDetails.java
@@ -88,7 +88,7 @@ public final class SecurityUserDetails implements UserDetails {
     @Override
     public String toString() {
         return "SecurityUserDetails{" +
-                "userId=" + userId +
+                "id=" + userId +
                 ", username='" + username + '\'' +
                 ", authorities=" + authorities +
                 ", accountNonLocked=" + accountNonLocked +

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * {@code
  *  @GetMapping("/user")
  *  public ResponseEntity<User> getUser(@AuthenticationPrincipal SecurityUser user) {
- *      Long userId = user.getId();
+ *      Long id = user.getId();
  *      ...
  *  }
  * }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/access/AccessTokenClaimKeys.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/access/AccessTokenClaimKeys.java
@@ -1,7 +1,7 @@
 package kr.co.pennyway.api.common.security.jwt.access;
 
 public enum AccessTokenClaimKeys {
-    USER_ID("userId"),
+    USER_ID("id"),
     ROLE("role");
 
     private final String value;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/refresh/RefreshTokenClaimKeys.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/refresh/RefreshTokenClaimKeys.java
@@ -1,7 +1,7 @@
 package kr.co.pennyway.api.common.security.jwt.refresh;
 
 public enum RefreshTokenClaimKeys {
-    USER_ID("userId"),
+    USER_ID("id"),
     ROLE("role");
 
     private final String value;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -27,7 +27,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {"/favicon.ico", "/v1/duplicate/**"};
-    private static final String[] PUBLIC_ENDPOINTS = {"/v1/questions/**"};
+    private static final String[] PUBLIC_ENDPOINTS = {"/v1/questions/**", "/v1/auth"};
     private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**", "/v1/phone/**"};
     private static final String[] SWAGGER_ENDPOINTS = {"/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",};
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -27,7 +27,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {"/favicon.ico", "/v1/duplicate/**"};
-    private static final String[] PUBLIC_ENDPOINTS = {"/v1/questions/**", "/v1/auth"};
+    private static final String[] PUBLIC_ENDPOINTS = {"/v1/questions/**"};
     private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**", "/v1/phone/**"};
     private static final String[] SWAGGER_ENDPOINTS = {"/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",};
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -21,17 +21,13 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.web.cors.CorsConfigurationSource;
 
+import static kr.co.pennyway.api.config.security.WebSecurityUrls.*;
+
 @Configuration
 @EnableWebSecurity
 @ConditionalOnDefaultWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {"/favicon.ico", "/v1/duplicate/**"};
-    private static final String[] PUBLIC_ENDPOINTS = {"/v1/questions/**"};
-    private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**", "/v1/phone/**"};
-    private static final String[] SWAGGER_ENDPOINTS = {"/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",};
-
-
     private final SecurityAdapterConfig securityAdapterConfig;
     private final CorsConfigurationSource corsConfigurationSource;
     private final AccessDeniedHandler accessDeniedHandler;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -78,6 +78,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.OPTIONS, "*").permitAll()
                 .requestMatchers(HttpMethod.GET, READ_ONLY_PUBLIC_ENDPOINTS).permitAll()
                 .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+                .requestMatchers(AUTHENTICATED_ENDPOINTS).authenticated() // FIXME: 2024-04-23 /v1/auth가 anonymous로 설정되어 있어서 authenticated로 덮어씀.
                 .requestMatchers(ANONYMOUS_ENDPOINTS).anonymous();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/WebSecurityUrls.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/WebSecurityUrls.java
@@ -4,5 +4,6 @@ public class WebSecurityUrls {
     protected static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {"/favicon.ico", "/v1/duplicate/**"};
     protected static final String[] PUBLIC_ENDPOINTS = {"/v1/questions/**"};
     protected static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**", "/v1/phone/**"};
+    protected static final String[] AUTHENTICATED_ENDPOINTS = {"/v1/auth"};
     protected static final String[] SWAGGER_ENDPOINTS = {"/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",};
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/WebSecurityUrls.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/WebSecurityUrls.java
@@ -1,0 +1,8 @@
+package kr.co.pennyway.api.config.security;
+
+public class WebSecurityUrls {
+    protected static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {"/favicon.ico", "/v1/duplicate/**"};
+    protected static final String[] PUBLIC_ENDPOINTS = {"/v1/questions/**"};
+    protected static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**", "/v1/phone/**"};
+    protected static final String[] SWAGGER_ENDPOINTS = {"/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",};
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-package kr.co.pennyway.api.apis.users.controller;
+package kr.co.pennyway.api.apis.auth.controller;
 
 import jakarta.servlet.http.Cookie;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
@@ -204,7 +204,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         private MockHttpServletRequestBuilder performSignOut() {
-            return get("/v1/users/sign-out")
+            return get("/v1/sign-out")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON);
         }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -3,7 +3,6 @@ package kr.co.pennyway.api.apis.auth.usecase;
 import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
-import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
 import kr.co.pennyway.infra.common.exception.JwtErrorCode;
 import kr.co.pennyway.infra.common.exception.JwtErrorException;
@@ -20,13 +19,15 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
 public class UserAuthUseCaseUnitTest {
     private final String secretStr = "helloMyNameIsPennywayThisIsSecretKeyItNeedsToBeLongerThan256Bits";
+    private final JwtClaims jwtClaims = AccessTokenClaim.of(1L, "ROLE_USER");
     private JwtProvider accessTokenProvider;
-    private JwtClaims jwtClaims;
     private UserAuthUseCase userAuthUseCase;
     @Mock
     private JwtAuthHelper jwtAuthHelper;
@@ -34,7 +35,6 @@ public class UserAuthUseCaseUnitTest {
     @BeforeEach
     public void setUp() {
         accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMinutes(5));
-        jwtClaims = AccessTokenClaim.of(1L, "ROLE_USER");
         userAuthUseCase = new UserAuthUseCase(jwtAuthHelper, accessTokenProvider);
     }
 
@@ -79,12 +79,13 @@ public class UserAuthUseCaseUnitTest {
     public void isSignedInWithValidToken() {
         // given
         String token = accessTokenProvider.generateToken(jwtClaims);
+        given(jwtAuthHelper.getClaimValue(any(), any(), any())).willReturn(1L);
 
         // when
         AuthStateDto result = userAuthUseCase.isSignIn("Bearer " + token);
 
         // then
         assertTrue(result.isSignIn());
-        assertEquals(jwtClaims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue()), result.userId());
+        assertEquals(1L, result.userId());
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -46,7 +46,7 @@ public class UserAuthUseCaseUnitTest {
 
         // then
         assertFalse(result.isSignIn());
-        assertNull(result.userId());
+        assertNull(result.id());
     }
 
     @Test
@@ -86,6 +86,6 @@ public class UserAuthUseCaseUnitTest {
 
         // then
         assertTrue(result.isSignIn());
-        assertEquals(1L, result.userId());
+        assertEquals(1L, result.id());
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -40,7 +40,7 @@ public class UserAuthUseCaseUnitTest {
     @DisplayName("[1] Authorication 헤더가 없으면 false를 반환한다.")
     public void isSignedInWithoutAuthorizationHeader() {
         // when
-        boolean result = userAuthUseCase.isSignedIn(null);
+        boolean result = userAuthUseCase.isSignedIn("");
 
         // then
         assertFalse(result);
@@ -50,7 +50,7 @@ public class UserAuthUseCaseUnitTest {
     @DisplayName("[2] 유효한 토큰이 아니면 false를 반환한다.")
     public void isSignedInWithInvalidToken() {
         // when
-        boolean result = userAuthUseCase.isSignedIn("Bearer invalidToken");
+        boolean result = userAuthUseCase.isSignedIn("invalidToken");
 
         // then
         assertFalse(result);
@@ -65,7 +65,7 @@ public class UserAuthUseCaseUnitTest {
         String expiredToken = accessTokenProvider.generateToken(jwtClaims);
 
         // when
-        JwtErrorException exception = assertThrows(JwtErrorException.class, () -> userAuthUseCase.isSignedIn("Bearer " + expiredToken));
+        JwtErrorException exception = assertThrows(JwtErrorException.class, () -> userAuthUseCase.isSignedIn(expiredToken));
         assertEquals(JwtErrorCode.EXPIRED_TOKEN, exception.getErrorCode());
     }
 
@@ -76,7 +76,7 @@ public class UserAuthUseCaseUnitTest {
         String token = accessTokenProvider.generateToken(jwtClaims);
 
         // when
-        boolean result = userAuthUseCase.isSignedIn("Bearer " + token);
+        boolean result = userAuthUseCase.isSignedIn(token);
 
         // then
         assertFalse(result);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -4,6 +4,8 @@ import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
+import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
+import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenService;
 import kr.co.pennyway.infra.common.exception.JwtErrorCode;
 import kr.co.pennyway.infra.common.exception.JwtErrorException;
 import kr.co.pennyway.infra.common.jwt.JwtClaims;
@@ -20,8 +22,6 @@ import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
@@ -30,14 +30,20 @@ public class UserAuthUseCaseUnitTest {
     private final JwtClaims jwtClaims = AccessTokenClaim.of(1L, "ROLE_USER");
     private JwtProvider accessTokenProvider;
     private UserAuthUseCase userAuthUseCase;
-    @Mock
     private JwtAuthHelper jwtAuthHelper;
+
+    @Mock
+    private JwtProvider refreshTokenProvider;
+    @Mock
+    private RefreshTokenService refreshTokenService;
+    @Mock
+    private ForbiddenTokenService forbiddenTokenService;
 
     @BeforeEach
     public void setUp() {
         accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMinutes(5));
+        jwtAuthHelper = new JwtAuthHelper(accessTokenProvider, refreshTokenProvider, refreshTokenService, forbiddenTokenService);
         userAuthUseCase = new UserAuthUseCase(jwtAuthHelper, accessTokenProvider);
-
     }
 
     @Test
@@ -60,7 +66,6 @@ public class UserAuthUseCaseUnitTest {
     public void isSignedInWithValidToken() {
         // given
         String token = accessTokenProvider.generateToken(jwtClaims);
-        given(jwtAuthHelper.getClaimValue(any(), any(), any())).willReturn(1L);
 
         // when
         AuthStateDto result = userAuthUseCase.isSignIn("Bearer " + token);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -1,7 +1,9 @@
 package kr.co.pennyway.api.apis.auth.usecase;
 
+import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
+import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
 import kr.co.pennyway.infra.common.exception.JwtErrorCode;
 import kr.co.pennyway.infra.common.exception.JwtErrorException;
@@ -40,10 +42,11 @@ public class UserAuthUseCaseUnitTest {
     @DisplayName("[1] Authorication 헤더가 없으면 false를 반환한다.")
     public void isSignedInWithoutAuthorizationHeader() {
         // when
-        boolean result = userAuthUseCase.isSignIn("");
+        AuthStateDto result = userAuthUseCase.isSignIn("");
 
         // then
-        assertFalse(result);
+        assertFalse(result.isSignIn());
+        assertNull(result.userId());
     }
 
     @Test
@@ -78,9 +81,10 @@ public class UserAuthUseCaseUnitTest {
         String token = accessTokenProvider.generateToken(jwtClaims);
 
         // when
-        boolean result = userAuthUseCase.isSignIn("Bearer " + token);
+        AuthStateDto result = userAuthUseCase.isSignIn("Bearer " + token);
 
         // then
-        assertTrue(result);
+        assertTrue(result.isSignIn());
+        assertEquals(jwtClaims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue()), result.userId());
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -1,17 +1,32 @@
 package kr.co.pennyway.api.apis.auth.usecase;
 
+import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
+import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
+import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
+import kr.co.pennyway.infra.common.jwt.JwtClaims;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
 public class UserAuthUseCaseUnitTest {
+    private final String secretStr = "helloMyNameIsPennywayThisIsSecretKeyItNeedsToBeLongerThan256Bits";
+    private JwtProvider accessTokenProvider;
+    private JwtClaims jwtClaims;
     private UserAuthUseCase userAuthUseCase;
+    @Mock
+    private JwtAuthHelper jwtAuthHelper;
 
     @BeforeEach
     public void setUp() {
-        userAuthUseCase = new UserAuthUseCase();
+        accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMinutes(5));
+        jwtClaims = AccessTokenClaim.of(1L, "ROLE_USER");
+        userAuthUseCase = new UserAuthUseCase(jwtAuthHelper, accessTokenProvider);
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -40,7 +40,7 @@ public class UserAuthUseCaseUnitTest {
     @DisplayName("[1] Authorication 헤더가 없으면 false를 반환한다.")
     public void isSignedInWithoutAuthorizationHeader() {
         // when
-        boolean result = userAuthUseCase.isSignedIn("");
+        boolean result = userAuthUseCase.isSignIn("");
 
         // then
         assertFalse(result);
@@ -50,7 +50,7 @@ public class UserAuthUseCaseUnitTest {
     @DisplayName("[2] 유효한 토큰이 아니면 false를 반환한다.")
     public void isSignedInWithInvalidToken() {
         // when
-        boolean result = userAuthUseCase.isSignedIn("invalidToken");
+        boolean result = userAuthUseCase.isSignIn("invalidToken");
 
         // then
         assertFalse(result);
@@ -65,7 +65,7 @@ public class UserAuthUseCaseUnitTest {
         String expiredToken = accessTokenProvider.generateToken(jwtClaims);
 
         // when
-        JwtErrorException exception = assertThrows(JwtErrorException.class, () -> userAuthUseCase.isSignedIn(expiredToken));
+        JwtErrorException exception = assertThrows(JwtErrorException.class, () -> userAuthUseCase.isSignIn(expiredToken));
         assertEquals(JwtErrorCode.EXPIRED_TOKEN, exception.getErrorCode());
     }
 
@@ -76,7 +76,7 @@ public class UserAuthUseCaseUnitTest {
         String token = accessTokenProvider.generateToken(jwtClaims);
 
         // when
-        boolean result = userAuthUseCase.isSignedIn(token);
+        boolean result = userAuthUseCase.isSignIn(token);
 
         // then
         assertFalse(result);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -47,25 +47,27 @@ public class UserAuthUseCaseUnitTest {
     }
 
     @Test
-    @DisplayName("[2] 유효한 토큰이 아니면 false를 반환한다.")
+    @DisplayName("[2] 유효한 토큰이 아니면 예외를 반환한다.")
     public void isSignedInWithInvalidToken() {
         // when
-        boolean result = userAuthUseCase.isSignIn("Bearer invalidToken");
+        JwtErrorException exception = assertThrows(JwtErrorException.class, () -> userAuthUseCase.isSignIn("Bearer invalidToken"));
 
         // then
-        assertFalse(result);
+        System.out.println(exception.getErrorCode());
     }
 
     @Test
     @DisplayName("[2-1] 유효하지 않으면서 만료된 토큰인 경우 ExpiredToken 예외를 던진다.")
     public void isSignedInWithExpiredToken() {
         // given
-        accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofSeconds(1));
+        accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMillis(0));
         userAuthUseCase = new UserAuthUseCase(jwtAuthHelper, accessTokenProvider);
         String expiredToken = accessTokenProvider.generateToken(jwtClaims);
 
         // when
         JwtErrorException exception = assertThrows(JwtErrorException.class, () -> userAuthUseCase.isSignIn("Bearer " + expiredToken));
+
+        // then
         assertEquals(JwtErrorCode.EXPIRED_TOKEN, exception.getErrorCode());
     }
 
@@ -79,6 +81,6 @@ public class UserAuthUseCaseUnitTest {
         boolean result = userAuthUseCase.isSignIn("Bearer " + token);
 
         // then
-        assertFalse(result);
+        assertTrue(result);
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -1,0 +1,17 @@
+package kr.co.pennyway.api.apis.auth.usecase;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+public class UserAuthUseCaseUnitTest {
+    private UserAuthUseCase userAuthUseCase;
+
+    @BeforeEach
+    public void setUp() {
+        userAuthUseCase = new UserAuthUseCase();
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -3,15 +3,21 @@ package kr.co.pennyway.api.apis.auth.usecase;
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
+import kr.co.pennyway.infra.common.exception.JwtErrorCode;
+import kr.co.pennyway.infra.common.exception.JwtErrorException;
 import kr.co.pennyway.infra.common.jwt.JwtClaims;
 import kr.co.pennyway.infra.common.jwt.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
@@ -28,5 +34,51 @@ public class UserAuthUseCaseUnitTest {
         accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMinutes(5));
         jwtClaims = AccessTokenClaim.of(1L, "ROLE_USER");
         userAuthUseCase = new UserAuthUseCase(jwtAuthHelper, accessTokenProvider);
+    }
+
+    @Test
+    @DisplayName("[1] Authorication 헤더가 없으면 false를 반환한다.")
+    public void isSignedInWithoutAuthorizationHeader() {
+        // when
+        boolean result = userAuthUseCase.isSignedIn(null);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("[2] 유효한 토큰이 아니면 false를 반환한다.")
+    public void isSignedInWithInvalidToken() {
+        // when
+        boolean result = userAuthUseCase.isSignedIn("Bearer invalidToken");
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("[2-1] 유효하지 않으면서 만료된 토큰인 경우 ExpiredToken 예외를 던진다.")
+    public void isSignedInWithExpiredToken() {
+        // given
+        accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofSeconds(1));
+        userAuthUseCase = new UserAuthUseCase(jwtAuthHelper, accessTokenProvider);
+        String expiredToken = accessTokenProvider.generateToken(jwtClaims);
+
+        // when
+        JwtErrorException exception = assertThrows(JwtErrorException.class, () -> userAuthUseCase.isSignedIn("Bearer " + expiredToken));
+        assertEquals(JwtErrorCode.EXPIRED_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("[3] 유효한 토큰이면 true를 반환한다.")
+    public void isSignedInWithValidToken() {
+        // given
+        String token = accessTokenProvider.generateToken(jwtClaims);
+
+        // when
+        boolean result = userAuthUseCase.isSignedIn("Bearer " + token);
+
+        // then
+        assertFalse(result);
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -4,6 +4,8 @@ import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
+import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
+import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenService;
 import kr.co.pennyway.infra.common.exception.JwtErrorCode;
 import kr.co.pennyway.infra.common.exception.JwtErrorException;
 import kr.co.pennyway.infra.common.jwt.JwtClaims;
@@ -19,8 +21,6 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
@@ -29,23 +29,29 @@ public class UserAuthUseCaseUnitTest {
     private final JwtClaims jwtClaims = AccessTokenClaim.of(1L, "ROLE_USER");
     private JwtProvider accessTokenProvider;
     private UserAuthUseCase userAuthUseCase;
-    @Mock
     private JwtAuthHelper jwtAuthHelper;
+
+    @Mock
+    private JwtProvider refreshTokenProvider;
+    @Mock
+    private RefreshTokenService refreshTokenService;
+    @Mock
+    private ForbiddenTokenService forbiddenTokenService;
 
     @BeforeEach
     public void setUp() {
         accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMinutes(5));
+        jwtAuthHelper = new JwtAuthHelper(accessTokenProvider, refreshTokenProvider, refreshTokenService, forbiddenTokenService);
         userAuthUseCase = new UserAuthUseCase(jwtAuthHelper, accessTokenProvider);
     }
 
     @Test
-    @DisplayName("[1] Authorication 헤더가 없으면 false를 반환한다.")
+    @DisplayName("[1] Authorication 헤더가 없으면 401 에러를 반환한다.")
     public void isSignedInWithoutAuthorizationHeader() {
         // when
         AuthStateDto result = userAuthUseCase.isSignIn("");
 
         // then
-        assertFalse(result.isSignIn());
         assertNull(result.id());
     }
 
@@ -75,17 +81,15 @@ public class UserAuthUseCaseUnitTest {
     }
 
     @Test
-    @DisplayName("[3] 유효한 토큰이면 true를 반환한다.")
+    @DisplayName("[3] 유효한 토큰이면 토큰의 사용자 아이디를 반환한다.")
     public void isSignedInWithValidToken() {
         // given
         String token = accessTokenProvider.generateToken(jwtClaims);
-        given(jwtAuthHelper.getClaimValue(any(), any(), any())).willReturn(1L);
 
         // when
         AuthStateDto result = userAuthUseCase.isSignIn("Bearer " + token);
 
         // then
-        assertTrue(result.isSignIn());
         assertEquals(1L, result.id());
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -20,7 +20,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Duration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
@@ -46,27 +47,7 @@ public class UserAuthUseCaseUnitTest {
     }
 
     @Test
-    @DisplayName("[1] Authorication 헤더가 없으면 401 에러를 반환한다.")
-    public void isSignedInWithoutAuthorizationHeader() {
-        // when
-        AuthStateDto result = userAuthUseCase.isSignIn("");
-
-        // then
-        assertNull(result.id());
-    }
-
-    @Test
-    @DisplayName("[2] 유효한 토큰이 아니면 예외를 반환한다.")
-    public void isSignedInWithInvalidToken() {
-        // when
-        JwtErrorException exception = assertThrows(JwtErrorException.class, () -> userAuthUseCase.isSignIn("Bearer invalidToken"));
-
-        // then
-        System.out.println(exception.getErrorCode());
-    }
-
-    @Test
-    @DisplayName("[2-1] 유효하지 않으면서 만료된 토큰인 경우 ExpiredToken 예외를 던진다.")
+    @DisplayName("[1] 만료된 토큰인 경우 ExpiredToken 예외를 던진다.")
     public void isSignedInWithExpiredToken() {
         // given
         accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMillis(0));
@@ -81,7 +62,7 @@ public class UserAuthUseCaseUnitTest {
     }
 
     @Test
-    @DisplayName("[3] 유효한 토큰이면 토큰의 사용자 아이디를 반환한다.")
+    @DisplayName("[2] 유효한 토큰이면 토큰의 사용자 아이디를 반환한다.")
     public void isSignedInWithValidToken() {
         // given
         String token = accessTokenProvider.generateToken(jwtClaims);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -50,7 +50,7 @@ public class UserAuthUseCaseUnitTest {
     @DisplayName("[2] 유효한 토큰이 아니면 false를 반환한다.")
     public void isSignedInWithInvalidToken() {
         // when
-        boolean result = userAuthUseCase.isSignIn("invalidToken");
+        boolean result = userAuthUseCase.isSignIn("Bearer invalidToken");
 
         // then
         assertFalse(result);
@@ -65,7 +65,7 @@ public class UserAuthUseCaseUnitTest {
         String expiredToken = accessTokenProvider.generateToken(jwtClaims);
 
         // when
-        JwtErrorException exception = assertThrows(JwtErrorException.class, () -> userAuthUseCase.isSignIn(expiredToken));
+        JwtErrorException exception = assertThrows(JwtErrorException.class, () -> userAuthUseCase.isSignIn("Bearer " + expiredToken));
         assertEquals(JwtErrorCode.EXPIRED_TOKEN, exception.getErrorCode());
     }
 
@@ -76,7 +76,7 @@ public class UserAuthUseCaseUnitTest {
         String token = accessTokenProvider.generateToken(jwtClaims);
 
         // when
-        boolean result = userAuthUseCase.isSignIn(token);
+        boolean result = userAuthUseCase.isSignIn("Bearer " + token);
 
         // then
         assertFalse(result);


### PR DESCRIPTION
## 작업 이유
- FE 팀 Page deletegate를 위한 토큰 만료 검증 API
- 필요성
   - 사용자가 `API 호출이 필요없는 화면`(ex. 설정창)으로 이동하는 경우
   - Client는 API를 호출하지 않으므로 사용자가 설정창으로 이동해도 되는지(로그인 여부)를 알 수 없습니다.
   - 따라서 `token`의 유효성 여부만을 확인하여, 사용자 로그인 상태를 응답으로 반환하는 API 제공
- 실제로 Naver나 여러 사이트에서 사용합니다.

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/8f4312da-b717-4263-9bd2-3fa908a40f33" width="500px"/>
</div>


<br/>

## 작업 사항
### 1️⃣ Scenario
1. `Authorization` 헤더가 없거나, `Bearer {Token}` 타입의 문자열이 아닌 경우
    ```json
    {
         "code": "2000",
         "data": {
              "isSignIn": false
         }
    }
    ```
    - 로그인하지 않은 사용자라고 판단하고 `false` 응답 반환
2. 유효한 토큰을 제공한 경우
    ```json
    {
         "code": "2000",
         "data": {
              "isSignIn": true,
              "userId": 1 // token에서 추출한 userId
         }
    }
    ```
    - 로그인한 사용자라고 판단하고 `true` 응답 반환
3. `Authorization` 헤더에 `Bearer {Token}` 형식으로 요청을 보냈으나 유효하지 않은 경우
    - JwtErrorCode에 정의한 예외가 발생합니다.
    - 명백히 인증 시도를 수행한 것으로 판단했기 때문에 `true`가 아닌 예외를 던져, Client가 핸들링하도록 처리했습니다.

<br/>

### 2️⃣ jwtAuthHeader의 *getClaimValue*()
```java
JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
Long userId = Long.parseLong((String) claims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue()));
```
- JwtClaims의 value 타입을 비한정적 와일드 카드를 사용하는 바람에 파싱을 위해 굉장히 번잡스러운 로직이 필요했습니다.
- 그렇다고 `JwtClaims`의 값 타입을 비한정적 와일드 카드로 수정하고 뭔갈 하기에도 너무 어려운 상황. (설계부터 막힘..)
- 그래서 편의용 메서드를 추가했습니다.

<br/>

```java
JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
Long userId = jwtAuthHelper.getClaimValue(claims, AccessTokenClaimKeys.USER_ID.getValue(), Long.class);
```
- 기존에 `MapUtil`에서 사용했던 방식을 `JwtClaims` 타입에 한정시켜 적용했습니다.
- Test case에선 *given*() 절로 받아오기 때문에 정상 동작을 의심해볼 수 있으나, Swagger로 테스트 해본 결과 정상적으로 값을 반환합니다.

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/d42b104f-4758-476a-8bf9-0a10513f6e4c" width="500px"/>
</div>

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- `Authorization` 헤더가 존재하지만 `Bearer {Token}` 형태가 아니면 `false` 응답을 반환하는데, 이 경우에도 예외를 처리하는 게 맞을지?

<br/>

## 발견한 이슈
### 1️⃣ *given*()과 *any*()
- 에러 로그
   ```
   Strict stubbing argument mismatch. Please check:
    - this invocation of 'getClaimValue' method:
       jwtAuthHelper.getClaimValue(
       kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim@574b7f4a,
       "userId",
       class java.lang.Long
   );
       -> at kr.co.pennyway.api.apis.auth.usecase.UserAuthUseCase.isSignIn(UserAuthUseCase.java:27)
    - has following stubbing(s) with different arguments:
       1. jwtAuthHelper.getClaimValue(
       kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim@3fae596,
       "userId",
       class java.lang.Long
   );
         -> at kr.co.pennyway.api.apis.auth.usecase.UserAuthUseCaseUnitTest.isSignedInWithValidToken(UserAuthUseCaseUnitTest.java:83)
   Typically, stubbing argument mismatch indicates user mistake when writing tests.
   ```
   - Mocking 하던 시점과 when 절에서 사용하던 객체가 다르기 때문에 발생([라고 백기선님이..](https://www.inflearn.com/questions/441973/mock%EC%97%90-stubbing-%EC%A4%91-%EB%B0%9C%EC%83%9D%ED%95%98%EB%8A%94-%EC%97%90%EB%9F%AC))
- 해결 방법
   ```java
   given(jwtAuthHelper.getClaimValue(any(), any(), any())).willReturn(1L);
   ```
   - 사용자 정의 객체는 `import static org.mockito.ArgumentMatchers.any;`로 넣어주면 된다.
   - 근데 지금까진 왜 에러가 안 났던 거지...?
- [참고 블로그](https://velog.io/@topqr123q/BDDMockito.given-%EC%9D%80-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%82%AC%EC%9A%A9%ED%95%B4%EC%95%BC-%ED%95%98%EB%82%98%EC%9A%94-Strict-stubbing-argument-mismatch)

