### PR TITLE
✨ 사용자 아이디/이름 수정 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -64,4 +64,7 @@ public interface UserAccountApi {
 
     @Operation(summary = "사용자 이름 수정")
     ResponseEntity<?> putName(@RequestBody @Validated UserProfileUpdateDto.NameReq request, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "사용자 아이디 수정")
+    ResponseEntity<?> putUsername(@RequestBody @Validated UserProfileUpdateDto.UsernameReq request, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
+import kr.co.pennyway.api.apis.users.dto.UserProfileUpdateDto;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -60,4 +61,7 @@ public interface UserAccountApi {
     @Operation(summary = "사용자 계정 조회", description = "사용자 본인의 계정 정보를 조회합니다.")
     @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "user", schema = @Schema(implementation = UserProfileDto.class))))
     ResponseEntity<?> getMyAccount(@AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "사용자 이름 수정")
+    ResponseEntity<?> putName(@RequestBody @Validated UserProfileUpdateDto.NameReq request, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.users.controller;
 import jakarta.validation.constraints.NotBlank;
 import kr.co.pennyway.api.apis.users.api.UserAccountApi;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.api.apis.users.dto.UserProfileUpdateDto;
 import kr.co.pennyway.api.apis.users.usecase.UserAccountUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
@@ -21,12 +22,14 @@ import org.springframework.web.bind.annotation.*;
 public class UserAccountController implements UserAccountApi {
     private final UserAccountUseCase userAccountUseCase;
 
+    @Override
     @PutMapping("/devices")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> putDevice(@RequestBody @Validated DeviceDto.RegisterReq request, @AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from("device", userAccountUseCase.registerDevice(user.getUserId(), request)));
     }
 
+    @Override
     @DeleteMapping("/devices")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> deleteDevice(@RequestParam("token") @Validated @NotBlank String token, @AuthenticationPrincipal SecurityUserDetails user) {
@@ -34,9 +37,18 @@ public class UserAccountController implements UserAccountApi {
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 
+    @Override
     @GetMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getMyAccount(@AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from("user", userAccountUseCase.getMyAccount(user.getUserId())));
+    }
+
+    @Override
+    @PutMapping("/name")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> putName(UserProfileUpdateDto.NameReq request, SecurityUserDetails user) {
+        userAccountUseCase.updateName(user.getUserId(), request.name());
+        return ResponseEntity.ok(SuccessResponse.noContent());
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -45,7 +45,7 @@ public class UserAccountController implements UserAccountApi {
     }
 
     @Override
-    @PutMapping("/name")
+    @PatchMapping("/name")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> putName(UserProfileUpdateDto.NameReq request, SecurityUserDetails user) {
         userAccountUseCase.updateName(user.getUserId(), request.name());
@@ -53,7 +53,7 @@ public class UserAccountController implements UserAccountApi {
     }
 
     @Override
-    @PutMapping("/username")
+    @PatchMapping("/username")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> putUsername(UserProfileUpdateDto.UsernameReq request, SecurityUserDetails user) {
         userAccountUseCase.updateUsername(user.getUserId(), request.username());

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -51,4 +51,12 @@ public class UserAccountController implements UserAccountApi {
         userAccountUseCase.updateName(user.getUserId(), request.name());
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
+
+    @Override
+    @PutMapping("/username")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> putUsername(UserProfileUpdateDto.UsernameReq request, SecurityUserDetails user) {
+        userAccountUseCase.updateUsername(user.getUserId(), request.username());
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileUpdateDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileUpdateDto.java
@@ -1,0 +1,16 @@
+package kr.co.pennyway.api.apis.users.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public class UserProfileUpdateDto {
+    @Schema(title = "이름 변경 요청 DTO")
+    public record NameReq(
+            @Schema(description = "이름", example = "페니웨이")
+            @NotBlank(message = "이름을 입력해주세요")
+            @Pattern(regexp = "^[가-힣a-z]{2,8}$", message = "2~8자의 한글, 영문 소문자만 사용 가능합니다.")
+            String name
+    ) {
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileUpdateDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileUpdateDto.java
@@ -13,4 +13,13 @@ public class UserProfileUpdateDto {
             String name
     ) {
     }
+
+    @Schema(title = "아이디 변경 요청 DTO")
+    public record UsernameReq(
+            @Schema(description = "아이디", example = "pennyway")
+            @NotBlank(message = "아이디를 입력해주세요")
+            @Pattern(regexp = "^[a-z-_.]{5,20}$", message = "5~20자의 영문 소문자, -, _, . 만 사용 가능합니다.")
+            String username
+    ) {
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
@@ -17,4 +17,9 @@ public class UserProfileUpdateService {
     public void updateName(User user, String newName) {
         user.updateName(newName);
     }
+
+    @Transactional
+    public void updateUsername(User user, String newUsername) {
+        user.updateUsername(newUsername);
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
@@ -1,7 +1,6 @@
 package kr.co.pennyway.api.apis.users.service;
 
 import kr.co.pennyway.domain.domains.user.domain.User;
-import kr.co.pennyway.domain.domains.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -11,8 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UserProfileUpdateService {
-    private final UserService userService;
-
     @Transactional
     public void updateName(User user, String newName) {
         user.updateName(newName);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.api.apis.users.service;
+
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserProfileUpdateService {
+    private final UserService userService;
+
+    @Transactional
+    public void updateName(User user, String newName) {
+        user.updateName(newName);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -57,4 +57,9 @@ public class UserAccountUseCase {
 
         return UserProfileDto.from(user);
     }
+
+    @Transactional
+    public void updateName(Long userId, String name) {
+
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.users.usecase;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
 import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
+import kr.co.pennyway.api.apis.users.service.UserProfileUpdateService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.device.domain.Device;
 import kr.co.pennyway.domain.domains.device.exception.DeviceErrorCode;
@@ -22,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserAccountUseCase {
     private final UserService userService;
     private final DeviceService deviceService;
+
+    private final UserProfileUpdateService userProfileUpdateService;
 
     private final DeviceRegisterService deviceRegisterService;
 
@@ -59,7 +62,11 @@ public class UserAccountUseCase {
     }
 
     @Transactional
-    public void updateName(Long userId, String name) {
+    public void updateName(Long userId, String newName) {
+        User user = userService.readUser(userId).orElseThrow(
+                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
+        );
 
+        userProfileUpdateService.updateName(user, newName);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -30,9 +30,7 @@ public class UserAccountUseCase {
 
     @Transactional
     public DeviceDto.RegisterRes registerDevice(Long userId, DeviceDto.RegisterReq request) {
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
+        User user = readUserOrThrow(userId);
 
         Device device = deviceRegisterService.createOrUpdateDevice(user, request);
 
@@ -41,9 +39,7 @@ public class UserAccountUseCase {
 
     @Transactional
     public void unregisterDevice(Long userId, String token) {
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
+        User user = readUserOrThrow(userId);
 
         Device device = deviceService.readDeviceByUserIdAndToken(user.getId(), token).orElseThrow(
                 () -> new DeviceErrorException(DeviceErrorCode.NOT_FOUND_DEVICE)
@@ -54,28 +50,28 @@ public class UserAccountUseCase {
 
     @Transactional(readOnly = true)
     public UserProfileDto getMyAccount(Long userId) {
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
+        User user = readUserOrThrow(userId);
 
         return UserProfileDto.from(user);
     }
 
     @Transactional
     public void updateName(Long userId, String newName) {
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
+        User user = readUserOrThrow(userId);
 
         userProfileUpdateService.updateName(user, newName);
     }
 
     @Transactional
     public void updateUsername(Long userId, String newUsername) {
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
+        User user = readUserOrThrow(userId);
 
         userProfileUpdateService.updateUsername(user, newUsername);
+    }
+
+    private User readUserOrThrow(Long userId) {
+        return userService.readUser(userId).orElseThrow(
+                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
+        );
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -69,4 +69,12 @@ public class UserAccountUseCase {
 
         userProfileUpdateService.updateName(user, newName);
     }
+
+    @Transactional
+    public void updateUsername(Long userId, String newUsername) {
+        User user = userService.readUser(userId).orElseThrow(
+                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
+        );
+
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -76,5 +76,6 @@ public class UserAccountUseCase {
                 () -> new UserErrorException(UserErrorCode.NOT_FOUND)
         );
 
+        userProfileUpdateService.updateUsername(user, newUsername);
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -196,8 +196,8 @@ public class UserAccountControllerUnitTest {
         @WithSecurityMockUser
         void updateNicknameDeletedUser() throws Exception {
             // given
-            String newNickname = "양재서";
-            willThrow(new UserErrorException(UserErrorCode.NOT_FOUND)).given(userAccountUseCase).updateNickname(1L, newNickname);
+            String newNickname = "jayang._.";
+            willThrow(new UserErrorException(UserErrorCode.NOT_FOUND)).given(userAccountUseCase).updateUsername(1L, newNickname);
 
             // when
             ResultActions result = performUpdateNicknameRequest(newNickname);
@@ -214,7 +214,7 @@ public class UserAccountControllerUnitTest {
         @WithSecurityMockUser
         void updateNicknameSuccess() throws Exception {
             // given
-            String newNickname = "양재서";
+            String newNickname = "jayang._.";
 
             // when
             ResultActions result = performUpdateNicknameRequest(newNickname);
@@ -227,7 +227,7 @@ public class UserAccountControllerUnitTest {
 
         private ResultActions performUpdateNicknameRequest(String newNickname) throws Exception {
             UserProfileUpdateDto.UsernameReq request = new UserProfileUpdateDto.UsernameReq(newNickname);
-            return mockMvc.perform(put("/v2/users/me/nickname")
+            return mockMvc.perform(put("/v2/users/me/username")
                     .contentType("application/json")
                     .content(objectMapper.writeValueAsString(request)));
         }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -226,7 +226,7 @@ public class UserAccountControllerUnitTest {
         }
 
         private ResultActions performUpdateNicknameRequest(String newNickname) throws Exception {
-            UserProfileUpdateDto.NicknameReq request = new UserProfileUpdateDto.NicknameReq(newNickname);
+            UserProfileUpdateDto.UsernameReq request = new UserProfileUpdateDto.UsernameReq(newNickname);
             return mockMvc.perform(put("/v2/users/me/nickname")
                     .contentType("application/json")
                     .content(objectMapper.writeValueAsString(request)));

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -19,6 +19,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import static kr.co.pennyway.common.exception.ReasonCode.TYPE_MISMATCH_ERROR_IN_REQUEST_BODY;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -111,7 +112,7 @@ public class UserAccountControllerUnitTest {
         void updateNameNotGeneralSignedUpUser() throws Exception {
             // given
             String newName = "양재서";
-            given(userAccountUseCase.updateName(1L, newName)).willThrow(new UserErrorException(UserErrorCode.DO_NOT_GENERAL_SIGNED_UP));
+            willThrow(new UserErrorException(UserErrorCode.DO_NOT_GENERAL_SIGNED_UP)).given(userAccountUseCase).updateName(1L, newName);
 
             // when
             ResultActions result = performUpdateNameRequest(newName);
@@ -129,7 +130,7 @@ public class UserAccountControllerUnitTest {
         void updateNameDeletedUser() throws Exception {
             // given
             String newName = "양재서";
-            given(userAccountUseCase.updateName(1L, newName)).willThrow(new UserErrorException(UserErrorCode.NOT_FOUND));
+            willThrow(new UserErrorException(UserErrorCode.NOT_FOUND)).given(userAccountUseCase).updateName(1L, newName);
 
             // when
             ResultActions result = performUpdateNameRequest(newName);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -5,6 +5,7 @@ import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.dto.UserProfileUpdateDto;
 import kr.co.pennyway.api.apis.users.usecase.UserAccountUseCase;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
+import kr.co.pennyway.common.exception.StatusCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
 import org.junit.jupiter.api.*;
@@ -17,7 +18,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import static kr.co.pennyway.common.exception.ReasonCode.TYPE_MISMATCH_ERROR_IN_REQUEST_BODY;
+import static kr.co.pennyway.common.exception.ReasonCode.REQUIRED_PARAMETERS_MISSING_IN_REQUEST_BODY;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -88,6 +89,7 @@ public class UserAccountControllerUnitTest {
             String newNameWithBlank = " ";
             String newNameWithOverLength = "안녕하세요장페르센입니다";
             String newNameWithSpecialCharacter = "hello!";
+            String expectedErrorCode = String.valueOf(StatusCode.UNPROCESSABLE_CONTENT.getCode() * 10 + REQUIRED_PARAMETERS_MISSING_IN_REQUEST_BODY.getCode());
 
             // when
             ResultActions result1 = performUpdateNameRequest(newNameWithBlank);
@@ -96,13 +98,13 @@ public class UserAccountControllerUnitTest {
 
             // then
             result1.andExpect(status().isUnprocessableEntity())
-                    .andExpect(jsonPath("$.code").value(TYPE_MISMATCH_ERROR_IN_REQUEST_BODY.getCode()))
+                    .andExpect(jsonPath("$.code").value(expectedErrorCode))
                     .andDo(print());
             result2.andExpect(status().isUnprocessableEntity())
-                    .andExpect(jsonPath("$.code").value(TYPE_MISMATCH_ERROR_IN_REQUEST_BODY.getCode()))
+                    .andExpect(jsonPath("$.code").value(expectedErrorCode))
                     .andDo(print());
             result3.andExpect(status().isUnprocessableEntity())
-                    .andExpect(jsonPath("$.code").value(TYPE_MISMATCH_ERROR_IN_REQUEST_BODY.getCode()))
+                    .andExpect(jsonPath("$.code").value(expectedErrorCode))
                     .andDo(print());
         }
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.usecase.UserAccountUseCase;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -26,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = {UserAccountController.class})
 @ActiveProfiles("local")
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class UserAccountControllerUnitTest {
     @Autowired
     private MockMvc mockMvc;
@@ -45,25 +44,31 @@ public class UserAccountControllerUnitTest {
                 .build();
     }
 
-    @DisplayName("[1] 디바이스가 정상적으로 저장되었을 때, 디바이스 pk와 등록된 토큰을 반환한다.")
-    @Test
-    @WithSecurityMockUser
-    void putDeviceSuccess() throws Exception {
-        // given
-        DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("newToken", "newToken", "modelA", "Windows");
-        DeviceDto.RegisterRes expectedResponse = new DeviceDto.RegisterRes(2L, "newToken");
-        given(userAccountUseCase.registerDevice(1L, request)).willReturn(expectedResponse);
+    @Nested
+    @Order(1)
+    @DisplayName("[1] 디바이스 요청 테스트")
+    class DeviceRequestTest {
+        @DisplayName("디바이스가 정상적으로 저장되었을 때, 디바이스 pk와 등록된 토큰을 반환한다.")
+        @Test
+        @WithSecurityMockUser
+        void putDevice() throws Exception {
+            // given
+            DeviceDto.RegisterReq request = new DeviceDto.RegisterReq("newToken", "newToken", "modelA", "Windows");
+            DeviceDto.RegisterRes expectedResponse = new DeviceDto.RegisterRes(2L, "newToken");
+            given(userAccountUseCase.registerDevice(1L, request)).willReturn(expectedResponse);
 
-        // when
-        ResultActions result = mockMvc.perform(put("/v2/users/me/devices")
-                .contentType("application/json")
-                .content(objectMapper.writeValueAsString(request)));
+            // when
+            ResultActions result = mockMvc.perform(put("/v2/users/me/devices")
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(request)));
 
-        // then
-        result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("2000"))
-                .andExpect(jsonPath("$.data.device.id").value(expectedResponse.id()))
-                .andExpect(jsonPath("$.data.device.token").value(expectedResponse.token()))
-                .andDo(print());
+            // then
+            result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("2000"))
+                    .andExpect(jsonPath("$.data.device.id").value(expectedResponse.id()))
+                    .andExpect(jsonPath("$.data.device.token").value(expectedResponse.token()))
+                    .andDo(print());
+        }
     }
+
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -22,8 +22,7 @@ import static kr.co.pennyway.common.exception.ReasonCode.REQUIRED_PARAMETERS_MIS
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -47,6 +46,7 @@ public class UserAccountControllerUnitTest {
                 .webAppContextSetup(webApplicationContext)
                 .defaultRequest(put("/**").with(csrf()))
                 .defaultRequest(delete("/**").with(csrf()))
+                .defaultRequest(patch("/**").with(csrf()))
                 .build();
     }
 
@@ -144,7 +144,7 @@ public class UserAccountControllerUnitTest {
 
         private ResultActions performUpdateNameRequest(String newName) throws Exception {
             UserProfileUpdateDto.NameReq request = new UserProfileUpdateDto.NameReq(newName);
-            return mockMvc.perform(put("/v2/users/me/name")
+            return mockMvc.perform(patch("/v2/users/me/name")
                     .contentType("application/json")
                     .content(objectMapper.writeValueAsString(request)));
         }
@@ -227,7 +227,7 @@ public class UserAccountControllerUnitTest {
 
         private ResultActions performUpdateNicknameRequest(String newNickname) throws Exception {
             UserProfileUpdateDto.UsernameReq request = new UserProfileUpdateDto.UsernameReq(newNickname);
-            return mockMvc.perform(put("/v2/users/me/username")
+            return mockMvc.perform(patch("/v2/users/me/username")
                     .contentType("application/json")
                     .content(objectMapper.writeValueAsString(request)));
         }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.users.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.api.apis.users.dto.UserProfileUpdateDto;
 import kr.co.pennyway.api.apis.users.usecase.UserAccountUseCase;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
@@ -118,7 +119,7 @@ public class UserAccountControllerUnitTest {
             // then
             result.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(UserErrorCode.DO_NOT_GENERAL_SIGNED_UP.causedBy().getCode()))
-                    .andExpect(jsonPath("$.message").value(UserErrorCode.DO_NOT_GENERAL_SIGNED_UP.getExplainError())
+                    .andExpect(jsonPath("$.message").value(UserErrorCode.DO_NOT_GENERAL_SIGNED_UP.getExplainError()))
                     .andDo(print());
         }
 
@@ -156,8 +157,8 @@ public class UserAccountControllerUnitTest {
                     .andDo(print());
         }
 
-        private ResultActions performUpdateNameRequest(String newName) {
-            UserAccountUpdateDto.NameReq request = new UserAccountUpdateDto.NameReq(newName);
+        private ResultActions performUpdateNameRequest(String newName) throws Exception {
+            UserProfileUpdateDto.NameReq request = new UserProfileUpdateDto.NameReq(newName);
             return mockMvc.perform(put("/v2/users/me/name")
                     .contentType("application/json")
                     .content(objectMapper.writeValueAsString(request)));

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -108,24 +108,6 @@ public class UserAccountControllerUnitTest {
                     .andDo(print());
         }
 
-        @DisplayName("사용자 이름 수정 요청 시, 일반 회원가입 계정이 아니면 400 에러를 반환한다.")
-        @Test
-        @WithSecurityMockUser
-        void updateNameNotGeneralSignedUpUser() throws Exception {
-            // given
-            String newName = "양재서";
-            willThrow(new UserErrorException(UserErrorCode.DO_NOT_GENERAL_SIGNED_UP)).given(userAccountUseCase).updateName(1L, newName);
-
-            // when
-            ResultActions result = performUpdateNameRequest(newName);
-
-            // then
-            result.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value(UserErrorCode.DO_NOT_GENERAL_SIGNED_UP.causedBy().getCode()))
-                    .andExpect(jsonPath("$.message").value(UserErrorCode.DO_NOT_GENERAL_SIGNED_UP.getExplainError()))
-                    .andDo(print());
-        }
-
         @DisplayName("사용자 이름 수정 요청 시, 삭제된 사용자인 경우 404 에러를 반환한다.")
         @Test
         @WithSecurityMockUser

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -71,4 +71,56 @@ public class UserAccountControllerUnitTest {
         }
     }
 
+    @Nested
+    @Order(2)
+    @DisplayName("[2] 사용자 이름, 닉네임 수정 테스트")
+    class UpdateUserProfileTest {
+        @DisplayName("사용자 이름 수정 요청 시, 유효성 검사에 실패하면 422 에러를 반환한다.")
+        @Test
+        @WithSecurityMockUser
+        void updateNameValidationFail() throws Exception {
+            // given
+
+            // when
+
+            // then
+
+        }
+
+        @DisplayName("사용자 이름 수정 요청 시, 일반 회원가입 계정이 아니면 400 에러를 반환한다.")
+        @Test
+        @WithSecurityMockUser
+        void updateNameNotGeneralSignedUpUser() throws Exception {
+            // given
+
+            // when
+
+            // then
+
+        }
+
+        @DisplayName("사용자 이름 수정 요청 시, 삭제된 사용자인 경우 404 에러를 반환한다.")
+        @Test
+        @WithSecurityMockUser
+        void updateNameDeletedUser() throws Exception {
+            // given
+
+            // when
+
+            // then
+
+        }
+
+        @DisplayName("사용자 이름 수정 요청 시, 사용자 이름이 정상적으로 수정되면 200 코드를 반환한다.")
+        @Test
+        @WithSecurityMockUser
+        void updateNameSuccess() throws Exception {
+            // given
+
+            // when
+
+            // then
+
+        }
+    }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -14,9 +14,7 @@ import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.service.UserService;
 import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
 import kr.co.pennyway.domain.domains.user.type.Role;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,185 +55,197 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
         requestUser = userService.createUser(user);
     }
 
-    @Test
-    @Transactional
-    @DisplayName("[1] originToken과 newToken이 같은 경우, 신규 디바이스를 등록한다.")
-    void registerNewDevice() {
-        // given
-        DeviceDto.RegisterReq request = DeviceFixture.INIT.toRegisterReq();
+    @Order(1)
+    @Nested
+    @DisplayName("[1] 디바이스 등록 테스트")
+    class DeviceRegisterTest {
+        @Test
+        @Transactional
+        @DisplayName("[1] originToken과 newToken이 같은 경우, 신규 디바이스를 등록한다.")
+        void registerNewDevice() {
+            // given
+            DeviceDto.RegisterReq request = DeviceFixture.INIT.toRegisterReq();
 
-        // when
-        DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
+            // when
+            DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
 
-        // then
-        deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
-                device -> {
-                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
-                    assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
-                    assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
-                    assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
-                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
-                    System.out.println("device = " + device);
-                },
-                () -> fail("신규 디바이스가 등록되어 있어야 한다.")
-        );
+            // then
+            deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
+                    device -> {
+                        assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
+                        assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
+                        assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
+                        assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
+                        assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
+                        System.out.println("device = " + device);
+                    },
+                    () -> fail("신규 디바이스가 등록되어 있어야 한다.")
+            );
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("[1-1] 저장 요청에서 originToken에 대한 디바이스가 이미 존재하는 경우, 디바이스 정보 변경 사항만 업데이트하고 기존 디바이스 정보를 반환한다.")
+        void registerNewDeviceWhenDeviceIsAlreadyExists() {
+            // given
+            Device originDevice = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
+            deviceService.createDevice(originDevice);
+            DeviceDto.RegisterReq request = DeviceFixture.ONLY_MODEL_AND_OS_CHANGED.toRegisterReq();
+
+            // when
+            DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
+
+            // then
+            deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
+                    device -> {
+                        assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
+                        assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
+                        assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
+                        assertEquals("디바이스 ID가 일치해야 한다.", originDevice.getId(), device.getId());
+                        assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
+                        assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
+                        System.out.println("device = " + device);
+                    },
+                    () -> fail("신규 디바이스가 등록되어 있어야 한다.")
+            );
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("[2] originToken과 일치하는 활성화 디바이스 토큰이 존재한다면, 디바이스 토큰을 갱신한다.")
+        void updateActivateDeviceToken() {
+            // given
+            Device originDevice = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
+            deviceService.createDevice(originDevice);
+
+            System.out.println("originDevice = " + originDevice);
+            DeviceDto.RegisterReq request = DeviceFixture.ONLY_TOKEN_CHANGED.toRegisterReq();
+
+            // when
+            DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
+
+            // then
+            deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
+                    device -> {
+                        assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
+                        assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
+                        assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
+                        assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
+                        assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
+                        assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
+                        System.out.println("device = " + device);
+                    },
+                    () -> fail("디바이스 토큰이 갱신되어 있어야 한다.")
+            );
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("[2-1] 기존에 등록된 비활성화 디바이스 토큰이 있고 디바이스 정보가 일치한다면, 디바이스 토큰을 갱신하고 활성화로 변경한다.")
+        void updateDeactivateDeviceToken() {
+            // given
+            Device originDevice = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
+            deviceService.createDevice(originDevice);
+            em.createQuery("UPDATE Device d SET d.activated = false WHERE d.id = :id AND d.token = :token")
+                    .setParameter("id", originDevice.getId())
+                    .setParameter("token", originDevice.getToken())
+                    .executeUpdate(); // 비활성화 처리
+
+            System.out.println("originDevice = " + originDevice);
+            DeviceDto.RegisterReq request = DeviceFixture.ONLY_TOKEN_CHANGED.toRegisterReq();
+
+            // when
+            DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
+
+            // then
+            deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
+                    device -> {
+                        assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
+                        assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
+                        assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
+                        assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
+                        assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
+                        assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
+                        System.out.println("device = " + device);
+                    },
+                    () -> fail("디바이스 토큰이 갱신되어 있어야 한다.")
+            );
+        }
+
+
+        @Test
+        @Transactional
+        @DisplayName("[2-2] 사용자가 유효한 토큰을 가지고 있지만 모델명이나 OS가 다른 경우, 디바이스 정보를 업데이트한다.")
+        void notMatchDevice() {
+            // given
+            Device originDevice = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
+            deviceService.createDevice(originDevice);
+            System.out.println("originDevice = " + originDevice);
+            DeviceDto.RegisterReq request = DeviceFixture.ALL_CHANGED.toRegisterReq();
+
+            // when
+            userAccountUseCase.registerDevice(requestUser.getId(), request);
+
+            // then
+            deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
+                    device -> {
+                        assertEquals("요청한 디바이스 토큰과 동일해야 한다.", request.newToken(), device.getToken());
+                        assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
+                        assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
+                        assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
+                        assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
+                        System.out.println("device = " + device);
+                    },
+                    () -> fail("디바이스 토큰이 갱신되어 있어야 한다.")
+            );
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("[3] 토큰 수정 요청에서 oldToken에 대한 디바이스가 존재하지 않는 경우, NOT_FOUND 에러를 반환한다.")
+        void registerNewDeviceWhenOldDeviceTokenIsNotExists() {
+            // given
+            DeviceDto.RegisterReq request = DeviceFixture.ONLY_TOKEN_CHANGED.toRegisterReq();
+
+            // when - then
+            DeviceErrorException ex = assertThrows(DeviceErrorException.class, () -> userAccountUseCase.registerDevice(requestUser.getId(), request));
+            assertEquals("디바이스 토큰이 존재하지 않으면 Not Found를 반환한다.", DeviceErrorCode.NOT_FOUND_DEVICE, ex.getBaseErrorCode());
+        }
     }
 
-    @Test
-    @Transactional
-    @DisplayName("[1-1] 저장 요청에서 originToken에 대한 디바이스가 이미 존재하는 경우, 디바이스 정보 변경 사항만 업데이트하고 기존 디바이스 정보를 반환한다.")
-    void registerNewDeviceWhenDeviceIsAlreadyExists() {
-        // given
-        Device originDevice = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
-        deviceService.createDevice(originDevice);
-        DeviceDto.RegisterReq request = DeviceFixture.ONLY_MODEL_AND_OS_CHANGED.toRegisterReq();
+    @Order(2)
+    @Nested
+    @DisplayName("[2] 디바이스 삭제 테스트")
+    class DeviceUnregisterTest {
+        @Test
+        @Transactional
+        @DisplayName("사용자 ID와 origin token에 매칭되는 활성 디바이스가 존재하는 경우 디바이스를 삭제한다.")
+        void unregisterDevice() {
+            // given
+            Device device = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
+            deviceService.createDevice(device);
 
-        // when
-        DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
+            // when
+            userAccountUseCase.unregisterDevice(requestUser.getId(), device.getToken());
 
-        // then
-        deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
-                device -> {
-                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
-                    assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
-                    assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
-                    assertEquals("디바이스 ID가 일치해야 한다.", originDevice.getId(), device.getId());
-                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
-                    assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
-                    System.out.println("device = " + device);
-                },
-                () -> fail("신규 디바이스가 등록되어 있어야 한다.")
-        );
-    }
+            // then
+            Optional<Device> deletedDevice = deviceService.readDeviceByUserIdAndToken(requestUser.getId(), device.getToken());
+            assertNull("디바이스가 삭제되어 있어야 한다.", deletedDevice.orElse(null));
+        }
 
-    @Test
-    @Transactional
-    @DisplayName("[2] originToken과 일치하는 활성화 디바이스 토큰이 존재한다면, 디바이스 토큰을 갱신한다.")
-    void updateActivateDeviceToken() {
-        // given
-        Device originDevice = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
-        deviceService.createDevice(originDevice);
+        @Test
+        @Transactional
+        @DisplayName("사용자 ID와 token에 매칭되는 디바이스가 존재하지 않는 경우 NOT_FOUND_DEVICE 에러를 반환한다.")
+        void unregisterDeviceWhenDeviceIsNotExists() {
+            // given
+            Device device = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
+            deviceService.createDevice(device);
 
-        System.out.println("originDevice = " + originDevice);
-        DeviceDto.RegisterReq request = DeviceFixture.ONLY_TOKEN_CHANGED.toRegisterReq();
-
-        // when
-        DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
-
-        // then
-        deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
-                device -> {
-                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
-                    assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
-                    assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
-                    assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
-                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
-                    assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
-                    System.out.println("device = " + device);
-                },
-                () -> fail("디바이스 토큰이 갱신되어 있어야 한다.")
-        );
-    }
-
-    @Test
-    @Transactional
-    @DisplayName("[2-1] 기존에 등록된 비활성화 디바이스 토큰이 있고 디바이스 정보가 일치한다면, 디바이스 토큰을 갱신하고 활성화로 변경한다.")
-    void updateDeactivateDeviceToken() {
-        // given
-        Device originDevice = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
-        deviceService.createDevice(originDevice);
-        em.createQuery("UPDATE Device d SET d.activated = false WHERE d.id = :id AND d.token = :token")
-                .setParameter("id", originDevice.getId())
-                .setParameter("token", originDevice.getToken())
-                .executeUpdate(); // 비활성화 처리
-
-        System.out.println("originDevice = " + originDevice);
-        DeviceDto.RegisterReq request = DeviceFixture.ONLY_TOKEN_CHANGED.toRegisterReq();
-
-        // when
-        DeviceDto.RegisterRes response = userAccountUseCase.registerDevice(requestUser.getId(), request);
-
-        // then
-        deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
-                device -> {
-                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", response.token(), device.getToken());
-                    assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
-                    assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
-                    assertEquals("디바이스 ID가 일치해야 한다.", response.id(), device.getId());
-                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
-                    assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
-                    System.out.println("device = " + device);
-                },
-                () -> fail("디바이스 토큰이 갱신되어 있어야 한다.")
-        );
+            // when - then
+            DeviceErrorException ex = assertThrows(DeviceErrorException.class, () -> userAccountUseCase.unregisterDevice(requestUser.getId(), "notExistsToken"));
+            assertEquals("디바이스 토큰이 존재하지 않으면 Not Found를 반환한다.", DeviceErrorCode.NOT_FOUND_DEVICE, ex.getBaseErrorCode());
+        }
     }
 
 
-    @Test
-    @Transactional
-    @DisplayName("[2-2] 사용자가 유효한 토큰을 가지고 있지만 모델명이나 OS가 다른 경우, 디바이스 정보를 업데이트한다.")
-    void notMatchDevice() {
-        // given
-        Device originDevice = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
-        deviceService.createDevice(originDevice);
-        System.out.println("originDevice = " + originDevice);
-        DeviceDto.RegisterReq request = DeviceFixture.ALL_CHANGED.toRegisterReq();
-
-        // when
-        userAccountUseCase.registerDevice(requestUser.getId(), request);
-
-        // then
-        deviceService.readDeviceByUserIdAndToken(requestUser.getId(), request.newToken()).ifPresentOrElse(
-                device -> {
-                    assertEquals("요청한 디바이스 토큰과 동일해야 한다.", request.newToken(), device.getToken());
-                    assertEquals("요청한 디바이스 모델과 동일해야 한다.", request.model(), device.getModel());
-                    assertEquals("요청한 디바이스 OS와 동일해야 한다.", request.os(), device.getOs());
-                    assertTrue("디바이스가 사용자 ID와 연결되어 있어야 한다.", device.getUser().getId().equals(requestUser.getId()));
-                    assertTrue("디바이스가 활성화 상태여야 한다.", device.getActivated());
-                    System.out.println("device = " + device);
-                },
-                () -> fail("디바이스 토큰이 갱신되어 있어야 한다.")
-        );
-    }
-
-    @Test
-    @Transactional
-    @DisplayName("[3] 토큰 수정 요청에서 oldToken에 대한 디바이스가 존재하지 않는 경우, NOT_FOUND 에러를 반환한다.")
-    void registerNewDeviceWhenOldDeviceTokenIsNotExists() {
-        // given
-        DeviceDto.RegisterReq request = DeviceFixture.ONLY_TOKEN_CHANGED.toRegisterReq();
-
-        // when - then
-        DeviceErrorException ex = assertThrows(DeviceErrorException.class, () -> userAccountUseCase.registerDevice(requestUser.getId(), request));
-        assertEquals("디바이스 토큰이 존재하지 않으면 Not Found를 반환한다.", DeviceErrorCode.NOT_FOUND_DEVICE, ex.getBaseErrorCode());
-    }
-
-    @Test
-    @Transactional
-    @DisplayName("[4] 사용자 ID와 origin token에 매칭되는 활성 디바이스가 존재하는 경우 디바이스를 삭제한다.")
-    void unregisterDevice() {
-        // given
-        Device device = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
-        deviceService.createDevice(device);
-
-        // when
-        userAccountUseCase.unregisterDevice(requestUser.getId(), device.getToken());
-
-        // then
-        Optional<Device> deletedDevice = deviceService.readDeviceByUserIdAndToken(requestUser.getId(), device.getToken());
-        assertNull("디바이스가 삭제되어 있어야 한다.", deletedDevice.orElse(null));
-    }
-
-    @Test
-    @Transactional
-    @DisplayName("[5] 사용자 ID와 token에 매칭되는 디바이스가 존재하지 않는 경우 NOT_FOUND_DEVICE 에러를 반환한다.")
-    void unregisterDeviceWhenDeviceIsNotExists() {
-        // given
-        Device device = DeviceFixture.ORIGIN_DEVICE.toDevice(requestUser);
-        deviceService.createDevice(device);
-
-        // when - then
-        DeviceErrorException ex = assertThrows(DeviceErrorException.class, () -> userAccountUseCase.unregisterDevice(requestUser.getId(), "notExistsToken"));
-        assertEquals("디바이스 토큰이 존재하지 않으면 Not Found를 반환한다.", DeviceErrorCode.NOT_FOUND_DEVICE, ex.getBaseErrorCode());
-    }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -37,6 +37,7 @@ import static org.springframework.test.util.AssertionErrors.*;
 @ContextConfiguration(classes = {JpaConfig.class, UserAccountUseCase.class, DeviceRegisterService.class, UserService.class, DeviceService.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
 class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
     @Autowired
     private UserService userService;

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -1,6 +1,5 @@
 package kr.co.pennyway.api.apis.users.usecase;
 
-import jakarta.persistence.EntityManager;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
 import kr.co.pennyway.api.apis.users.service.UserProfileUpdateService;
@@ -40,9 +39,6 @@ import static org.springframework.test.util.AssertionErrors.*;
 @ActiveProfiles("test")
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
-    @Autowired
-    private EntityManager em;
-
     @Autowired
     private UserService userService;
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
@@ -47,6 +47,10 @@ public class Device extends DateAuditable {
         this.activated = Boolean.TRUE;
     }
 
+    public void deactivate() {
+        this.activated = Boolean.FALSE;
+    }
+
     public void updateToken(String token) {
         this.token = token;
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
@@ -75,6 +75,10 @@ public class User extends DateAuditable {
         this.passwordUpdatedAt = LocalDateTime.now();
     }
 
+    public void updateName(String name) {
+        this.name = name;
+    }
+
     @Override
     public String toString() {
         return "User{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
@@ -79,6 +79,10 @@ public class User extends DateAuditable {
         this.name = name;
     }
 
+    public void updateUsername(String username) {
+        this.username = username;
+    }
+
     @Override
     public String toString() {
         return "User{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 public enum UserErrorCode implements BaseErrorCode {
     /* 400 BAD_REQUEST */
     ALREADY_SIGNUP(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "이미 회원가입한 유저입니다."),
-    DO_NOT_GENERAL_SIGNED_UP(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "일반 회원가입 계정이 아닙니다."),
 
     /* 401 UNAUTHORIZED */
     NOT_MATCHED_PASSWORD(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS, "비밀번호가 일치하지 않습니다."),

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum UserErrorCode implements BaseErrorCode {
     /* 400 BAD_REQUEST */
     ALREADY_SIGNUP(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "이미 회원가입한 유저입니다."),
+    DO_NOT_GENERAL_SIGNED_UP(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "일반 회원가입 계정이 아닙니다."),
 
     /* 401 UNAUTHORIZED */
     NOT_MATCHED_PASSWORD(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS, "비밀번호가 일치하지 않습니다."),


### PR DESCRIPTION
## 작업 이유
- 사용자 아이디(username) 수정 API 구현
- 사용자 이름(name) 수정 API 구현

<br/>

## 작업 사항

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/afd968c1-f032-4550-b7af-465c9e6e069c" width="600px"/>
</div>

- 요청 경로
   - 이름 수정 : `PUT /v1/users/me/name`
   - 아이디 수정 : `PUT /v1/users/me/name`

테스트 케이스가 많아서 그렇지 로직은 단순하기 그지 없습니댜.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 변경 요청을 위해 `PUT` 메서드를 사용하는 것이 적절한지?
- 요청 `url`이 적절한지?
   - 하려면 Query Parameter로 분리할 수 있긴 함.
   - 다만 그렇게 하면 거대한 `if-elseif-else`이 탄생할 수도 있을 것 같아서 보류

<br/>

## 발견한 이슈
### Device Entity에 *deactivate*()를 선언한 이유 (동작은 하도록 수정했으나, 에러 원인을 못 찾음)

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/db613140-c943-4713-ae44-e4e7e9536b65" width="600px"/>
</div>

- 기존에 정상적으로 동작하던 `em.createQuery()`가 `TransactionRequiredException (Executing an update/delete query)` 예외를 발생시키며 실패함.
- 해당 에러는 선언적 Tx(`@Transactional`)가 없으면 발생한다는데, 해당 테스트에는 분명이 어노테이션이 존재함.
- 실패한 해결 방법
   1. `@Modifying` 어노테이션 추가 -> 실패
   2. `em.joinTransaction();`으로 트랜잭션 참여 -> PessimisticLockingFailureException 데드락 에러 발생
   3. EntityManager를 Autowired가 아닌 `@PresistenceContext`로 호출 -> PessimisticLockingFailureException 데드락 에러 발생
- 이 외에도 여러가지 수단을 써보았으나, Tx 실패 혹은 데드락 문제로 이어짐.
   - 이 문제에 대해서 원인을 분석할 예정.

<br/>

임시 방편으로 다음과 같이 처리

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/9ec1cb73-daf9-4e09-8d6a-1157e387c08f" width="600px"/>
</div>

