### PR TITLE
✨ 사용자 알림 설정 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -100,7 +100,7 @@ public interface UserAccountApi {
                             """)
             }))
     })
-    ResponseEntity<?> putNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user);
+    ResponseEntity<?> patchNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "사용자 알림 비활성화")
     @Parameter(name = "type", description = "알림 타입", examples = {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -14,6 +14,7 @@ import jakarta.validation.constraints.NotBlank;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -60,4 +61,10 @@ public interface UserAccountApi {
     @Operation(summary = "사용자 계정 조회", description = "사용자 본인의 계정 정보를 조회합니다.")
     @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "user", schema = @Schema(implementation = UserProfileDto.class))))
     ResponseEntity<?> getMyAccount(@AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "사용자 알림 활성화")
+    @Parameter(name = "type", description = "알림 타입", examples = {
+            @ExampleObject(name = "가계부", value = "account_book"), @ExampleObject(name = "피드", value = "feed"), @ExampleObject(name = "채팅", value = "chat")
+    }, required = true, in = ParameterIn.QUERY)
+    ResponseEntity<?> putNotifySetting(@RequestParam NotifySetting.NotifyType type, @RequestBody @Validated UserProfileDto.NotifySettingReq request, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -66,11 +66,79 @@ public interface UserAccountApi {
     @Parameter(name = "type", description = "알림 타입", examples = {
             @ExampleObject(name = "가계부", value = "account_book"), @ExampleObject(name = "피드", value = "feed"), @ExampleObject(name = "채팅", value = "chat")
     }, required = true, in = ParameterIn.QUERY)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "가계부 알림 활성화", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "notifySetting": {
+                                        "accountBookNotify": true
+                                    }
+                                }
+                            }
+                            """),
+                    @ExampleObject(name = "피드 알림 활성화", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "notifySetting": {
+                                        "feedNotify": true
+                                    }
+                                }
+                            }
+                            """),
+                    @ExampleObject(name = "채팅 알림 활성화", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "notifySetting": {
+                                        "chatNotify": true
+                                    }
+                                }
+                            }
+                            """)
+            }))
+    })
     ResponseEntity<?> putNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "사용자 알림 비활성화")
     @Parameter(name = "type", description = "알림 타입", examples = {
             @ExampleObject(name = "가계부", value = "account_book"), @ExampleObject(name = "피드", value = "feed"), @ExampleObject(name = "채팅", value = "chat")
     }, required = true, in = ParameterIn.QUERY)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "가계부 알림 비활성화", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "notifySetting": {
+                                        "accountBookNotify": false
+                                    }
+                                }
+                            }
+                            """),
+                    @ExampleObject(name = "피드 알림 비활성화", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "notifySetting": {
+                                        "feedNotify": false
+                                    }
+                                }
+                            }
+                            """),
+                    @ExampleObject(name = "채팅 알림 비활성화", value = """
+                            {
+                                "code": "2000",
+                                "data": {
+                                    "notifySetting": {
+                                        "chatNotify": false
+                                    }
+                                }
+                            }
+                            """)
+            }))
+    })
     ResponseEntity<?> deleteNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -66,5 +66,11 @@ public interface UserAccountApi {
     @Parameter(name = "type", description = "알림 타입", examples = {
             @ExampleObject(name = "가계부", value = "account_book"), @ExampleObject(name = "피드", value = "feed"), @ExampleObject(name = "채팅", value = "chat")
     }, required = true, in = ParameterIn.QUERY)
-    ResponseEntity<?> putNotifySetting(@RequestParam NotifySetting.NotifyType type, @RequestBody @Validated UserProfileDto.NotifySettingReq request, @AuthenticationPrincipal SecurityUserDetails user);
+    ResponseEntity<?> putNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "사용자 알림 비활성화")
+    @Parameter(name = "type", description = "알림 타입", examples = {
+            @ExampleObject(name = "가계부", value = "account_book"), @ExampleObject(name = "피드", value = "feed"), @ExampleObject(name = "채팅", value = "chat")
+    }, required = true, in = ParameterIn.QUERY)
+    ResponseEntity<?> deleteNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -3,7 +3,6 @@ package kr.co.pennyway.api.apis.users.controller;
 import jakarta.validation.constraints.NotBlank;
 import kr.co.pennyway.api.apis.users.api.UserAccountApi;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
-import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
 import kr.co.pennyway.api.apis.users.usecase.UserAccountUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
