### PR TITLE
🐛 RTR 오동작 검증 (아무 문제 없었다..)

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
@@ -92,9 +92,6 @@ public class JwtAuthHelper {
         String role = getClaimsValue(claims, RefreshTokenClaimKeys.ROLE.getValue(), String.class);
         log.debug("refresh token userId : {}, role : {}", userId, role);
 
-        String newAccessToken = accessTokenProvider.generateToken(AccessTokenClaim.of(userId, role));
-        log.debug("new access token : {}", newAccessToken);
-
         RefreshToken newRefreshToken;
         try {
             newRefreshToken = refreshTokenService.refresh(userId, refreshToken, refreshTokenProvider.generateToken(RefreshTokenClaim.of(userId, role)));
@@ -104,6 +101,9 @@ public class JwtAuthHelper {
         } catch (IllegalStateException e) {
             throw new JwtErrorException(JwtErrorCode.TAKEN_AWAY_TOKEN);
         }
+
+        String newAccessToken = accessTokenProvider.generateToken(AccessTokenClaim.of(userId, role));
+        log.debug("new access token : {}", newAccessToken);
 
         return Pair.of(userId, Jwts.of(newAccessToken, newRefreshToken.getToken()));
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelperTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelperTest.java
@@ -1,0 +1,82 @@
+package kr.co.pennyway.api.apis.auth.helper;
+
+import kr.co.pennyway.api.common.security.jwt.Jwts;
+import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
+import kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaim;
+import kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenProvider;
+import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
+import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
+import kr.co.pennyway.domain.common.redis.refresh.RefreshToken;
+import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenRepository;
+import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenService;
+import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenServiceImpl;
+import kr.co.pennyway.domain.config.RedisConfig;
+import kr.co.pennyway.domain.config.RedisUnitTest;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+@RedisUnitTest
+@DataRedisTest(properties = "spring.config.location=classpath:application-domain.yml")
+@ContextConfiguration(classes = {RedisConfig.class, JwtAuthHelper.class})
+@ActiveProfiles("test")
+public class JwtAuthHelperTest extends ExternalApiDBTestConfig {
+    @Autowired
+    private JwtAuthHelper jwtAuthHelper;
+
+    private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @MockBean
+    private AccessTokenProvider accessTokenProvider;
+
+    @MockBean
+    private RefreshTokenProvider refreshTokenProvider;
+
+    @MockBean
+    private ForbiddenTokenService forbiddenTokenService;
+
+    @BeforeEach
+    void setUp() {
+        this.refreshTokenService = new RefreshTokenServiceImpl(refreshTokenRepository);
+    }
+
+    @Test
+    public void RefreshTokenRefreshSuccess() {
+        // given
+        RefreshToken refreshToken = RefreshToken.builder()
+                .userId(1L)
+                .token("refreshToken")
+                .ttl(1000L)
+                .build();
+        refreshTokenRepository.save(refreshToken);
+        given(refreshTokenProvider.getJwtClaimsFromToken(refreshToken.getToken())).willReturn(RefreshTokenClaim.of(refreshToken.getUserId(), refreshToken.getToken()));
+        given(accessTokenProvider.generateToken(any())).willReturn("newAccessToken");
+        given(refreshTokenProvider.generateToken(any())).willReturn("newRefreshToken");
+
+        // when
+        Pair<Long, Jwts> jwts = jwtAuthHelper.refresh(refreshToken.getToken());
+
+        // then
+        assertEquals("사용자 아이디가 일치하지 않습니다.", refreshToken.getUserId(), jwts.getLeft());
+        assertEquals("갱신된 액세스 토큰이 일치하지 않습니다.", "newAccessToken", jwts.getRight().accessToken());
+        assertEquals("리프레시 토큰이 갱신되지 않았습니다.", "newRefreshToken", jwts.getRight().refreshToken());
+        log.info("갱신된 리프레시 토큰 정보 : {}", refreshTokenRepository.findById(refreshToken.getUserId()).orElse(null));
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/config/RedisUnitTest.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/config/RedisUnitTest.java
@@ -1,0 +1,16 @@
+package kr.co.pennyway.domain.config;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ComponentScan(basePackages = "kr.co.pennyway.domain.common.redis")
+@EnableAutoConfiguration
+@EnableRedisRepositories(basePackages = "kr.co.pennyway.domain.common.redis")
+@Documented
+public @interface RedisUnitTest {
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceUnitTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceUnitTest.java
@@ -1,0 +1,49 @@
+package kr.co.pennyway.domain.common.redis.refresh;
+
+import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenRepository;
+import kr.co.pennyway.domain.config.ContainerRedisTestConfig;
+import kr.co.pennyway.domain.config.RedisConfig;
+import kr.co.pennyway.domain.config.RedisUnitTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+@Slf4j
+@RedisUnitTest
+@DataRedisTest(properties = "spring.config.location=classpath:application-domain.yml")
+@ContextConfiguration(classes = {RedisConfig.class})
+@ActiveProfiles("test")
+public class RefreshTokenServiceUnitTest extends ContainerRedisTestConfig {
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+    @Autowired
+    private ForbiddenTokenRepository forbiddenTokenRepository;
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void setUp() {
+        this.refreshTokenService = new RefreshTokenServiceImpl(refreshTokenRepository);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 저장 테스트")
+    void saveTest() {
+        // given
+        RefreshToken refreshToken = RefreshToken.builder()
+                .userId(1L)
+                .token("refreshToken")
+                .ttl(1000L)
+                .build();
+
+        // when
+        refreshTokenService.save(refreshToken);
+
+        // then
+        log.info("test : {}", refreshTokenRepository.findById(1L));
+    }
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceUnitTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceUnitTest.java
@@ -1,6 +1,5 @@
 package kr.co.pennyway.domain.common.redis.refresh;
 
-import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenRepository;
 import kr.co.pennyway.domain.config.ContainerRedisTestConfig;
 import kr.co.pennyway.domain.config.RedisConfig;
 import kr.co.pennyway.domain.config.RedisUnitTest;
@@ -23,8 +22,6 @@ import static org.springframework.test.util.AssertionErrors.assertEquals;
 public class RefreshTokenServiceUnitTest extends ContainerRedisTestConfig {
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
-    @Autowired
-    private ForbiddenTokenRepository forbiddenTokenRepository;
     private RefreshTokenService refreshTokenService;
 
     @BeforeEach

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceUnitTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceUnitTest.java
@@ -13,6 +13,8 @@ import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
 @Slf4j
 @RedisUnitTest
 @DataRedisTest(properties = "spring.config.location=classpath:application-domain.yml")
@@ -44,6 +46,28 @@ public class RefreshTokenServiceUnitTest extends ContainerRedisTestConfig {
         refreshTokenService.save(refreshToken);
 
         // then
-        log.info("test : {}", refreshTokenRepository.findById(1L));
+        RefreshToken savedRefreshToken = refreshTokenRepository.findById(1L).orElse(null);
+        assertEquals("저장된 리프레시 토큰이 일치하지 않습니다.", refreshToken, savedRefreshToken);
+        log.info("저장된 리프레시 토큰 정보 : {}", savedRefreshToken);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 갱신 테스트")
+    void refreshTest() {
+        // given
+        RefreshToken refreshToken = RefreshToken.builder()
+                .userId(1L)
+                .token("refreshToken")
+                .ttl(1000L)
+                .build();
+        refreshTokenService.save(refreshToken);
+
+        // when
+        refreshTokenService.refresh(1L, "refreshToken", "newRefreshToken");
+
+        // then
+        RefreshToken savedRefreshToken = refreshTokenRepository.findById(1L).orElse(null);
+        assertEquals("갱신된 리프레시 토큰이 일치하지 않습니다.", "newRefreshToken", savedRefreshToken.getToken());
+        log.info("갱신된 리프레시 토큰 정보 : {}", savedRefreshToken);
     }
 }


### PR DESCRIPTION
## 작업 이유
- Swagger로 Refresh 요청 시, 동일 토큰으로 무한번 요청이 성공하는 이슈 발생
- 테스트 케이스로 문제점을 확인하고 수정...하려 했으나...

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/14ea7619-e4d9-4572-8f13-503745aa378c" width="500px"/>
</div>

이번 작업 한 장 요약

<br/>

## 작업 사항
### 🤔 RTR(Refresh Token Refresh)이란?
- 수명이 긴 Refresh Token이 탈취될 시, 공격자는 유효한 Access Token을 소유할 수 있게 됨.
- 따라서 유효한 Refresh Token을 `{userId : RefreshToken}` 쌍으로 서버에서 관리함.
- 사용자가 유효한 refresh token으로 access token을 재발급 요청하면, "Refresh Token"도 재발급하는 방식
- 만약 해당 사용자 id로 다른 refresh token이 서버에 저장되어 있으면, refresh 요청 시 토큰이 탈취되었다고 판단하여 캐시에서 제거. 정상 유저든 해커든 다시 로그인하도록 처리함.

<br/>

### 1️⃣ Domain 모듈의 `RefreshTokenService` 단위 테스트

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/d064a57b-2daa-4f39-8b6d-89eb859fd25f" width="700px"/>
</div>

- 처음엔 당연히 재발급된 RT가 저장이 안 되고 있다고 생각하여 Redis 쪽을 테스트함.
- 그러나 아무런 문제가 없고, 모든 테스트에 통과함.

<br/>

### 2️⃣ Api 모듈의 `JwtAuthHelper` 단위 테스트

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/fb42650a-c40a-444f-8171-36d9c02e462a" width="700px"/>
</div>

- external-api 모듈 쪽을 테스트해봐도 너무 잘 동작하고 있음....

<br/>

### 3️⃣ 포스트맨 실행 결과

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/49ef9488-b245-4282-968a-c38841b771ca" width="700px"/>
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/21a5a40a-a172-4631-9d14-de25fb05c5ea" width="700px"/>
</div>

- 띠옹? Swagger에서는 안 되던 게 Postman으로 요청해보니 아무런 문제가 없음.

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/dd5d031b-1ed4-4d98-93f6-1c9519a42bf7" width="700px"/>
</div>

- 알고보니 Swagger에서 RT를 사용자가 직접 입력하도록 넣어놨는데, 이 값이 전달되지 않고 브라우저에 저장된 RT가 나가고 있었기 때문 ㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎ....

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 이번 기회에 redis 단위 테스트 편의를 위해 `@RedisUnitTest`를 만들었습니다.
   - `@DataRedisTest`와 `@ContextConfiguration`는 어노테이션에 선언이 안 돼서, 따로 써줘야 해요. 셋이 세트입니다!
- Redis 단위 테스트 하는데 저게 맞나...너무 마구잡이로 어노테이션 때려 넣은 거 같아서 나중에 문제 생길 수도 있어요.
   - 그런데 저렇게 안 하면 계속 빈 주입이 안 돼서, 일단 돌아가게 만드느라 저 꼴이 났습니다.

<br/>

## 발견한 이슈
- 없음

<br/>

## 이슈 연결
close #65 
