### PR TITLE
✨ OIDC 정책에서 id token에 nonce 필드 추가

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
@@ -19,24 +19,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "[인증 API]")
 public interface AuthApi {
-    @Deprecated
-    @Operation(summary = "[1] 일반 회원가입 인증번호 전송", description = "deprecated된 API입니다. [인증코드 SMS 요청]의 /v1/phone API를 사용해주세요.", deprecated = true)
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
-            @ExampleObject(name = "발신 성공", value = """
-                    {
-                        "code": "2000",
-                        "data": {
-                            "sms": {
-                                "to": "010-1234-5678",
-                                "sendAt": "2024-04-04 00:31:57",
-                                "expiresAt": "2024-04-04 00:36:57"
-                            }
-                        }
-                    }
-                    """)
-    }))
-    ResponseEntity<?> sendCode(@RequestBody @Validated PhoneVerificationDto.PushCodeReq request);
-
     @Operation(summary = "[2] 일반 회원가입 인증번호 검증", description = "인증번호를 검증합니다. 미인증 사용자만 가능합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
@@ -59,27 +59,6 @@ public interface OauthApi {
     })
     ResponseEntity<?> signIn(@RequestParam Provider provider, @RequestBody @Validated SignInReq.Oauth request);
 
-    @Deprecated
-    @Operation(summary = "[2] 인증번호 발송", description = "deprecated된 API입니다. [인증코드 SMS 요청]의 /v1/phone API를 사용해주세요.", deprecated = true)
-    @Parameter(name = "provider", description = "소셜 제공자", examples = {
-            @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
-    }, required = true, in = ParameterIn.QUERY)
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
-            @ExampleObject(name = "발신 성공", value = """
-                    {
-                        "code": "2000",
-                        "data": {
-                            "sms": {
-                                "to": "010-1234-5678",
-                                "sendAt": "2024-04-04 00:31:57",
-                                "expiresAt": "2024-04-04 00:36:57"
-                            }
-                        }
-                    }
-                    """)
-    }))
-    ResponseEntity<?> sendCode(@RequestParam Provider provider, @RequestBody @Validated PhoneVerificationDto.PushCodeReq request);
-
     @Operation(summary = "[3] 전화번호 인증", description = "전화번호 인증 후 이미 계정이 존재하면 연동, 없으면 회원가입")
     @Parameter(name = "provider", description = "소셜 제공자", examples = {
             @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,9 +21,9 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "[사용자 인증 관리 API]", description = "사용자의 인증과 관련된 UseCase(로그아웃, 소셜 계정 연동/해지 등)를 제공하는 API")
 public interface UserAuthApi {
-    @Operation(summary = "로그인 상태 확인", description = "사용자의 로그인 상태를 확인한다. 단, 유효하지 않은 토큰은 에러 응답이 발생한다.")
+    @Operation(summary = "로그인 상태 확인", description = "사용자의 로그인 상태를 확인하고 토큰에 등록된 사용자 pk값을 확인한다. 만약, 토큰이 만료되었거나 유효하지 않은 경우에는 401 에러를 반환한다.")
     @Parameter(name = "Authorization", in = ParameterIn.HEADER, hidden = true)
-    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuthStateDto.class)))
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schemaProperties = @SchemaProperty(name = "user", schema = @Schema(implementation = AuthStateDto.class))))
     ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization", required = false, defaultValue = "") String authHeader);
 
     @Operation(summary = "로그아웃", description = """

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthController.java
@@ -30,12 +30,6 @@ public class AuthController implements AuthApi {
     private final AuthUseCase authUseCase;
     private final CookieUtil cookieUtil;
 
-    @PostMapping("/phone")
-    @PreAuthorize("isAnonymous()")
-    public ResponseEntity<?> sendCode(@RequestBody @Validated PhoneVerificationDto.PushCodeReq request) {
-        return ResponseEntity.ok(SuccessResponse.from("sms", authUseCase.sendCode(request)));
-    }
-
     @PostMapping("/phone/verification")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> verifyCode(@RequestBody @Validated PhoneVerificationDto.VerifyCodeReq request) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/OauthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/OauthController.java
@@ -43,13 +43,6 @@ public class OauthController implements OauthApi {
     }
 
     @Override
-    @PostMapping("/phone")
-    @PreAuthorize("isAnonymous()")
-    public ResponseEntity<?> sendCode(@RequestParam Provider provider, @RequestBody @Validated PhoneVerificationDto.PushCodeReq request) {
-        return ResponseEntity.ok(SuccessResponse.from("sms", oauthUseCase.sendCode(provider, request)));
-    }
-
-    @Override
     @PostMapping("/phone/verification")
     @PreAuthorize("isAnonymous()")
     public ResponseEntity<?> verifyCode(@RequestParam Provider provider, @RequestBody @Validated PhoneVerificationDto.VerifyCodeReq request) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
@@ -22,7 +22,10 @@ public class SignInReq {
             String oauthId,
             @Schema(description = "OIDC 토큰")
             @NotBlank(message = "OIDC 토큰은 필수 입력값입니다.")
-            String idToken
+            String idToken,
+            @Schema(description = "OIDC nonce")
+            @NotBlank(message = "OIDC nonce는 필수 입력값입니다.")
+            String nonce
     ) {
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -105,6 +105,9 @@ public class SignUpReq {
             @Schema(description = "OIDC 토큰")
             @NotBlank(message = "OIDC 토큰은 필수 입력값입니다.")
             String idToken,
+            @Schema(description = "OIDC nonce")
+            @NotBlank(message = "OIDC nonce는 필수 입력값입니다.")
+            String nonce,
             @Schema(description = "이름", example = "페니웨이")
             @NotBlank(message = "이름을 입력해주세요")
             @Pattern(regexp = "^[가-힣a-z]{2,8}$", message = "2~8자의 한글, 영문 소문자만 사용 가능합니다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -40,7 +40,7 @@ public class SignUpReq {
         }
     }
 
-    public record OauthInfo(String idToken, String name, String username, String phone, String code) {
+    public record OauthInfo(String idToken, String nonce, String name, String username, String phone, String code) {
         public User toUser() {
             return User.builder()
                     .username(username)
@@ -126,7 +126,7 @@ public class SignUpReq {
             String code
     ) {
         public OauthInfo toOauthInfo() {
-            return new OauthInfo(idToken, name, username, phone, code);
+            return new OauthInfo(idToken, nonce, name, username, phone, code);
         }
     }
 
@@ -135,6 +135,9 @@ public class SignUpReq {
             @Schema(description = "OIDC 토큰")
             @NotBlank(message = "OIDC 토큰은 필수 입력값입니다.")
             String idToken,
+            @Schema(description = "OIDC nonce")
+            @NotBlank(message = "OIDC nonce는 필수 입력값입니다.")
+            String nonce,
             @Schema(description = "전화번호", example = "010-1234-5678")
             @NotBlank(message = "전화번호를 입력해주세요")
             @Pattern(regexp = "^01[01]-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
@@ -145,7 +148,7 @@ public class SignUpReq {
             String code
     ) {
         public OauthInfo toOauthInfo() {
-            return new OauthInfo(idToken, null, null, phone, code);
+            return new OauthInfo(idToken, nonce, null, null, phone, code);
         }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/OauthOidcHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/OauthOidcHelper.java
@@ -41,14 +41,15 @@ public class OauthOidcHelper {
      *
      * @param provider : {@link Provider}
      * @param idToken  : idToken
+     * @param nonce    : 인증 서버 로그인 요청 시 전달한 임의의 문자열
      * @return OIDCDecodePayload : ID Token의 payload
      */
-    public OidcDecodePayload getPayload(Provider provider, String idToken) {
+    public OidcDecodePayload getPayload(Provider provider, String idToken, String nonce) {
         OauthOidcClient client = oauthOidcClients.get(provider).keySet().iterator().next();
         OauthOidcClientProperties properties = oauthOidcClients.get(provider).values().iterator().next();
         OidcPublicKeyResponse response = client.getOidcPublicKey();
 
-        return getPayloadFromIdToken(idToken, properties.getIssuer(), properties.getSecret(), null, response);
+        return getPayloadFromIdToken(idToken, properties.getIssuer(), properties.getSecret(), nonce, response);
     }
 
     /**

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
@@ -33,7 +33,7 @@ public class OauthUseCase {
     private final UserOauthSignService userOauthSignService;
 
     public Pair<Long, Jwts> signIn(Provider provider, SignInReq.Oauth request) {
-        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken());
+        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken(), request.nonce());
         log.debug("payload : {}", payload);
 
         if (!request.oauthId().equals(payload.sub()))
@@ -69,7 +69,7 @@ public class OauthUseCase {
             throw new OauthException(OauthErrorCode.INVALID_OAUTH_SYNC_REQUEST);
         }
 
-        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken());
+        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken(), request.nonce());
         User user = userOauthSignService.saveUser(request, userSync, provider, payload.sub());
 
         return Pair.of(user.getId(), jwtAuthHelper.createToken(user));

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
@@ -57,9 +57,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = "oauth2.client.provider.kakao.jwks-uri=http://localhost:${wiremock.server.port}")
 public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
     private final String expectedUsername = "jayang";
-
     private final String expectedOauthId = "testOauthId";
     private final String expectedIdToken = "testIdToken";
+    private final String expectedNonce = "testNonce";
     private final String expectedPhone = "010-1234-5678";
     private final String expectedCode = "123456";
     @Autowired
@@ -140,12 +140,12 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Provider provider = Provider.KAKAO;
             User user = createOauthSignedUser();
 
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
             userService.createUser(user);
             oauthService.createOauth(createOauthAccount(user, provider));
 
             // when
-            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken);
+            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken, expectedNonce);
 
             // then
             result
@@ -165,12 +165,12 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Provider provider = Provider.KAKAO;
             User user = createOauthSignedUser();
 
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
             userService.createUser(user);
             oauthService.createOauth(createOauthAccount(user, Provider.GOOGLE));
 
             // when
-            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken);
+            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken, expectedNonce);
 
             // then
             result
@@ -188,11 +188,11 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Provider provider = Provider.KAKAO;
             User user = createGeneralSignedUser();
 
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
             userService.createUser(user);
 
             // when
-            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken);
+            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken, expectedNonce);
 
             // then
             result
@@ -209,10 +209,10 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             // given
             Provider provider = Provider.KAKAO;
 
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
-            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken);
+            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken, expectedNonce);
 
             // then
             result
@@ -230,12 +230,12 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Provider provider = Provider.KAKAO;
             User user = createOauthSignedUser();
 
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", "differentOauthId", "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", "differentOauthId", "email"));
             userService.createUser(user);
             oauthService.createOauth(createOauthAccount(user, provider));
 
             // when
-            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken);
+            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken, expectedNonce);
 
             // then
             result
@@ -245,8 +245,8 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andDo(print());
         }
 
-        private ResultActions performOauthSignIn(Provider provider, String oauthId, String idToken) throws Exception {
-            SignInReq.Oauth request = new SignInReq.Oauth(oauthId, idToken);
+        private ResultActions performOauthSignIn(Provider provider, String oauthId, String idToken, String nonce) throws Exception {
+            SignInReq.Oauth request = new SignInReq.Oauth(oauthId, idToken, expectedNonce);
 
             return mockMvc.perform(post("/v1/auth/oauth/sign-in")
                     .param("provider", provider.name())
@@ -422,7 +422,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
             userService.createUser(user);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode);
@@ -452,7 +452,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             userService.createUser(user);
             oauthService.createOauth(oauth);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode);
@@ -477,7 +477,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             // given
             Provider provider = Provider.KAKAO;
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode);
@@ -503,7 +503,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             userService.createUser(user);
             oauthService.createOauth(oauth);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode);
@@ -517,7 +517,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         private ResultActions performOauthSignUpAccountLinking(Provider provider, String code) throws Exception {
-            SignUpReq.SyncWithAuth request = new SignUpReq.SyncWithAuth(expectedIdToken, expectedPhone, code);
+            SignUpReq.SyncWithAuth request = new SignUpReq.SyncWithAuth(expectedIdToken, expectedNonce, expectedPhone, code);
             return mockMvc.perform(post("/v1/auth/oauth/link-auth")
                     .param("provider", provider.name())
                     .contentType("application/json")
@@ -537,7 +537,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             // given
             Provider provider = Provider.KAKAO;
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUp(provider, expectedCode);
@@ -565,7 +565,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
             userService.createUser(user);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUp(provider, expectedCode);
@@ -591,7 +591,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             userService.createUser(user);
             oauthService.createOauth(oauth);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUp(provider, expectedCode);
@@ -605,7 +605,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         private ResultActions performOauthSignUp(Provider provider, String code) throws Exception {
-            SignUpReq.Oauth request = new SignUpReq.Oauth(expectedIdToken, "jayang", expectedUsername, expectedPhone, code);
+            SignUpReq.Oauth request = new SignUpReq.Oauth(expectedIdToken, expectedNonce, "jayang", expectedUsername, expectedPhone, code);
             return mockMvc.perform(post("/v1/auth/oauth/sign-up")
                     .param("provider", provider.name())
                     .contentType("application/json")

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
@@ -52,6 +52,7 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
      * ID Token의 header와 body를 Base64 방식으로 디코딩하는 메서드 <br/>
      * payload의 iss, aud, exp, nonce를 검증하고, 실패시 예외 처리
      */
+    @SuppressWarnings("unchecked")
     private Map<String, Map<String, String>> getUnsignedTokenClaims(String token, String iss, String aud, String nonce) {
         try {
             Base64.Decoder decoder = Base64.getUrlDecoder();
@@ -60,13 +61,12 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
             String headerJson = new String(decoder.decode(unsignedToken.split("\\.")[0]));
             String payloadJson = new String(decoder.decode(unsignedToken.split("\\.")[1]));
 
-            @SuppressWarnings("unchecked")
             Map<String, String> header = objectMapper.readValue(headerJson, Map.class);
-            @SuppressWarnings("unchecked")
             Map<String, String> payload = objectMapper.readValue(payloadJson, Map.class);
 
             Assert.isTrue(payload.get("aud").equals(aud), "aud is not matched. expected : " + aud + ", actual : " + payload.get("aud"));
             Assert.isTrue(payload.get("iss").equals(iss), "iss is not matched. expected : " + iss + ", actual : " + payload.get("iss"));
+            Assert.isTrue(payload.get("nonce").equals(nonce), "nonce is not matched. expected : " + nonce + ", actual : " + payload.get("nonce"));
 
             return Map.of("header", header, "payload", payload);
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
## 작업 이유
> ⚠️ iOS팀하고 테스트 후 일반 PR로 전환할 예정
- id token 검증 시, `nonce` 필드 검증 추가

<br/>

## 작업 사항
### 💡왜 nonce가 필요한가?

- nonce는 [OIDC Connect 스펙](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps)에서 도입되었으며 토큰의 유효성 검증을 위한 매개변수입니다.
   1. IdToken을 생성할 때 `nonce` 값을 추가하도록 provider에 임의의 문자열을 함께 보내고, 서버에 `idToken`과 `nonce`를 함께 보냅니다.
   2. 서버는 `idToken`에 있는 `nonce`가 요청값과 동일한지 검증합니다.
- 즉, `nonce`를 추가함으로써 재생 공격을 어느정도 방지하는 데 사용가능합니다.

<br/>

### 🤔 왜 이제와서 적용했는가?

- 기존에는 Client 측에서 구글과 애플 측에 `nonce`를 전달하는 방법을 찾지 못 했기 때문입니다.
   - 그런데 얼마 전에 회의하다가 우연히 찾음 ㅋ
- Apple의 경우에 `sub`에 해당하는 값이 `secret_key`가 아닌, `identifier`에 해당합니다. (iOS 팀에서 정하는 프로젝트 식별값. 유추하기 매우 쉬움)
   - 즉, `sub`의 값을 유추하기가 너무 쉬워서 보안에 상당히 취약하다는 문제가 존재합니다.
   - OIDC 서명 검증에 필요한 정보는 모두 공개되어 있으므로, 마음만 먹으면 임의로 생성한 토큰을 서버로 보내 공격할 수 있습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 딱히 없긴 한데, `nonce`의 필요성에 대해 알고 가시면 좋을 것 같아요!

<br/>

## 발견한 이슈
- 없음
