### PR TITLE
✏️ 인증번호 전송 API 통합에 따른 Deprecated API 삭제

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
@@ -19,24 +19,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "[인증 API]")
 public interface AuthApi {
-    @Deprecated
-    @Operation(summary = "[1] 일반 회원가입 인증번호 전송", description = "deprecated된 API입니다. [인증코드 SMS 요청]의 /v1/phone API를 사용해주세요.", deprecated = true)
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
-            @ExampleObject(name = "발신 성공", value = """
-                    {
-                        "code": "2000",
-                        "data": {
-                            "sms": {
-                                "to": "010-1234-5678",
-                                "sendAt": "2024-04-04 00:31:57",
-                                "expiresAt": "2024-04-04 00:36:57"
-                            }
-                        }
-                    }
-                    """)
-    }))
-    ResponseEntity<?> sendCode(@RequestBody @Validated PhoneVerificationDto.PushCodeReq request);
-
     @Operation(summary = "[2] 일반 회원가입 인증번호 검증", description = "인증번호를 검증합니다. 미인증 사용자만 가능합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
@@ -59,27 +59,6 @@ public interface OauthApi {
     })
     ResponseEntity<?> signIn(@RequestParam Provider provider, @RequestBody @Validated SignInReq.Oauth request);
 
-    @Deprecated
-    @Operation(summary = "[2] 인증번호 발송", description = "deprecated된 API입니다. [인증코드 SMS 요청]의 /v1/phone API를 사용해주세요.", deprecated = true)
-    @Parameter(name = "provider", description = "소셜 제공자", examples = {
-            @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
-    }, required = true, in = ParameterIn.QUERY)
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
-            @ExampleObject(name = "발신 성공", value = """
-                    {
-                        "code": "2000",
-                        "data": {
-                            "sms": {
-                                "to": "010-1234-5678",
-                                "sendAt": "2024-04-04 00:31:57",
-                                "expiresAt": "2024-04-04 00:36:57"
-                            }
-                        }
-                    }
-                    """)
-    }))
-    ResponseEntity<?> sendCode(@RequestParam Provider provider, @RequestBody @Validated PhoneVerificationDto.PushCodeReq request);
-
     @Operation(summary = "[3] 전화번호 인증", description = "전화번호 인증 후 이미 계정이 존재하면 연동, 없으면 회원가입")
     @Parameter(name = "provider", description = "소셜 제공자", examples = {
             @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,9 +21,9 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "[사용자 인증 관리 API]", description = "사용자의 인증과 관련된 UseCase(로그아웃, 소셜 계정 연동/해지 등)를 제공하는 API")
 public interface UserAuthApi {
-    @Operation(summary = "로그인 상태 확인", description = "사용자의 로그인 상태를 확인한다. 단, 유효하지 않은 토큰은 에러 응답이 발생한다.")
+    @Operation(summary = "로그인 상태 확인", description = "사용자의 로그인 상태를 확인하고 토큰에 등록된 사용자 pk값을 확인한다. 만약, 토큰이 만료되었거나 유효하지 않은 경우에는 401 에러를 반환한다.")
     @Parameter(name = "Authorization", in = ParameterIn.HEADER, hidden = true)
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuthStateDto.class)))
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schemaProperties = @SchemaProperty(name = "user", schema = @Schema(implementation = AuthStateDto.class))))
     ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization", required = false, defaultValue = "") String authHeader);
 
     @Operation(summary = "로그아웃", description = """

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
@@ -30,12 +30,6 @@ public class AuthController implements AuthApi {
     private final AuthUseCase authUseCase;
     private final CookieUtil cookieUtil;
 
-    @PostMapping("/phone")
-    @PreAuthorize("isAnonymous()")
-    public ResponseEntity<?> sendCode(@RequestBody @Validated PhoneVerificationDto.PushCodeReq request) {
-        return ResponseEntity.ok(SuccessResponse.from("sms", authUseCase.sendCode(request)));
-    }
-
     @PostMapping("/phone/verification")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> verifyCode(@RequestBody @Validated PhoneVerificationDto.VerifyCodeReq request) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/OauthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/OauthController.java
@@ -43,13 +43,6 @@ public class OauthController implements OauthApi {
     }
 
     @Override
-    @PostMapping("/phone")
-    @PreAuthorize("isAnonymous()")
-    public ResponseEntity<?> sendCode(@RequestParam Provider provider, @RequestBody @Validated PhoneVerificationDto.PushCodeReq request) {
-        return ResponseEntity.ok(SuccessResponse.from("sms", oauthUseCase.sendCode(provider, request)));
-    }
-
-    @Override
     @PostMapping("/phone/verification")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> verifyCode(@RequestParam Provider provider, @RequestBody @Validated PhoneVerificationDto.VerifyCodeReq request) {


### PR DESCRIPTION
## 작업 이유
- iOS팀에서 변경된 API 반영됨을 확인하여 Depreacted API 제거

<br/>

## 작업 사항
- AuthController와 OauthController의 *sendCode*() 메서드 제거
- 이전 PR에서 반영했어야 했는데 커밋 놓친 로그인 확인 API 스웨거 문서 수정 첨가..ㅎ

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음

<br/>

## 발견한 이슈
- 없음

