### PR TITLE
✨ 인증된 사용자의 소셜 계정 연동 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/AuthApi.java
@@ -46,14 +46,6 @@ public interface AuthApi {
                             }
                             """)
             })),
-            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "일반 회원가입 계정이 이미 존재함", value = """
-                            {
-                                "code": "4004",
-                                "message": "이미 회원가입한 유저입니다."
-                            }
-                            """)
-            })),
             @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(name = "검증 실패", value = """
                             {
@@ -67,6 +59,14 @@ public interface AuthApi {
                             {
                                 "code": "4042",
                                 "message": "만료되었거나 등록되지 않은 휴대폰 정보입니다."
+                            }
+                            """)
+            })),
+            @ApiResponse(responseCode = "409", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "일반 회원가입 계정이 이미 존재함", value = """
+                            {
+                                "code": "4091",
+                                "message": "이미 회원가입한 유저입니다."
                             }
                             """)
             }))

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/OauthApi.java
@@ -89,14 +89,6 @@ public interface OauthApi {
                             }
                             """)
             })),
-            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "해당 provider로 로그인한 이력이 이미 존재함", value = """
-                            {
-                                "code": "4004",
-                                "message": "이미 해당 제공자로 가입된 사용자입니다."
-                            }
-                            """)
-            })),
             @ApiResponse(responseCode = "401", content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(name = "인증코드 불일치", value = """
                             {
@@ -112,7 +104,15 @@ public interface OauthApi {
                                 "message": "만료되었거나 등록되지 않은 휴대폰 정보입니다."
                             }
                             """),
-            }))
+            })),
+            @ApiResponse(responseCode = "409", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "해당 provider로 로그인한 이력이 이미 존재함", value = """
+                            {
+                                "code": "4091",
+                                "message": "이미 해당 제공자로 가입된 사용자입니다."
+                            }
+                            """)
+            })),
     })
     ResponseEntity<?> verifyCode(@RequestParam Provider provider, @RequestBody @Validated PhoneVerificationDto.VerifyCodeReq request);
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -63,7 +63,7 @@ public interface UserAuthApi {
             @AuthenticationPrincipal SecurityUserDetails user
     );
 