@@ -53,6 +52,6 @@ public class UserAccountController implements UserAccountApi {
     @DeleteMapping("/notifications")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> deleteNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user) {
-        return ResponseEntity.ok(SuccessResponse.from("notifySetting", userAccountUseCase.deactivateNotification(user.getUserId(), type));
+        return ResponseEntity.ok(SuccessResponse.from("notifySetting", userAccountUseCase.deactivateNotification(user.getUserId(), type)));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -45,7 +45,14 @@ public class UserAccountController implements UserAccountApi {
     @Override
     @PutMapping("/notifications")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> putNotifySetting(@RequestParam NotifySetting.NotifyType type, @RequestBody @Validated UserProfileDto.NotifySettingReq request, @AuthenticationPrincipal SecurityUserDetails user) {
-        return ResponseEntity.ok(SuccessResponse.from("notifySetting", userAccountUseCase.putNotifySetting(user.getUserId(), type, request)));
+    public ResponseEntity<?> putNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(SuccessResponse.from("notifySetting", userAccountUseCase.activateNotification(user.getUserId(), type)));
+    }
+
+    @Override
+    @DeleteMapping("/notifications")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> deleteNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(SuccessResponse.from("notifySetting", userAccountUseCase.deactivateNotification(user.getUserId(), type));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -42,9 +42,9 @@ public class UserAccountController implements UserAccountApi {
     }
 
     @Override
-    @PutMapping("/notifications")
+    @PatchMapping("/notifications")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> putNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user) {
+    public ResponseEntity<?> patchNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from("notifySetting", userAccountUseCase.activateNotification(user.getUserId(), type)));
     }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -3,9 +3,11 @@ package kr.co.pennyway.api.apis.users.controller;
 import jakarta.validation.constraints.NotBlank;
 import kr.co.pennyway.api.apis.users.api.UserAccountApi;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
+import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
 import kr.co.pennyway.api.apis.users.usecase.UserAccountUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -38,5 +40,12 @@ public class UserAccountController implements UserAccountApi {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getMyAccount(@AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from("user", userAccountUseCase.getMyAccount(user.getUserId())));
+    }
+
+    @Override
+    @PutMapping("/notifications")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> putNotifySetting(@RequestParam NotifySetting.NotifyType type, @RequestBody @Validated UserProfileDto.NotifySettingReq request, @AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(SuccessResponse.from("notifySetting", userAccountUseCase.putNotifySetting(user.getUserId(), type, request)));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileUpdateDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileUpdateDto.java
@@ -1,0 +1,28 @@
+package kr.co.pennyway.api.apis.users.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
+
+public class UserProfileUpdateDto {
+    @Schema(title = "사용자 알림 설정 응답 DTO")
+    public record NotifySettingUpdateReq(
+            @Schema(description = "계좌 알림 설정", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Boolean accountBookNotify,
+            @Schema(description = "피드 알림 설정", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Boolean feedNotify,
+            @Schema(description = "채팅 알림 설정", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Boolean chatNotify
+    ) {
+        public static NotifySettingUpdateReq of(NotifySetting.NotifyType type, Boolean flag) {
+            return switch (type) {
+                case ACCOUNT_BOOK -> new NotifySettingUpdateReq(flag, null, null);
+                case FEED -> new NotifySettingUpdateReq(null, flag, null);
+                case CHAT -> new NotifySettingUpdateReq(null, null, flag);
+            };
+        }
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
@@ -1,0 +1,18 @@
+package kr.co.pennyway.api.apis.users.service;
+
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserProfileUpdateService {
+    @Transactional
+    public void updateNotifySetting(User user, NotifySetting.NotifyType type, Boolean flag) {
+        user.getNotifySetting().updateNotifySetting(type, flag);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.users.usecase;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
 import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
+import kr.co.pennyway.api.apis.users.service.UserProfileUpdateService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.device.domain.Device;
 import kr.co.pennyway.domain.domains.device.exception.DeviceErrorCode;
@@ -24,6 +25,7 @@ public class UserAccountUseCase {
     private final UserService userService;
     private final DeviceService deviceService;
 
+    private final UserProfileUpdateService userProfileUpdateService;
     private final DeviceRegisterService deviceRegisterService;
 
     @Transactional
@@ -57,14 +59,14 @@ public class UserAccountUseCase {
     public void activateNotification(Long userId, NotifySetting.NotifyType type) {
         User user = readUserOrThrow(userId);
 
-        user.activateNotifySetting(type);
+        userProfileUpdateService.updateNotifySetting(user, type, Boolean.TRUE);
     }
 
     @Transactional
     public void deactivateNotification(Long userId, NotifySetting.NotifyType type) {
         User user = readUserOrThrow(userId);
 
-        user.deactivateNotifySetting(type);
+        userProfileUpdateService.updateNotifySetting(user, type, Boolean.FALSE);
     }
 
     private User readUserOrThrow(Long userId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -28,9 +28,7 @@ public class UserAccountUseCase {
 
     @Transactional
     public DeviceDto.RegisterRes registerDevice(Long userId, DeviceDto.RegisterReq request) {
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
+        User user = readUserOrThrow(userId);
 
         Device device = deviceRegisterService.createOrUpdateDevice(user, request);
 
@@ -39,9 +37,7 @@ public class UserAccountUseCase {
 
     @Transactional
     public void unregisterDevice(Long userId, String token) {
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
+        User user = readUserOrThrow(userId);
 
         Device device = deviceService.readDeviceByUserIdAndToken(user.getId(), token).orElseThrow(
                 () -> new DeviceErrorException(DeviceErrorCode.NOT_FOUND_DEVICE)
@@ -52,28 +48,28 @@ public class UserAccountUseCase {
 
     @Transactional(readOnly = true)
     public UserProfileDto getMyAccount(Long userId) {
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
+        User user = readUserOrThrow(userId);
 
         return UserProfileDto.from(user);
     }
 
     @Transactional
     public void activateNotification(Long userId, NotifySetting.NotifyType type) {
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
+        User user = readUserOrThrow(userId);
 
         user.activateNotifySetting(type);
     }
 
     @Transactional
     public void deactivateNotification(Long userId, NotifySetting.NotifyType type) {
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
+        User user = readUserOrThrow(userId);
 
         user.deactivateNotifySetting(type);
+    }
+
+    private User readUserOrThrow(Long userId) {
+        return userService.readUser(userId).orElseThrow(
+                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
+        );
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -8,6 +8,7 @@ import kr.co.pennyway.domain.domains.device.domain.Device;
 import kr.co.pennyway.domain.domains.device.exception.DeviceErrorCode;
 import kr.co.pennyway.domain.domains.device.exception.DeviceErrorException;
 import kr.co.pennyway.domain.domains.device.service.DeviceService;
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
@@ -56,5 +57,23 @@ public class UserAccountUseCase {
         );
 
         return UserProfileDto.from(user);
+    }
+
+    @Transactional
+    public void activateNotification(Long userId, NotifySetting.NotifyType type) {
+        User user = userService.readUser(userId).orElseThrow(
+                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
+        );
+
+        user.activateNotifySetting(type);
+    }
+
+    @Transactional
+    public void deactivateNotification(Long userId, NotifySetting.NotifyType type) {
+        User user = userService.readUser(userId).orElseThrow(
+                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
+        );
+
+        user.deactivateNotifySetting(type);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.users.usecase;
 
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
+import kr.co.pennyway.api.apis.users.dto.UserProfileUpdateDto;
 import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
 import kr.co.pennyway.api.apis.users.service.UserProfileUpdateService;
 import kr.co.pennyway.common.annotation.UseCase;
@@ -56,17 +57,19 @@ public class UserAccountUseCase {
     }
 
     @Transactional
-    public void activateNotification(Long userId, NotifySetting.NotifyType type) {
+    public UserProfileUpdateDto.NotifySettingUpdateReq activateNotification(Long userId, NotifySetting.NotifyType type) {
         User user = readUserOrThrow(userId);
 
         userProfileUpdateService.updateNotifySetting(user, type, Boolean.TRUE);
+        return UserProfileUpdateDto.NotifySettingUpdateReq.of(type, Boolean.TRUE);
     }
 
     @Transactional
-    public void deactivateNotification(Long userId, NotifySetting.NotifyType type) {
+    public UserProfileUpdateDto.NotifySettingUpdateReq deactivateNotification(Long userId, NotifySetting.NotifyType type) {
         User user = readUserOrThrow(userId);
 
         userProfileUpdateService.updateNotifySetting(user, type, Boolean.FALSE);
+        return UserProfileUpdateDto.NotifySettingUpdateReq.of(type, Boolean.FALSE);
     }
 
     private User readUserOrThrow(Long userId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/converter/NotifyTypeConverter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/converter/NotifyTypeConverter.java
@@ -1,0 +1,17 @@
+package kr.co.pennyway.api.common.converter;
+
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
+import org.springframework.core.convert.converter.Converter;
+
+public class NotifyTypeConverter implements Converter<String, NotifySetting.NotifyType> {
+    @Override
+    public NotifySetting.NotifyType convert(String type) {
+        try {
+            return NotifySetting.NotifyType.valueOf(type.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new UserErrorException(UserErrorCode.INVALID_NOTIFY_TYPE);
+        }
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/WebConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/WebConfig.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.api.config;
 
+import kr.co.pennyway.api.common.converter.NotifyTypeConverter;
 import kr.co.pennyway.api.common.converter.ProviderConverter;
 import kr.co.pennyway.api.common.converter.VerificationTypeConverter;
 import org.springframework.context.annotation.Configuration;
@@ -13,5 +14,6 @@ public class WebConfig implements WebMvcConfigurer {
 
         registrar.addConverter(new ProviderConverter());
         registrar.addConverter(new VerificationTypeConverter());
+        registrar.addConverter(new NotifyTypeConverter());
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.users.usecase;
 import jakarta.persistence.EntityManager;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
+import kr.co.pennyway.api.apis.users.service.UserProfileUpdateService;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.api.config.fixture.DeviceFixture;
 import kr.co.pennyway.domain.config.JpaConfig;
@@ -33,7 +34,7 @@ import static org.springframework.test.util.AssertionErrors.*;
 
 @ExtendWith(MockitoExtension.class)
 @DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create")
-@ContextConfiguration(classes = {JpaConfig.class, UserAccountUseCase.class, DeviceRegisterService.class, UserService.class, DeviceService.class})
+@ContextConfiguration(classes = {JpaConfig.class, UserAccountUseCase.class, DeviceRegisterService.class, UserService.class, DeviceService.class, UserProfileUpdateService.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
 class UserAccountUseCaseTest extends ExternalApiDBTestConfig {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/NotifySetting.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/NotifySetting.java
@@ -41,7 +41,7 @@ public class NotifySetting {
         }
     }
 
-    enum NotifyType {
+    public enum NotifyType {
         ACCOUNT_BOOK, FEED, CHAT
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/NotifySetting.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/NotifySetting.java
@@ -32,4 +32,16 @@ public class NotifySetting {
                 .chatNotify(chatNotify)
                 .build();
     }
+
+    public void updateNotifySetting(NotifyType notifyType, Boolean notify) {
+        switch (notifyType) {
+            case ACCOUNT_BOOK -> this.accountBookNotify = notify;
+            case FEED -> this.feedNotify = notify;
+            case CHAT -> this.chatNotify = notify;
+        }
+    }
+
+    enum NotifyType {
+        ACCOUNT_BOOK, FEED, CHAT
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/NotifySetting.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/NotifySetting.java
@@ -33,11 +33,11 @@ public class NotifySetting {
                 .build();
     }
 
-    public void updateNotifySetting(NotifyType notifyType, Boolean notify) {
+    public void updateNotifySetting(NotifyType notifyType, Boolean flag) {
         switch (notifyType) {
-            case ACCOUNT_BOOK -> this.accountBookNotify = notify;
-            case FEED -> this.feedNotify = notify;
-            case CHAT -> this.chatNotify = notify;
+            case ACCOUNT_BOOK -> this.accountBookNotify = flag;
+            case FEED -> this.feedNotify = flag;
+            case CHAT -> this.chatNotify = flag;
         }
     }
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 public enum UserErrorCode implements BaseErrorCode {
     /* 400 BAD_REQUEST */
     ALREADY_SIGNUP(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "이미 회원가입한 유저입니다."),
-    INVALID_NOTIFY_TYPE(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "유효하지 않은 알림 타입입니다."),
 
     /* 401 UNAUTHORIZED */
     NOT_MATCHED_PASSWORD(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS, "비밀번호가 일치하지 않습니다."),
@@ -20,7 +19,10 @@ public enum UserErrorCode implements BaseErrorCode {
     ALREADY_WITHDRAWAL(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "이미 탈퇴한 유저입니다."),
 
     /* 404 NOT_FOUND */
-    NOT_FOUND(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "유저를 찾을 수 없습니다.");
+    NOT_FOUND(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "유저를 찾을 수 없습니다."),
+
+    /* 422 UNPROCESSABLE_ENTITY */
+    INVALID_NOTIFY_TYPE(StatusCode.UNPROCESSABLE_CONTENT, ReasonCode.TYPE_MISMATCH_ERROR_IN_REQUEST_BODY, "유효하지 않은 알림 타입입니다.");
 
     private final StatusCode statusCode;
     private final ReasonCode reasonCode;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum UserErrorCode implements BaseErrorCode {
     /* 400 BAD_REQUEST */
     ALREADY_SIGNUP(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "이미 회원가입한 유저입니다."),
+    INVALID_NOTIFY_TYPE(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "유효하지 않은 알림 타입입니다."),
 
     /* 401 UNAUTHORIZED */
     NOT_MATCHED_PASSWORD(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS, "비밀번호가 일치하지 않습니다."),


### PR DESCRIPTION
## 작업 이유
- 사용자 알림 on/off API 구현

<br/>

## 작업 사항
- 기존에 상의한 대로 활성화는 `PUT`, 비활성화는 `DELETE` 요청을 보내도록 했습니다!
- QueryParameter로는 `NotifySetting` Embedded 클래스 내에 정의한 열거 타입 `NotifyType`을 사용했습니다.  
- 테스트 케이스를 작성하려다가...이전 PR하고 거하게 충돌나버릴 것 같아서 ㅎㅎ 병합 후에 따로 PR 작성해서 쓰겠습니다.
   - 정상 동작은 확인했으나, 테케가 없어서 증명이 어렵네요 ㅜ

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 요청 경로 및 url이 적절한지?

<br/>

## 발견한 이슈
- 없음

