### PR TITLE
🐛 아이디 찾기 API 요청 시 휴대폰 번호 및 인증 코드를 입력하지 않을 경우 INTERNAL_SERVER_ERROR 해결

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthCheckApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthCheckApi.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotBlank;
+import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
 
 @Tag(name = "[계정 검사 API]")
 public interface AuthCheckApi {
@@ -51,5 +51,5 @@ public interface AuthCheckApi {
 							""")
 			})),
 	})
-	ResponseEntity<?> findUsername(@RequestParam @NotBlank String phone, @RequestParam @NotBlank String code);
+	ResponseEntity<?> findUsername(@Validated PhoneVerificationDto.VerifyCodeReq request);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthCheckController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/AuthCheckController.java
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.validation.constraints.NotBlank;
 import kr.co.pennyway.api.apis.auth.api.AuthCheckApi;
+import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
 import kr.co.pennyway.api.apis.auth.usecase.AuthCheckUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +32,7 @@ public class AuthCheckController implements AuthCheckApi {
 
 	@GetMapping("/find/username")
 	@PreAuthorize("isAnonymous()")
-	public ResponseEntity<?> findUsername(@RequestParam @NotBlank String phone, @RequestParam @NotBlank String code) {
-		return ResponseEntity.ok(SuccessResponse.from("user", authCheckUseCase.findUsername(phone, code)));
+	public ResponseEntity<?> findUsername(@Validated PhoneVerificationDto.VerifyCodeReq request) {
+		return ResponseEntity.ok(SuccessResponse.from("user", authCheckUseCase.findUsername(request)));
 	}
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneVerificationDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/PhoneVerificationDto.java
@@ -64,10 +64,6 @@ public class PhoneVerificationDto {
 		public static VerifyCodeReq from(SignUpReq.OauthInfo request) {
 			return new VerifyCodeReq(request.phone(), request.code());
 		}
-
-		public static VerifyCodeReq of(String phone, String code) {
-			return new VerifyCodeReq(phone, code);
-		}
 	}
 
 	@Schema(title = "인증번호 검증 응답 DTO")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/PhoneVerificationService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/PhoneVerificationService.java
@@ -1,5 +1,11 @@
 package kr.co.pennyway.api.apis.auth.service;
 
+import java.time.LocalDateTime;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
 import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
 import kr.co.pennyway.api.common.exception.PhoneVerificationErrorCode;
 import kr.co.pennyway.api.common.exception.PhoneVerificationException;
@@ -8,62 +14,58 @@ import kr.co.pennyway.domain.common.redis.phone.PhoneCodeService;
 import kr.co.pennyway.infra.common.event.PushCodeEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
-import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class PhoneVerificationService {
-    private final PhoneCodeService phoneCodeService;
-    private final ApplicationEventPublisher eventPublisher;
+	private final PhoneCodeService phoneCodeService;
+	private final ApplicationEventPublisher eventPublisher;
 
-    /**
-     * 휴대폰 번호로 인증 코드를 발송하고 캐싱한다. (5분간 유효)
-     *
-     * @param request  {@link PhoneVerificationDto.PushCodeReq}
-     * @param codeType {@link PhoneCodeKeyType}
-     * @return {@link PhoneVerificationDto.PushCodeRes}
-     */
-    public PhoneVerificationDto.PushCodeRes sendCode(PhoneVerificationDto.PushCodeReq request, PhoneCodeKeyType codeType) {
-        String code = issueVerificationCode();
-        LocalDateTime expiresAt = phoneCodeService.create(request.phone(), code, codeType);
+	/**
+	 * 휴대폰 번호로 인증 코드를 발송하고 캐싱한다. (5분간 유효)
+	 *
+	 * @param request  {@link PhoneVerificationDto.PushCodeReq}
+	 * @param codeType {@link PhoneCodeKeyType}
+	 * @return {@link PhoneVerificationDto.PushCodeRes}
+	 */
+	public PhoneVerificationDto.PushCodeRes sendCode(PhoneVerificationDto.PushCodeReq request, PhoneCodeKeyType codeType) {
+		String code = issueVerificationCode();
+		LocalDateTime expiresAt = phoneCodeService.create(request.phone(), code, codeType);
 
-        eventPublisher.publishEvent(PushCodeEvent.of(request.phone(), code));
+		eventPublisher.publishEvent(PushCodeEvent.of(request.phone(), code));
 
-        return PhoneVerificationDto.PushCodeRes.of(request.phone(), LocalDateTime.now(), expiresAt);
-    }
+		return PhoneVerificationDto.PushCodeRes.of(request.phone(), LocalDateTime.now(), expiresAt);
+	}
 
-    /**
-     * 휴대폰 번호로 인증 코드를 확인한다.
-     *
-     * @param request  {@link PhoneVerificationDto.VerifyCodeReq}
-     * @param codeType {@link PhoneCodeKeyType}
-     * @return Boolean : 인증 코드가 유효한지 여부 (TRUE: 유효, 실패하는 경우 예외가 발생하므로 FALSE가 반환되지 않음)
-     * @throws PhoneVerificationException : 전화번호가 만료되었거나 유효하지 않은 경우(EXPIRED_OR_INVALID_PHONE), 인증 코드가 유효하지 않은 경우(IS_NOT_VALID_CODE)
-     */
-    public Boolean isValidCode(PhoneVerificationDto.VerifyCodeReq request, PhoneCodeKeyType codeType) {
-        String expectedCode;
-        try {
-            expectedCode = phoneCodeService.readByPhone(request.phone(), codeType);
-        } catch (IllegalArgumentException e) {
-            throw new PhoneVerificationException(PhoneVerificationErrorCode.EXPIRED_OR_INVALID_PHONE);
-        }
+	/**
+	 * 휴대폰 번호로 인증 코드를 확인한다.
+	 *
+	 * @param request  {@link PhoneVerificationDto.VerifyCodeReq}
+	 * @param codeType {@link PhoneCodeKeyType}
+	 * @return Boolean : 인증 코드가 유효한지 여부 (TRUE: 유효, 실패하는 경우 예외가 발생하므로 FALSE가 반환되지 않음)
+	 * @throws PhoneVerificationException : 전화번호가 만료되었거나 유효하지 않은 경우(EXPIRED_OR_INVALID_PHONE), 인증 코드가 유효하지 않은 경우(IS_NOT_VALID_CODE)
+	 */
+	public Boolean isValidCode(PhoneVerificationDto.VerifyCodeReq request, PhoneCodeKeyType codeType) throws IllegalArgumentException {
+		String expectedCode;
+		try {
+			expectedCode = phoneCodeService.readByPhone(request.phone(), codeType);
+		} catch (IllegalArgumentException e) {
+			throw new PhoneVerificationException(PhoneVerificationErrorCode.EXPIRED_OR_INVALID_PHONE);
+		}
 
-        if (!expectedCode.equals(request.code()))
-            throw new PhoneVerificationException(PhoneVerificationErrorCode.IS_NOT_VALID_CODE);
-        return Boolean.TRUE;
-    }
+		if (!expectedCode.equals(request.code()))
+			throw new PhoneVerificationException(PhoneVerificationErrorCode.IS_NOT_VALID_CODE);
 
-    private String issueVerificationCode() {
-        StringBuilder sb = new StringBuilder();
+		return Boolean.TRUE;
+	}
 
-        for (int i = 0; i < 6; i++) {
-            sb.append(ThreadLocalRandom.current().nextInt(0, 10));
-        }
-        return sb.toString();
-    }
+	private String issueVerificationCode() {
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < 6; i++) {
+			sb.append(ThreadLocalRandom.current().nextInt(0, 10));
+		}
+		return sb.toString();
+	}
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthCheckUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthCheckUseCase.java
@@ -28,9 +28,9 @@ public class AuthCheckUseCase {
 	}
 
 	@Transactional(readOnly = true)
-	public AuthFindDto.FindUsernameRes findUsername(String phone, String code) {
-		phoneVerificationService.isValidCode(PhoneVerificationDto.VerifyCodeReq.of(phone, code), PhoneCodeKeyType.FIND_USERNAME);
-		phoneCodeService.delete(phone, PhoneCodeKeyType.FIND_USERNAME);
-		return authFindService.findUsername(phone);
+	public AuthFindDto.FindUsernameRes findUsername(PhoneVerificationDto.VerifyCodeReq request) {
+		phoneVerificationService.isValidCode(request, PhoneCodeKeyType.FIND_USERNAME);
+		phoneCodeService.delete(request.phone(), PhoneCodeKeyType.FIND_USERNAME);
+		return authFindService.findUsername(request.phone());
 	}
 }


### PR DESCRIPTION
## 작업 이유

- 아이디 찾기 API 요청 시 `phone`과 `code`의 값이 넘어오지 않음

  <img width="429" alt="image" src="https://github.com/CollaBu/pennyway-was/assets/68031450/37d25e19-c433-4e4b-8211-a2443d74547d">

<br/>

## 작업 사항

- 기존에는 Controller의 인자를 각각 `String`에서 받아왔으나, `DTO`로 받아오도록 변경하였음
- 아이디 찾기 API 요청 시 `phone`과 `code`의 값이 넘어오지 않는 테스트 케이스 추가

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- 수정 후 결과 (`phone`과 `code`의 값을 입력하지 않았을 경우)
   <img width="435" alt="image" src="https://github.com/CollaBu/pennyway-was/assets/68031450/fd7ab4a7-7472-4138-b211-c0f96f65221c">

<br/>

## 발견한 이슈

- `@RequestParam`과 같이, 인자를 `query-string`으로 선언하는 어노테이션을 별도로 명시하지 않았으나 `query-string`으로 처리됨
  - 이에 대한 이유 분석 필요