-    @Operation(summary = "소셜 계정 연동")
+    @Operation(summary = "소셜 계정 연동", description = "인증된 사용자의 소셜 계정을 연동한다. 이미 연동된 계정이 있는 경우에는 409 에러를 반환한다. 미인증 사용자는 해당 API를 사용할 수 없다.")
     @Parameter(name = "provider", description = "소셜 제공자", examples = {
             @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
     }, required = true, in = ParameterIn.QUERY)

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -13,11 +13,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "[사용자 인증 관리 API]", description = "사용자의 인증과 관련된 UseCase(로그아웃, 소셜 계정 연동/해지 등)를 제공하는 API")
 public interface UserAuthApi {
@@ -57,4 +61,10 @@ public interface UserAuthApi {
             @CookieValue(value = "refreshToken", required = false) String refreshToken,
             @AuthenticationPrincipal SecurityUserDetails user
     );
+
+    @Operation(summary = "소셜 계정 연동")
+    @Parameter(name = "provider", description = "소셜 제공자", examples = {
+            @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
+    }, required = true, in = ParameterIn.QUERY)
+    ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated OauthLinkReq request, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
+import kr.co.pennyway.api.apis.auth.dto.SignInReq;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import org.springframework.http.ResponseEntity;
@@ -66,5 +67,5 @@ public interface UserAuthApi {
     @Parameter(name = "provider", description = "소셜 제공자", examples = {
             @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
     }, required = true, in = ParameterIn.QUERY)
-    ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated OauthLinkReq request, @AuthenticationPrincipal SecurityUserDetails user);
+    ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated SignInReq.Oauth request, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -67,5 +67,13 @@ public interface UserAuthApi {
     @Parameter(name = "provider", description = "소셜 제공자", examples = {
             @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
     }, required = true, in = ParameterIn.QUERY)
+    @ApiResponse(responseCode = "409", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "해당 provider로 로그인한 이력이 이미 존재함", value = """
+                    {
+                        "code": "4091",
+                        "message": "이미 해당 제공자로 가입된 사용자입니다."
+                    }
+                    """)
+    }))
     ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated SignInReq.Oauth request, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -24,12 +24,14 @@ public class UserAuthController implements UserAuthApi {
     private final UserAuthUseCase userAuthUseCase;
     private final CookieUtil cookieUtil;
 
+    @Override
     @GetMapping("/auth")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getAuthState(@RequestHeader(value = "Authorization") String authHeader) {
         return ResponseEntity.ok(SuccessResponse.from("user", userAuthUseCase.isSignIn(authHeader)));
     }
 
+    @Override
     @GetMapping("/sign-out")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> signOut(
@@ -46,6 +48,7 @@ public class UserAuthController implements UserAuthApi {
 
     @Override
     @PostMapping("/link-oauth")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated SignInReq.Oauth request, @AuthenticationPrincipal SecurityUserDetails user) {
         userAuthUseCase.linkOauth(provider, request, user.getUserId());
         return ResponseEntity.ok(SuccessResponse.noContent());

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.auth.controller;
 
 import kr.co.pennyway.api.apis.auth.api.UserAuthApi;
+import kr.co.pennyway.api.apis.auth.dto.SignInReq;
 import kr.co.pennyway.api.apis.auth.usecase.UserAuthUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
@@ -45,7 +46,7 @@ public class UserAuthController implements UserAuthApi {
 
     @Override
     @PostMapping("/link-oauth")
-    public ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated OauthLinkReq request, @AuthenticationPrincipal SecurityUserDetails user) {
+    public ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated SignInReq.Oauth request, @AuthenticationPrincipal SecurityUserDetails user) {
         userAuthUseCase.linkOauth(provider, request, user.getUserId());
         return ResponseEntity.ok(SuccessResponse.noContent());
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -5,12 +5,14 @@ import kr.co.pennyway.api.apis.auth.usecase.UserAuthUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import kr.co.pennyway.api.common.util.CookieUtil;
+import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -39,5 +41,12 @@ public class UserAuthController implements UserAuthApi {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookieUtil.deleteCookie("refreshToken").toString())
                 .body(SuccessResponse.noContent());
+    }
+
+    @Override
+    @PostMapping("/link-oauth")
+    public ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated OauthLinkReq request, @AuthenticationPrincipal SecurityUserDetails user) {
+        userAuthUseCase.linkOauth(provider, request, user.getUserId());
+        return ResponseEntity.ok(SuccessResponse.noContent());
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -47,7 +47,7 @@ public class UserAuthController implements UserAuthApi {
     }
 
     @Override
-    @PostMapping("/link-oauth")
+    @PutMapping("/link-oauth")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated SignInReq.Oauth request, @AuthenticationPrincipal SecurityUserDetails user) {
         userAuthUseCase.linkOauth(provider, request, user.getUserId());

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
@@ -1,5 +1,8 @@
 package kr.co.pennyway.api.apis.auth.dto;
 
+import kr.co.pennyway.domain.domains.oauth.type.Provider;
+import kr.co.pennyway.domain.domains.user.domain.User;
+
 /**
  * 전화번호 검증 후, 시나리오 분기 정보를 위한 DTO
  */
@@ -8,24 +11,37 @@ public record UserSyncDto(
         boolean isSignUpAllowed,
         boolean isExistAccount,
         Long userId,
-        String username
+        String username,
+        /* 계정과 연동하기 위한 oauth 정보. 없다면 null */
+        OauthSync oauthSync
 ) {
     /**
      * @param isSignUpAllowed boolean : 회원가입 시나리오 가능 여부 (true: 회원가입 혹은 계정 연동 가능, false: 불가능)
      * @param isExistAccount  boolean : 이미 존재하는 계정 여부
-     * @param username        boolean : 사용자명 (isExistAccount이 true인 경우에만 존재)
+     * @param user            {@link User} : 사용자 정보
+     * @param oauthSync       {@link OauthSync} : 연동할 Oauth 정보. 없다면 null
      */
-    public static UserSyncDto of(boolean isSignUpAllowed, boolean isExistAccount, Long userId, String username) {
-        return new UserSyncDto(isSignUpAllowed, isExistAccount, userId, username);
+    public static UserSyncDto of(boolean isSignUpAllowed, boolean isExistAccount, User user, OauthSync oauthSync) {
+        return new UserSyncDto(isSignUpAllowed, isExistAccount, user.getId(), user.getUsername(), oauthSync);
     }
 
     /**
      * 이미 회원이 존재하는 경우 사용하는 편의용 메서드. <br/>
-     * 내부에서 {@link UserSyncDto#of(boolean, boolean, Long, String)}를 호출한다.
+     * 내부에서 {@link UserSyncDto#of(boolean, boolean, User, OauthSync)}를 호출한다.
      *
-     * @param username String : 사용자명
+     * @param user {@link User} : 사용자 정보
      */
-    public static UserSyncDto abort(Long userId, String username) {
-        return UserSyncDto.of(false, true, userId, username);
+    public static UserSyncDto abort(User user) {
+        return UserSyncDto.of(false, true, user, null);
+    }
+
+    public record OauthSync(
+            Long id,
+            String oauthId,
+            Provider provider
+    ) {
+        public static OauthSync of(Long id, String oauthId, Provider provider) {
+            return new OauthSync(id, oauthId, provider);
+        }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
@@ -44,6 +44,13 @@ public record UserSyncDto(
         return UserSyncDto.of(true, false, null, null, null);
     }
 
+    /**
+     * 기존의 soft delete된 Oauth 정보가 있는지 확인한다.
+     */
+    public boolean isExistOauthAccount() {
+        return oauthSync != null;
+    }
+
     public record OauthSync(
             Long id,
             String oauthId,

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
@@ -1,6 +1,9 @@
 package kr.co.pennyway.api.apis.auth.dto;
 
+import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
 import kr.co.pennyway.domain.domains.oauth.type.Provider;
+
+import java.time.LocalDateTime;
 
 /**
  * 전화번호 검증 후, 시나리오 분기 정보를 위한 DTO
@@ -44,10 +47,18 @@ public record UserSyncDto(
     public record OauthSync(
             Long id,
             String oauthId,
-            Provider provider
+            Provider provider,
+            LocalDateTime deletedAt
     ) {
-        public static OauthSync of(Long id, String oauthId, Provider provider) {
-            return new OauthSync(id, oauthId, provider);
+        /**
+         * Oauth 정보를 OauthSync로 변환한다. <br/>
+         * Oauth 정보가 없는 경우 null을 반환한다.
+         */
+        public static OauthSync from(Oauth oauth) {
+            if (oauth == null) {
+                return null;
+            }
+            return new OauthSync(oauth.getId(), oauth.getOauthId(), oauth.getProvider(), oauth.getDeletedAt());
         }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
@@ -33,6 +33,14 @@ public record UserSyncDto(
         return UserSyncDto.of(false, true, userId, username, null);
     }
 
+    /**
+     * 회원 가입 이력이 없는 경우 사용하는 편의용 메서드. <br/>
+     * 내부에서 {@link UserSyncDto#of(boolean, boolean, Long, String, OauthSync)}를 호출한다.
+     */
+    public static UserSyncDto signUpAllowed() {
+        return UserSyncDto.of(true, false, null, null, null);
+    }
+
     public record OauthSync(
             Long id,
             String oauthId,

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
@@ -1,7 +1,6 @@
 package kr.co.pennyway.api.apis.auth.dto;
 
 import kr.co.pennyway.domain.domains.oauth.type.Provider;
-import kr.co.pennyway.domain.domains.user.domain.User;
 
 /**
  * 전화번호 검증 후, 시나리오 분기 정보를 위한 DTO
@@ -18,21 +17,20 @@ public record UserSyncDto(
     /**
      * @param isSignUpAllowed boolean : 회원가입 시나리오 가능 여부 (true: 회원가입 혹은 계정 연동 가능, false: 불가능)
      * @param isExistAccount  boolean : 이미 존재하는 계정 여부
-     * @param user            {@link User} : 사용자 정보
+     * @param userId          Long : 사용자 ID. 없다면 null
+     * @param username        String : 사용자 이름. 없다면 null
      * @param oauthSync       {@link OauthSync} : 연동할 Oauth 정보. 없다면 null
      */
-    public static UserSyncDto of(boolean isSignUpAllowed, boolean isExistAccount, User user, OauthSync oauthSync) {
-        return new UserSyncDto(isSignUpAllowed, isExistAccount, user.getId(), user.getUsername(), oauthSync);
+    public static UserSyncDto of(boolean isSignUpAllowed, boolean isExistAccount, Long userId, String username, OauthSync oauthSync) {
+        return new UserSyncDto(isSignUpAllowed, isExistAccount, userId, username, oauthSync);
     }
 
     /**
      * 이미 회원이 존재하는 경우 사용하는 편의용 메서드. <br/>
-     * 내부에서 {@link UserSyncDto#of(boolean, boolean, User, OauthSync)}를 호출한다.
-     *
-     * @param user {@link User} : 사용자 정보
+     * 내부에서 {@link UserSyncDto#of(boolean, boolean, Long, String, OauthSync)}를 호출한다.
      */
-    public static UserSyncDto abort(User user) {
-        return UserSyncDto.of(false, true, user, null);
+    public static UserSyncDto abort(Long userId, String username) {
+        return UserSyncDto.of(false, true, userId, username, null);
     }
 
     public record OauthSync(

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserGeneralSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserGeneralSignService.java
@@ -38,7 +38,7 @@ public class UserGeneralSignService {
 
         if (!isExistUser(user)) {
             log.info("회원가입 이력이 없는 사용자입니다. phone: {}", phone);
-            return UserSyncDto.of(true, false, null, null);
+            return UserSyncDto.signUpAllowed();
         }
 
         if (isGeneralSignUpUser(user.get())) {
@@ -47,7 +47,7 @@ public class UserGeneralSignService {
         }
 
         log.info("소셜 회원가입 사용자입니다. user: {}", user.get());
-        return UserSyncDto.of(true, true, user.get().getId(), user.get().getUsername());
+        return UserSyncDto.of(true, true, user.get().getId(), user.get().getUsername(), null);
     }
 
     /**

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
@@ -3,6 +3,8 @@ package kr.co.pennyway.api.apis.auth.service;
 import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
 import kr.co.pennyway.api.apis.auth.dto.UserSyncDto;
 import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
+import kr.co.pennyway.domain.domains.oauth.exception.OauthErrorCode;
+import kr.co.pennyway.domain.domains.oauth.exception.OauthException;
 import kr.co.pennyway.domain.domains.oauth.service.OauthService;
 import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import kr.co.pennyway.domain.domains.user.domain.User;
@@ -28,6 +30,14 @@ public class UserOauthSignService {
         Optional<Oauth> oauth = oauthService.readOauthByOauthIdAndProvider(oauthId, provider);
 
         return oauth.map(Oauth::getUser).orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public User readUserIfDoesNotExistOauthProvider(Long userId, Provider provider) {
+        if (oauthService.isExistOauthAccount(userId, provider))
+            throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
+
+        return userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
     }
 
     /**

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
@@ -44,7 +44,7 @@ public class UserOauthSignService {
 
         if (user.isEmpty()) {
             log.info("회원가입 이력이 없는 사용자입니다. phone: {}", phone);
-            return UserSyncDto.of(true, false, null, null);
+            return UserSyncDto.signUpAllowed();
         }
 
         if (oauthService.isExistOauthAccount(user.get().getId(), provider)) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
@@ -57,6 +57,21 @@ public class UserOauthSignService {
     }
 
     /**
+     * 인증된 사용자에게 provider로 연동할 수 있는지 여부를 반환한다.
+     *
+     * @return {@link UserSyncDto}
+     */
+    @Transactional(readOnly = true)
+    public UserSyncDto isLinkAllowed(Long userId, Provider provider) {
+        if (oauthService.isExistOauthAccount(userId, provider))
+            throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
+
+        User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
+
+        return UserSyncDto.of(true, true, user.getId(), user.getUsername());
+    }
+
+    /**
      * 기존 계정이 존재하면 Oauth 계정을 생성하여 연동하고, 존재하지 않으면 새로운 계정을 생성한다.
      *
      * @param request {@link SignUpReq.OauthInfo}
@@ -79,21 +94,6 @@ public class UserOauthSignService {
         log.info("연동된 Oauth 정보 : {}", oauth);
 
         return user;
-    }
-
-    /**
-     * 인증된 사용자에게 provider로 연동할 수 있는지 여부를 반환한다.
-     *
-     * @return {@link UserSyncDto}
-     */
-    @Transactional(readOnly = true)
-    public UserSyncDto isLinkAllowed(Long userId, Provider provider) {
-        if (oauthService.isExistOauthAccount(userId, provider))
-            throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
-
-        User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
-
-        return UserSyncDto.of(true, true, user.getId(), user.getUsername());
     }
 
     private Oauth mappingOauthToUser(User user, Provider provider, String oauthId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
@@ -91,8 +91,7 @@ public class UserOauthSignService {
 
         if (userSync.isExistAccount()) {
             log.info("기존 계정에 연동합니다. username: {}", userSync.username());
-            user = userService.readUser(userSync.userId())
-                    .orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
+            user = userService.readUser(userSync.userId()).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
         } else {
             log.info("새로운 계정을 생성합니다. username: {}", request.username());
             user = request.toUser();
@@ -109,8 +108,7 @@ public class UserOauthSignService {
     private Oauth revertDeletedOauth(UserSyncDto userSync) {
         log.info("기존 Oauth 정보가 삭제된 계정입니다. oauth: {}", userSync.oauthSync());
 
-        Oauth oauth = oauthService.readOauth(userSync.oauthSync().id())
-                .orElseThrow(() -> new OauthException(OauthErrorCode.NOT_FOUND_OAUTH));
+        Oauth oauth = oauthService.readOauth(userSync.oauthSync().id()).orElseThrow(() -> new OauthException(OauthErrorCode.NOT_FOUND_OAUTH));
         oauth.revertDelete(userSync.oauthSync().oauthId());
         return oauth;
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
@@ -63,7 +63,9 @@ public class UserOauthSignService {
      */
     @Transactional(readOnly = true)
     public UserSyncDto isLinkAllowed(Long userId, Provider provider) {
-        if (oauthService.isExistOauthAccount(userId, provider))
+        Optional<Oauth> oauth = oauthService.readOauthByUserIdAndProvider(userId, provider);
+
+        if (oauth.isPresent() && oauth.get().getDeletedAt() != null)
             throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
 
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
@@ -32,14 +32,6 @@ public class UserOauthSignService {
         return oauth.map(Oauth::getUser).orElse(null);
     }
 
-    @Transactional(readOnly = true)
-    public User readUserIfDoesNotExistOauthProvider(Long userId, Provider provider) {
-        if (oauthService.isExistOauthAccount(userId, provider))
-            throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
-
-        return userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
-    }
-
     /**
      * Oauth 회원가입 시나리오를 결정한다.
      *
@@ -87,6 +79,21 @@ public class UserOauthSignService {
         log.info("연동된 Oauth 정보 : {}", oauth);
 
         return user;
+    }
+
+    /**
+     * 인증된 사용자에게 provider로 연동할 수 있는지 여부를 반환한다.
+     *
+     * @return {@link UserSyncDto}
+     */
+    @Transactional(readOnly = true)
+    public UserSyncDto isLinkAllowed(Long userId, Provider provider) {
+        if (oauthService.isExistOauthAccount(userId, provider))
+            throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
+
+        User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
+
+        return UserSyncDto.of(true, true, user.getId(), user.getUsername());
     }
 
     private Oauth mappingOauthToUser(User user, Provider provider, String oauthId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -10,25 +10,18 @@ import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.oauth.exception.OauthErrorCode;
 import kr.co.pennyway.domain.domains.oauth.exception.OauthException;
-import kr.co.pennyway.domain.domains.oauth.service.OauthService;
 import kr.co.pennyway.domain.domains.oauth.type.Provider;
-import kr.co.pennyway.domain.domains.user.domain.User;
-import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
-import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
-import kr.co.pennyway.domain.domains.user.service.UserService;
 import kr.co.pennyway.infra.common.jwt.JwtClaims;
 import kr.co.pennyway.infra.common.jwt.JwtProvider;
 import kr.co.pennyway.infra.common.oidc.OidcDecodePayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class UserAuthUseCase {
-    private final UserService userService;
-    private final OauthService oauthService;
-
     private final UserOauthSignService userOauthSignService;
 
     private final JwtAuthHelper jwtAuthHelper;
@@ -50,23 +43,14 @@ public class UserAuthUseCase {
         jwtAuthHelper.removeAccessTokenAndRefreshToken(userId, authHeader, refreshToken);
     }
 
+    @Transactional
     public void linkOauth(Provider provider, SignInReq.Oauth request, Long userId) {
-        // 1. 페이로드를 추출한다.
         OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken(), request.nonce());
 
-        // 2. 요청을 검증하고 사용자가 연동 가능한 지 validation한다.
         if (!request.oauthId().equals(payload.sub()))
             throw new OauthException(OauthErrorCode.NOT_MATCHED_OAUTH_ID);
-        if (oauthService.isExistOauthAccount(userId, provider))
-            throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
 
-        // 3. 사용자를 읽어온다.
-        User user = userService.readUser(userId).orElseThrow(
-                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
-        );
-
-        // 4. 사용자 로그인 정보에 Oauth 정보를 추가한다.
-        UserSyncDto userSync = UserSyncDto.of(true, true, user.getId(), user.getUsername());
+        UserSyncDto userSync = userOauthSignService.isLinkAllowed(userId, provider);
         userOauthSignService.saveUser(null, userSync, provider, request.oauthId());
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -1,11 +1,24 @@
 package kr.co.pennyway.api.apis.auth.usecase;
 
 import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
+import kr.co.pennyway.api.apis.auth.dto.SignInReq;
+import kr.co.pennyway.api.apis.auth.dto.UserSyncDto;
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
+import kr.co.pennyway.api.apis.auth.helper.OauthOidcHelper;
+import kr.co.pennyway.api.apis.auth.service.UserOauthSignService;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.domains.oauth.exception.OauthErrorCode;
+import kr.co.pennyway.domain.domains.oauth.exception.OauthException;
+import kr.co.pennyway.domain.domains.oauth.service.OauthService;
+import kr.co.pennyway.domain.domains.oauth.type.Provider;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
+import kr.co.pennyway.domain.domains.user.service.UserService;
 import kr.co.pennyway.infra.common.jwt.JwtClaims;
 import kr.co.pennyway.infra.common.jwt.JwtProvider;
+import kr.co.pennyway.infra.common.oidc.OidcDecodePayload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,7 +26,14 @@ import lombok.extern.slf4j.Slf4j;
 @UseCase
 @RequiredArgsConstructor
 public class UserAuthUseCase {
+    private final UserService userService;
+    private final OauthService oauthService;
+
+    private final UserOauthSignService userOauthSignService;
+
     private final JwtAuthHelper jwtAuthHelper;
+    private final OauthOidcHelper oauthOidcHelper;
+
     private final JwtProvider accessTokenProvider;
 
     public AuthStateDto isSignIn(String authHeader) {
@@ -28,5 +48,25 @@ public class UserAuthUseCase {
 
     public void signOut(Long userId, String authHeader, String refreshToken) {
         jwtAuthHelper.removeAccessTokenAndRefreshToken(userId, authHeader, refreshToken);
+    }
+
+    public void linkOauth(Provider provider, SignInReq.Oauth request, Long userId) {
+        // 1. 페이로드를 추출한다.
+        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken(), request.nonce());
+
+        // 2. 요청을 검증하고 사용자가 연동 가능한 지 validation한다.
+        if (!request.oauthId().equals(payload.sub()))
+            throw new OauthException(OauthErrorCode.NOT_MATCHED_OAUTH_ID);
+        if (oauthService.isExistOauthAccount(userId, provider))
+            throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
+
+        // 3. 사용자를 읽어온다.
+        User user = userService.readUser(userId).orElseThrow(
+                () -> new UserErrorException(UserErrorCode.NOT_FOUND)
+        );
+
+        // 4. 사용자 로그인 정보에 Oauth 정보를 추가한다.
+        UserSyncDto userSync = UserSyncDto.of(true, true, user.getId(), user.getUsername());
+        userOauthSignService.saveUser(null, userSync, provider, request.oauthId());
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthControllerIntegrationTest.java
@@ -106,7 +106,7 @@ public class AuthControllerIntegrationTest extends ExternalApiDBTestConfig {
     class GeneralSignUpPhoneVerifyTest {
         @Test
         @WithAnonymousUser
-        @DisplayName("일반 회원가입 이력이 있는 경우 400 BAD_REQUEST를 반환하고, 인증 코드 캐시 데이터가 제거된다.")
+        @DisplayName("일반 회원가입 이력이 있는 경우 409 Conflict를 반환하고, 인증 코드 캐시 데이터가 제거된다.")
         void generalSignUpFailBecauseAlreadyGeneralSignUp() throws Exception {
             // given
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.SIGN_UP);
@@ -117,7 +117,7 @@ public class AuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
             // then
             resultActions
-                    .andExpect(status().isBadRequest())
+                    .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.code").value(UserErrorCode.ALREADY_SIGNUP.causedBy().getCode()))
                     .andExpect(jsonPath("$.message").value(UserErrorCode.ALREADY_SIGNUP.getExplainError()))
                     .andDo(print());

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
@@ -336,7 +336,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         @Test
         @WithAnonymousUser
         @Transactional
-        @DisplayName("같은 provider로 OAuth 회원가입 이력이 있으면 400 에러가 발생한다.")
+        @DisplayName("같은 provider로 OAuth 회원가입 이력이 있으면 409 Conflict 에러가 발생한다.")
         void signUpWithSameProvider() throws Exception {
             // given
             Provider provider = Provider.KAKAO;
@@ -352,7 +352,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
             // then
             result
-                    .andExpect(status().isBadRequest())
+                    .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.code").value(OauthErrorCode.ALREADY_SIGNUP_OAUTH.causedBy().getCode()))
                     .andExpect(jsonPath("$.message").value(OauthErrorCode.ALREADY_SIGNUP_OAUTH.getExplainError()))
                     .andDo(print());
@@ -493,7 +493,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         @Test
         @WithAnonymousUser
         @Transactional
-        @DisplayName("같은 provider로 OAuth 회원가입 이력이 있으면 400 에러가 발생한다.")
+        @DisplayName("같은 provider로 OAuth 회원가입 이력이 있으면 409 Conflict 에러가 발생한다.")
         void signUpWithSameProvider() throws Exception {
             // given
             Provider provider = Provider.KAKAO;
@@ -510,7 +510,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
             // then
             result
-                    .andExpect(status().isBadRequest())
+                    .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.code").value(OauthErrorCode.ALREADY_SIGNUP_OAUTH.causedBy().getCode()))
                     .andExpect(jsonPath("$.message").value(OauthErrorCode.ALREADY_SIGNUP_OAUTH.getExplainError()))
                     .andDo(print());

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
@@ -251,7 +251,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             given(oauthOidcHelper.getPayload(expectedProvider, "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "oauthId", "email"));
 
             // when
-            ResultActions result = performLinkOauth(expectedProvider);
+            ResultActions result = performLinkOauth(expectedProvider, "oauthId");
 
             // then
             result.andExpect(status().isOk()).andDo(print());
@@ -272,7 +272,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             given(oauthOidcHelper.getPayload(expectedProvider, "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "oauthId", "email"));
 
             // when
-            ResultActions result = performLinkOauth(expectedProvider);
+            ResultActions result = performLinkOauth(expectedProvider, "oauthId");
 
             // then
             result.andExpect(status().isConflict())
@@ -297,7 +297,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             given(oauthOidcHelper.getPayload(expectedProvider, "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "newOauthId", "email"));
 
             // when
-            ResultActions result = performLinkOauth(expectedProvider);
+            ResultActions result = performLinkOauth(expectedProvider, "newOauthId");
 
             // then
             result.andExpect(status().isOk()).andDo(print());
@@ -308,8 +308,8 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             log.info("연동된 Oauth 정보 : {}", savedOauth);
         }
 
-        private ResultActions performLinkOauth(Provider provider) throws Exception {
-            SignInReq.Oauth request = new SignInReq.Oauth("oauthId", "idToken", "nonce");
+        private ResultActions performLinkOauth(Provider provider, String oauthId) throws Exception {
+            SignInReq.Oauth request = new SignInReq.Oauth(oauthId, "idToken", "nonce");
             return mockMvc.perform(put("/v1/link-oauth")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
@@ -1,42 +1,61 @@
 package kr.co.pennyway.api.apis.auth.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
+import kr.co.pennyway.api.apis.auth.dto.SignInReq;
+import kr.co.pennyway.api.apis.auth.helper.OauthOidcHelper;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
 import kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaim;
 import kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenProvider;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
+import kr.co.pennyway.api.config.fixture.UserFixture;
+import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
 import kr.co.pennyway.domain.common.redis.refresh.RefreshToken;
 import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenService;
+import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
+import kr.co.pennyway.domain.domains.oauth.exception.OauthErrorCode;
+import kr.co.pennyway.domain.domains.oauth.service.OauthService;
+import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.service.UserService;
 import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
 import kr.co.pennyway.domain.domains.user.type.Role;
 import kr.co.pennyway.infra.common.exception.JwtErrorCode;
+import kr.co.pennyway.infra.common.oidc.OidcDecodePayload;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@Slf4j
 @ExternalApiIntegrationTest
 @AutoConfigureMockMvc
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private AccessTokenProvider accessTokenProvider;
@@ -50,7 +69,11 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
     private ForbiddenTokenService forbiddenTokenService;
     @Autowired
     private UserService userService;
+    @Autowired
+    private OauthService oauthService;
 
+    @MockBean
+    private OauthOidcHelper oauthOidcHelper;
 
     @Nested
     @Order(1)
@@ -207,6 +230,64 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             return get("/v1/sign-out")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON);
+        }
+    }
+
+    @Nested
+    @Order(2)
+    @DisplayName("소셜 계정 연동")
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class LinkOauth {
+        @Order(1)
+        @Test
+        @DisplayName("provider로 로그인한 이력이 없다면, 사용자는 계정 연동에 성공한다.")
+        @WithSecurityMockUser(userId = "8")
+        @Transactional
+        void linkOauthWithNoHistory() throws Exception {
+            // given
+            User user = UserFixture.GENERAL_USER.toUser();
+            userService.createUser(user);
+            Provider expectedProvider = Provider.KAKAO;
+            given(oauthOidcHelper.getPayload(expectedProvider, "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "oauthId", "email"));
+
+            // when
+            ResultActions result = performLinkOauth(expectedProvider);
+
+            // then
+            result.andExpect(status().isOk()).andDo(print());
+            assertTrue(oauthService.isExistOauthAccount(user.getId(), expectedProvider));
+        }
+
+        @Order(2)
+        @Test
+        @DisplayName("provider로 로그인한 이력이 있다면, 사용자는 계정 연동에 실패하고 409 에러를 반환한다.")
+        @WithSecurityMockUser(userId = "9")
+        @Transactional
+        void linkOauthWithHistory() throws Exception {
+            // given
+            User user = UserFixture.GENERAL_USER.toUser();
+            userService.createUser(user);
+            Provider expectedProvider = Provider.KAKAO;
+            oauthService.createOauth(Oauth.of(expectedProvider, "oauthId", user));
+            given(oauthOidcHelper.getPayload(expectedProvider, "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "oauthId", "email"));
+
+            // when
+            ResultActions result = performLinkOauth(expectedProvider);
+
+            // then
+            result.andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value(OauthErrorCode.ALREADY_SIGNUP_OAUTH.causedBy().getCode()))
+                    .andExpect(jsonPath("$.message").value(OauthErrorCode.ALREADY_SIGNUP_OAUTH.getExplainError()))
+                    .andDo(print());
+        }
+
+        private ResultActions performLinkOauth(Provider provider) throws Exception {
+            SignInReq.Oauth request = new SignInReq.Oauth("oauthId", "idToken", "nonce");
+            return mockMvc.perform(post("/v1/link-oauth")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .queryParam("provider", provider.name())
+                    .content(objectMapper.writeValueAsString(request)));
         }
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -2,6 +2,8 @@ package kr.co.pennyway.api.apis.auth.usecase;
 
 import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
+import kr.co.pennyway.api.apis.auth.helper.OauthOidcHelper;
+import kr.co.pennyway.api.apis.auth.service.UserOauthSignService;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
 import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
@@ -33,6 +35,10 @@ public class UserAuthUseCaseUnitTest {
     private JwtAuthHelper jwtAuthHelper;
 
     @Mock
+    private UserOauthSignService userOauthSignService;
+    @Mock
+    private OauthOidcHelper oauthOidcHelper;
+    @Mock
     private JwtProvider refreshTokenProvider;
     @Mock
     private RefreshTokenService refreshTokenService;
@@ -43,7 +49,7 @@ public class UserAuthUseCaseUnitTest {
     public void setUp() {
         accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMinutes(5));
         jwtAuthHelper = new JwtAuthHelper(accessTokenProvider, refreshTokenProvider, refreshTokenService, forbiddenTokenService);
-        userAuthUseCase = new UserAuthUseCase(jwtAuthHelper, accessTokenProvider);
+        userAuthUseCase = new UserAuthUseCase(userOauthSignService, jwtAuthHelper, oauthOidcHelper, accessTokenProvider);
     }
 
     @Test
@@ -51,7 +57,7 @@ public class UserAuthUseCaseUnitTest {
     public void isSignedInWithExpiredToken() {
         // given
         accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMillis(0));
-        userAuthUseCase = new UserAuthUseCase(jwtAuthHelper, accessTokenProvider);
+        userAuthUseCase = new UserAuthUseCase(userOauthSignService, jwtAuthHelper, oauthOidcHelper, accessTokenProvider);
         String expiredToken = accessTokenProvider.generateToken(jwtClaims);
 
         // when

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -64,6 +64,14 @@ public class Oauth {
         return deletedAt != null;
     }
 
+    public void revertDelete(String oauthId) {
+        if (deletedAt != null) {
+            throw new IllegalStateException("이미 삭제된 Oauth입니다. oauthId: " + oauthId);
+        }
+        this.oauthId = oauthId;
+        this.deletedAt = null;
+    }
+
     @Override
     public String toString() {
         return "Oauth{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -60,6 +60,10 @@ public class Oauth {
                 .build();
     }
 
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
     @Override
     public String toString() {
         return "Oauth{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -23,7 +22,6 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @DynamicInsert
-@SQLRestriction("deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE oauth SET deleted_at = NOW() WHERE id = ?")
 public class Oauth {
     @Id

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -65,8 +65,8 @@ public class Oauth {
     }
 
     public void revertDelete(String oauthId) {
-        if (deletedAt != null) {
-            throw new IllegalStateException("이미 삭제된 Oauth입니다. oauthId: " + oauthId);
+        if (deletedAt == null) {
+            throw new IllegalStateException("삭제되지 않은 oauth 정보 갱신 요청입니다. oauthId: " + oauthId);
         }
         this.oauthId = oauthId;
         this.deletedAt = null;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/exception/OauthErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/exception/OauthErrorCode.java
@@ -16,6 +16,9 @@ public enum OauthErrorCode implements BaseErrorCode {
     /* 401 Unauthorized */
     NOT_MATCHED_OAUTH_ID(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS, "OAuth ID가 일치하지 않습니다."),
 
+    /* 404 Not Found */
+    NOT_FOUND_OAUTH(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "해당 제공자로 가입된 이력을 찾을 수 없습니다."),
+
     /* 409 Conflict */
     ALREADY_SIGNUP_OAUTH(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 해당 제공자로 가입된 사용자입니다."),
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/exception/OauthErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/exception/OauthErrorCode.java
@@ -11,11 +11,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum OauthErrorCode implements BaseErrorCode {
     /* 400 Bad Request */
-    ALREADY_SIGNUP_OAUTH(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "이미 해당 제공자로 가입된 사용자입니다."),
     INVALID_OAUTH_SYNC_REQUEST(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "Oauth 동기화 요청이 잘못되었습니다."),
 
     /* 401 Unauthorized */
     NOT_MATCHED_OAUTH_ID(StatusCode.UNAUTHORIZED, ReasonCode.MISSING_OR_INVALID_AUTHENTICATION_CREDENTIALS, "OAuth ID가 일치하지 않습니다."),
+
+    /* 409 Conflict */
+    ALREADY_SIGNUP_OAUTH(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 해당 제공자로 가입된 사용자입니다."),
 
     /* 422 Unprocessable Entity */
     INVALID_PROVIDER(StatusCode.UNPROCESSABLE_CONTENT, ReasonCode.TYPE_MISMATCH_ERROR_IN_REQUEST_BODY, "유효하지 않은 제공자입니다.");

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/repository/OauthRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/repository/OauthRepository.java
@@ -9,5 +9,7 @@ import java.util.Optional;
 public interface OauthRepository extends JpaRepository<Oauth, Long> {
     Optional<Oauth> findByOauthIdAndProvider(String oauthId, Provider provider);
 
+    Optional<Oauth> findByUser_IdAndProvider(Long userId, Provider provider);
+
     boolean existsByUser_IdAndProvider(Long userId, Provider provider);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -19,6 +19,11 @@ public class OauthService {
         return oauthRepository.save(oauth);
     }
 
+    @Transactional
+    public Optional<Oauth> readOauth(Long id) {
+        return oauthRepository.findById(id);
+    }
+
     @Transactional(readOnly = true)
     public Optional<Oauth> readOauthByOauthIdAndProvider(String oauthId, Provider provider) {
         return oauthRepository.findByOauthIdAndProvider(oauthId, provider);

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -25,6 +25,11 @@ public class OauthService {
     }
 
     @Transactional(readOnly = true)
+    public Optional<Oauth> readOauthByUserIdAndProvider(Long userId, Provider provider) {
+        return oauthRepository.findByUser_IdAndProvider(userId, provider);
+    }
+
+    @Transactional(readOnly = true)
     public boolean isExistOauthAccount(Long userId, Provider provider) {
         return oauthRepository.existsByUser_IdAndProvider(userId, provider);
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -38,4 +38,9 @@ public class OauthService {
     public boolean isExistOauthAccount(Long userId, Provider provider) {
         return oauthRepository.existsByUser_IdAndProvider(userId, provider);
     }
+
+    @Transactional
+    public void deleteOauth(Oauth oauth) {
+        oauthRepository.delete(oauth);
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
     /* 400 BAD_REQUEST */
-    ALREADY_SIGNUP(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "이미 회원가입한 유저입니다."),
     NOT_MATCHED_PASSWORD(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "비밀번호가 일치하지 않습니다."),
     PASSWORD_NOT_CHANGED(StatusCode.BAD_REQUEST, ReasonCode.CLIENT_ERROR, "현재 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
 
@@ -19,6 +18,9 @@ public enum UserErrorCode implements BaseErrorCode {
     /* 403 FORBIDDEN */
     ALREADY_WITHDRAWAL(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "이미 탈퇴한 유저입니다."),
     DO_NOT_GENERAL_SIGNED_UP(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "일반 회원가입 계정이 아닙니다."),
+
+    /* 409 Conflict */
+    ALREADY_SIGNUP(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 회원가입한 유저입니다."),
 
     /* 404 NOT_FOUND */
     NOT_FOUND(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "유저를 찾을 수 없습니다."),


### PR DESCRIPTION
## 작업 이유
> ⚠️ LoC가 좀 긴데, 정말 최소한의 작업만을 수행했음을 알리고 시작합니다.

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/93cc5dbe-f42b-430d-bdd9-b3350ad3448c" width="600px"/>
</div>

- `인증된 사용자`가 소셜 계정을 연동하기 위한 API 구현

<br/>

## 작업 사항
### 1️⃣ 에러 코드 수정
```java
public enum UserErrorCode implements BaseErrorCode {
    ...
    /* 409 Conflict */
    ALREADY_SIGNUP(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 회원가입한 유저입니다."),
   ...
}
```
```java
public enum OauthErrorCode implements BaseErrorCode {
    ...
    /* 409 Conflict */
    ALREADY_SIGNUP_OAUTH(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 해당 제공자로 가입된 사용자입니다."),
   ...
}
```
- `400 Bad Request`에 해당하던 값을 `409 Conflict`로 수정했습니다.
- Client가 API에서 제공하는 ErrorCode로 예외 핸들링을 수행하는 만큼, 최대한 중복을 제거하기 위해 수정하게 되었습니다.

<br/>

### 2️⃣ 시나리오 설명
```java
@Transactional
public void linkOauth(Provider provider, SignInReq.Oauth request, Long userId) {
    OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken(), request.nonce());

    if (!request.oauthId().equals(payload.sub()))
        throw new OauthException(OauthErrorCode.NOT_MATCHED_OAUTH_ID);

    UserSyncDto userSync = userOauthSignService.isLinkAllowed(userId, provider);
    userOauthSignService.saveUser(null, userSync, provider, request.oauthId());
}
```
1. Id token 유효성 검사
2. Id token의 oauthId와 request로 보낸 oauthId가 일치하지 않을 시 예외 ⇾ 이 부분은 1번으로 삽입할 예정 (iOS 요청 수정 후)
3. 사용자가 oauth link가 가능한지 판단
    - 이미 provider에 해당하는 삭제되지 않은 oauth 정보가 있는 경우 409 에러
    - provider에 해당하는 oauth 정보가 있지만 삭제된 경우, 해당 oauth entity의 id 반환
    - provider에 해당하는 oauth 정보가 없는 경우 신규 등록
4. 소셜 계정 연동
    - soft delete된 oauth 정보가 존재하면 delete_at을 null로 복구하고, oauth_id를 갱신
    - soft delete된 oauth 정보가 없으면 새로 생성하여 연결

<br/>

> 🤔 oauth_id를 갱신하는 이유
>
> 만약 개인 계정으로 구글 로그인을 한 후 취소한 다음, 다른 계정으로 로그인을 시도한 경우
> 단순히 복구만 하면 이전 계정이 홀성화되기 때문입니다.

<br/>

### 3️⃣ 그 외 주요 수정 사항
1. 요청이 `POST`가 아닌 `PUT`인 이유
    - Oauth 테이블이 soft delete 정책을 사용하기 때문에, provider 로그인 이력은 있으나 delete된 상태일 수 있기 때문입니다.
6. Oauth Entity의 `@SQLRestriction`을 제거한 이유
    - 연동을 해제한 사용자의 Provider 재연결 시나리오에서 Soft Delete의 사용에 제약이 발생했습니다. [참고](https://www.inflearn.com/questions/1197298/sqlrestriction%EC%9C%BC%EB%A1%9C-%EB%85%BC%EB%A6%AC%EC%A0%81-%EC%82%AD%EC%A0%9C-%ED%95%84%EB%93%9C%EC%97%90-%EB%8C%80%ED%95%9C-teardown%EC%97%90-%EB%8C%80%ED%95%B4-%EA%B6%81%EA%B8%88%ED%95%A9%EB%8B%88%EB%8B%A4)
    - SoftDelete 정책을 Domain 모듈이 반영하고 있는 것부터 설계 상 오점이 아니었을까..`@SQLDelete`는 그럴 수 있다 치지만, `@SQLRestriction`를 사용하면 Domain 모듈 사용에 제약이 심해진다고 판단했습니다.
    - 이렇게 하지 않고, Domain Service 단에서 entity manager를 활용하여 우회할 수는 있으나...그럼 Domain Service가 삭제 모드와 일반 모드를 구분하여 최대 2배의 메서드를 제공해야 하는 문제가 발생합니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- `PUT` 요청 메서드와 경로가 적절한지?
- Entity에 `@SQLRestriction` 어노테이션을 제거한 이유와 방법이 타당하다고 생각하는지? (이해 안 됐으면 다시 설명드리겠습니다!)

<br/>

## 발견한 이슈
- 사용자 Oauth 로그인 시나리오에 대한 soft delete에 대응 시나리오 재검토 필요
   - 이슈 등록 후, 검증 과정 수행 예정
   - 현재는 컴파일 에러와 테스트 통고가 가능할 정도의 최소한의 변경 작업만을 반영한 상태입니다.

