### PR TITLE
🐛 OAuth 로그인/회원가입 시 Soft Delete 정책 반영 검사

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -40,7 +40,8 @@ public class SignUpReq {
         }
     }
 
-    public record OauthInfo(String idToken, String nonce, String name, String username, String phone, String code) {
+    public record OauthInfo(String oauthId, String idToken, String nonce, String name, String username, String phone,
+                            String code) {
         public User toUser() {
             return User.builder()
                     .username(username)
@@ -102,6 +103,9 @@ public class SignUpReq {
 
     @Schema(title = "소셜 회원가입 요청 DTO")
     public record Oauth(
+            @Schema(description = "OAuth id")
+            @NotBlank(message = "OAuth id는 필수 입력값입니다.")
+            String oauthId,
             @Schema(description = "OIDC 토큰")
             @NotBlank(message = "OIDC 토큰은 필수 입력값입니다.")
             String idToken,
@@ -126,12 +130,15 @@ public class SignUpReq {
             String code
     ) {
         public OauthInfo toOauthInfo() {
-            return new OauthInfo(idToken, nonce, name, username, phone, code);
+            return new OauthInfo(oauthId, idToken, nonce, name, username, phone, code);
         }
     }
 
     @Schema(title = "소셜 회원가입(기존 계정 존재) 요청 DTO")
     public record SyncWithAuth(
+            @Schema(description = "OAuth id")
+            @NotBlank(message = "OAuth id는 필수 입력값입니다.")
+            String oauthId,
             @Schema(description = "OIDC 토큰")
             @NotBlank(message = "OIDC 토큰은 필수 입력값입니다.")
             String idToken,
@@ -148,7 +155,7 @@ public class SignUpReq {
             String code
     ) {
         public OauthInfo toOauthInfo() {
-            return new OauthInfo(idToken, nonce, null, null, phone, code);
+            return new OauthInfo(oauthId, idToken, nonce, null, null, phone, code);
         }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/OauthOidcHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/OauthOidcHelper.java
@@ -40,16 +40,17 @@ public class OauthOidcHelper {
      * Provider에 따라 Client와 Properties를 선택하고 Odic public key 정보를 가져와서 ID Token의 payload를 추출하는 메서드
      *
      * @param provider : {@link Provider}
+     * @param oauthId  : Provider에서 발급한 사용자 식별자
      * @param idToken  : idToken
      * @param nonce    : 인증 서버 로그인 요청 시 전달한 임의의 문자열
      * @return OIDCDecodePayload : ID Token의 payload
      */
-    public OidcDecodePayload getPayload(Provider provider, String idToken, String nonce) {
+    public OidcDecodePayload getPayload(Provider provider, String oauthId, String idToken, String nonce) {
         OauthOidcClient client = oauthOidcClients.get(provider).keySet().iterator().next();
         OauthOidcClientProperties properties = oauthOidcClients.get(provider).values().iterator().next();
         OidcPublicKeyResponse response = client.getOidcPublicKey();
 
-        return getPayloadFromIdToken(idToken, properties.getIssuer(), properties.getSecret(), nonce, response);
+        return getPayloadFromIdToken(idToken, properties.getIssuer(), oauthId, properties.getSecret(), nonce, response);
     }
 
     /**
@@ -58,13 +59,14 @@ public class OauthOidcHelper {
      *
      * @param idToken  : idToken
      * @param iss      : ID Token을 발급한 provider의 URL
+     * @param sub      : ID Token의 subject (사용자 식별자)
      * @param aud      : ID Token이 발급된 앱의 앱 키
      * @param nonce    : 인증 서버 로그인 요청 시 전달한 임의의 문자열 (Optional, 현재는 사용하지 않음)
      * @param response : 공개키 목록
      * @return OIDCDecodePayload : ID Token의 payload
      */
-    private OidcDecodePayload getPayloadFromIdToken(String idToken, String iss, String aud, String nonce, OidcPublicKeyResponse response) {
-        String kid = getKidFromUnsignedIdToken(idToken, iss, aud, nonce);
+    private OidcDecodePayload getPayloadFromIdToken(String idToken, String iss, String sub, String aud, String nonce, OidcPublicKeyResponse response) {
+        String kid = getKidFromUnsignedIdToken(idToken, iss, sub, aud, nonce);
 
         OidcPublicKey key = response.getKeys().stream()
                 .filter(k -> k.kid().equals(kid))
@@ -73,7 +75,7 @@ public class OauthOidcHelper {
         return oauthOidcProvider.getOIDCTokenBody(idToken, key.n(), key.e());
     }
 
-    private String getKidFromUnsignedIdToken(String token, String iss, String aud, String nonce) {
-        return oauthOidcProvider.getKidFromUnsignedTokenHeader(token, iss, aud, nonce);
+    private String getKidFromUnsignedIdToken(String token, String iss, String sub, String aud, String nonce) {
+        return oauthOidcProvider.getKidFromUnsignedTokenHeader(token, iss, sub, aud, nonce);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
@@ -34,11 +34,9 @@ public class OauthUseCase {
 
     @Transactional(readOnly = true)
     public Pair<Long, Jwts> signIn(Provider provider, SignInReq.Oauth request) {
-        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken(), request.nonce());
+        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.oauthId(), request.idToken(), request.nonce());
         log.debug("payload : {}", payload);
 
-        if (!request.oauthId().equals(payload.sub()))
-            throw new OauthException(OauthErrorCode.NOT_MATCHED_OAUTH_ID);
         User user = userOauthSignService.readUser(request.oauthId(), provider);
 
         return (user != null) ? Pair.of(user.getId(), jwtAuthHelper.createToken(user)) : Pair.of(-1L, null);
@@ -66,7 +64,7 @@ public class OauthUseCase {
             throw new OauthException(OauthErrorCode.INVALID_OAUTH_SYNC_REQUEST);
         }
 
-        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken(), request.nonce());
+        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.oauthId(), request.idToken(), request.nonce());
         User user = userOauthSignService.saveUser(request, userSync, provider, payload.sub());
 
         return Pair.of(user.getId(), jwtAuthHelper.createToken(user));

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -8,8 +8,6 @@ import kr.co.pennyway.api.apis.auth.helper.OauthOidcHelper;
 import kr.co.pennyway.api.apis.auth.service.UserOauthSignService;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.common.annotation.UseCase;
-import kr.co.pennyway.domain.domains.oauth.exception.OauthErrorCode;
-import kr.co.pennyway.domain.domains.oauth.exception.OauthException;
 import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import kr.co.pennyway.infra.common.jwt.JwtClaims;
 import kr.co.pennyway.infra.common.jwt.JwtProvider;
@@ -45,12 +43,9 @@ public class UserAuthUseCase {
 
     @Transactional
     public void linkOauth(Provider provider, SignInReq.Oauth request, Long userId) {
-        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.idToken(), request.nonce());
-
-        if (!request.oauthId().equals(payload.sub()))
-            throw new OauthException(OauthErrorCode.NOT_MATCHED_OAUTH_ID);
+        OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.oauthId(), request.idToken(), request.nonce());
 
         UserSyncDto userSync = userOauthSignService.isLinkAllowed(userId, provider);
-        userOauthSignService.saveUser(null, userSync, provider, request.oauthId());
+        userOauthSignService.saveUser(null, userSync, provider, payload.sub());
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
@@ -139,7 +139,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Provider provider = Provider.KAKAO;
             User user = createOauthSignedUser();
 
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
             userService.createUser(user);
             oauthService.createOauth(createOauthAccount(user, provider));
 
@@ -164,7 +164,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Provider provider = Provider.KAKAO;
             User user = createOauthSignedUser();
 
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
             userService.createUser(user);
             oauthService.createOauth(createOauthAccount(user, Provider.GOOGLE));
 
@@ -187,7 +187,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Provider provider = Provider.KAKAO;
             User user = createGeneralSignedUser();
 
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
             userService.createUser(user);
 
             // when
@@ -208,7 +208,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             // given
             Provider provider = Provider.KAKAO;
 
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken, expectedNonce);
@@ -217,30 +217,6 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             result
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.user.id").value(-1))
-                    .andDo(print());
-        }
-
-        @Test
-        @WithAnonymousUser
-        @Transactional
-        @DisplayName("OAuth id와 payload의 sub가 다른 경우에는 NOT_MATCHED_OAUTH_ID 에러가 발생한다.")
-        void signInWithNotMatchedOauthId() throws Exception {
-            // given
-            Provider provider = Provider.KAKAO;
-            User user = createOauthSignedUser();
-
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", "differentOauthId", "email"));
-            userService.createUser(user);
-            oauthService.createOauth(createOauthAccount(user, provider));
-
-            // when
-            ResultActions result = performOauthSignIn(provider, expectedOauthId, expectedIdToken, expectedNonce);
-
-            // then
-            result
-                    .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.code").value(OauthErrorCode.NOT_MATCHED_OAUTH_ID.causedBy().getCode()))
-                    .andExpect(jsonPath("$.message").value(OauthErrorCode.NOT_MATCHED_OAUTH_ID.getExplainError()))
                     .andDo(print());
         }
 
@@ -449,7 +425,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
             userService.createUser(user);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode, expectedOauthId);
@@ -479,7 +455,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             userService.createUser(user);
             oauthService.createOauth(oauth);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode, expectedOauthId);
@@ -504,7 +480,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             // given
             Provider provider = Provider.KAKAO;
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode, expectedOauthId);
@@ -530,7 +506,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             userService.createUser(user);
             oauthService.createOauth(oauth);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode, expectedOauthId);
@@ -557,7 +533,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             oauthService.createOauth(oauth);
             oauthService.deleteOauth(oauth);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, "newOauthId", expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", "newOauthId", "email"));
 
             // when
             ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode, "newOauthId");
@@ -569,7 +545,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(header().exists("Authorization"))
                     .andExpect(jsonPath("$.data.user.id").value(user.getId()))
                     .andDo(print());
-            Oauth savedOauth = oauthService.readOauthByOauthIdAndProvider(expectedOauthId, provider).get();
+            Oauth savedOauth = oauthService.readOauthByOauthIdAndProvider("newOauthId", provider).get();
             assertEquals(user.getId(), savedOauth.getUser().getId());
             assertEquals(oauth.getId(), savedOauth.getId());
             assertEquals("newOauthId", savedOauth.getOauthId());
@@ -578,7 +554,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         private ResultActions performOauthSignUpAccountLinking(Provider provider, String code, String oauthId) throws Exception {
-            SignUpReq.SyncWithAuth request = new SignUpReq.SyncWithAuth(expectedIdToken, oauthId, expectedNonce, expectedPhone, code);
+            SignUpReq.SyncWithAuth request = new SignUpReq.SyncWithAuth(oauthId, expectedIdToken, expectedNonce, expectedPhone, code);
             return mockMvc.perform(post("/v1/auth/oauth/link-auth")
                     .param("provider", provider.name())
                     .contentType("application/json")
@@ -598,7 +574,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             // given
             Provider provider = Provider.KAKAO;
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUp(provider, expectedCode);
@@ -626,7 +602,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
             userService.createUser(user);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUp(provider, expectedCode);
@@ -652,7 +628,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             userService.createUser(user);
             oauthService.createOauth(oauth);
             phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider));
-            given(oauthOidcHelper.getPayload(provider, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
+            given(oauthOidcHelper.getPayload(provider, expectedOauthId, expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", expectedOauthId, "email"));
 
             // when
             ResultActions result = performOauthSignUp(provider, expectedCode);
@@ -666,7 +642,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         private ResultActions performOauthSignUp(Provider provider, String code) throws Exception {
-            SignUpReq.Oauth request = new SignUpReq.Oauth(expectedIdToken, expectedNonce, "jayang", expectedUsername, expectedPhone, code);
+            SignUpReq.Oauth request = new SignUpReq.Oauth(expectedOauthId, expectedIdToken, expectedNonce, "jayang", expectedUsername, expectedPhone, code);
             return mockMvc.perform(post("/v1/auth/oauth/sign-up")
                     .param("provider", provider.name())
                     .contentType("application/json")

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
@@ -248,7 +248,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             User user = UserFixture.GENERAL_USER.toUser();
             userService.createUser(user);
             Provider expectedProvider = Provider.KAKAO;
-            given(oauthOidcHelper.getPayload(expectedProvider, "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "oauthId", "email"));
+            given(oauthOidcHelper.getPayload(expectedProvider, "oauthId", "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "oauthId", "email"));
 
             // when
             ResultActions result = performLinkOauth(expectedProvider, "oauthId");
@@ -269,7 +269,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             userService.createUser(user);
             Provider expectedProvider = Provider.KAKAO;
             oauthService.createOauth(Oauth.of(expectedProvider, "oauthId", user));
-            given(oauthOidcHelper.getPayload(expectedProvider, "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "oauthId", "email"));
+            given(oauthOidcHelper.getPayload(expectedProvider, "oauthId", "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "oauthId", "email"));
 
             // when
             ResultActions result = performLinkOauth(expectedProvider, "oauthId");
@@ -294,7 +294,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Oauth oauth = Oauth.of(expectedProvider, "oauthId", user);
             oauthService.createOauth(oauth);
             oauthService.deleteOauth(oauth);
-            given(oauthOidcHelper.getPayload(expectedProvider, "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "newOauthId", "email"));
+            given(oauthOidcHelper.getPayload(expectedProvider, "oauthId", "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "newOauthId", "email"));
 
             // when
             ResultActions result = performLinkOauth(expectedProvider, "newOauthId");

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
@@ -294,7 +294,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Oauth oauth = Oauth.of(expectedProvider, "oauthId", user);
             oauthService.createOauth(oauth);
             oauthService.deleteOauth(oauth);
-            given(oauthOidcHelper.getPayload(expectedProvider, "oauthId", "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "newOauthId", "email"));
+            given(oauthOidcHelper.getPayload(expectedProvider, "newOauthId", "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "newOauthId", "email"));
 
             // when
             ResultActions result = performLinkOauth(expectedProvider, "newOauthId");

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProvider.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProvider.java
@@ -10,7 +10,7 @@ public interface OauthOidcProvider {
      * @param nonce : 인증 서버 로그인 요청 시 전달한 임의의 문자열
      * @return kid : ID Token의 서명에 사용된 공개키의 ID
      */
-    String getKidFromUnsignedTokenHeader(String token, String iss, String aud, String nonce);
+    String getKidFromUnsignedTokenHeader(String token, String iss, String sub, String aud, String nonce);
 
     /**
      * ID Token의 payload를 추출하는 메서드

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/oidc/OauthOidcProviderImpl.java
@@ -32,8 +32,8 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
     private final ObjectMapper objectMapper;
 
     @Override
-    public String getKidFromUnsignedTokenHeader(String token, String iss, String aud, String nonce) {
-        return getUnsignedTokenClaims(token, iss, aud, nonce).get("header").get(KID);
+    public String getKidFromUnsignedTokenHeader(String token, String iss, String sub, String aud, String nonce) {
+        return getUnsignedTokenClaims(token, iss, sub, aud, nonce).get("header").get(KID);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
      * payload의 iss, aud, exp, nonce를 검증하고, 실패시 예외 처리
      */
     @SuppressWarnings("unchecked")
-    private Map<String, Map<String, String>> getUnsignedTokenClaims(String token, String iss, String aud, String nonce) {
+    private Map<String, Map<String, String>> getUnsignedTokenClaims(String token, String iss, String sub, String aud, String nonce) {
         try {
             Base64.Decoder decoder = Base64.getUrlDecoder();
 
@@ -64,8 +64,9 @@ public class OauthOidcProviderImpl implements OauthOidcProvider {
             Map<String, String> header = objectMapper.readValue(headerJson, Map.class);
             Map<String, String> payload = objectMapper.readValue(payloadJson, Map.class);
 
-            Assert.isTrue(payload.get("aud").equals(aud), "aud is not matched. expected : " + aud + ", actual : " + payload.get("aud"));
             Assert.isTrue(payload.get("iss").equals(iss), "iss is not matched. expected : " + iss + ", actual : " + payload.get("iss"));
+            Assert.isTrue(payload.get("sub").equals(sub), "sub is not matched. expected : " + sub + ", actual : " + payload.get("sub"));
+            Assert.isTrue(payload.get("aud").equals(aud), "aud is not matched. expected : " + aud + ", actual : " + payload.get("aud"));
             Assert.isTrue(payload.get("nonce").equals(nonce), "nonce is not matched. expected : " + nonce + ", actual : " + payload.get("nonce"));
 
             return Map.of("header", header, "payload", payload);


### PR DESCRIPTION
## 작업 이유
> 🤗 결론: 테스트 코드 상으로는 문제 없음.
- OAuth Entity의 `@SQLRestriction`을 제거함으로써 기존 소셜 로그인/회원가입 시나리오 검증

<br/>

## 작업 사항
### 1️⃣ 테스트 항목
**🟡 소셜 회원가입 전화번호 검증 시 soft delete된 oauth 정보를 무시한다.**
```java
@Test
@WithAnonymousUser
@Transactional
@DisplayName("같은 provider로 Oauth 로그인 이력이 soft delete 되었으면 성공 응답을 반환한다.")
void signUpWithDeletedOauth() throws Exception {
    // given
    Provider provider = Provider.KAKAO; // provider는 카카오로 선택
    User user = createGeneralSignedUser(); // 일반 회원가입 유저 생성
    Oauth oauth = createOauthAccount(user, provider); // 일반 회원가입 유저에 카카오 oauth 정보 추가

    userService.createUser(user); // DB에 저장
    oauthService.createOauth(oauth);
    oauthService.deleteOauth(oauth); // Oauth 정보는 삭제 (soft delete)
    phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider)); // 전화번호를 redis에 미리 저장

    // when
    ResultActions result = performOauthSignUpPhoneVerification(provider, expectedCode); // `/v1/auth/oauth/phone/verification`로 요청

    // then
    result
        .andExpect(status().isOk())
        .andExpect(jsonPath("$.code").value("2000"))
        .andExpect(jsonPath("$.data.sms.code").value(true))
        .andExpect(jsonPath("$.data.sms.existsUser").value(true)) // 일반 회원가입 유저이므로 oauth 정보가 삭제되어도 true
        .andExpect(jsonPath("$.data.sms.username").value(user.getUsername()))
        .andDo(print());
}
```

<br/>

**🟡 소셜 계정 연동 요청 시 soft delete된 oauth 정보가 있다면, soft delete된 oauth 정보를 복구하고 oauth_id를 갱신한다.**
```java
@Test
@WithAnonymousUser
@Transactional
@DisplayName("같은 provider로 Oauth 로그인 이력이 soft delete 되었으면, Oauth 정보가 복구되고 새로운 oauth_id를 반영한다.")
void signUpWithDeletedOauth() throws Exception {
    // given
    Provider provider = Provider.KAKAO; // provider는 카카오로 고정
    User user = createGeneralSignedUser(); // 일반 회원가입 계정 생성
    Oauth oauth = createOauthAccount(user, provider); // oauth 계정 연동

    userService.createUser(user); // 사용자 생성
    oauthService.createOauth(oauth); // oauth 등록
    oauthService.deleteOauth(oauth); // oauth 삭제
    phoneCodeService.create(expectedPhone, expectedCode, PhoneCodeKeyType.getOauthSignUpTypeByProvider(provider)); // 전화번호 인증 코드 미리 등록
    given(oauthOidcHelper.getPayload(provider, "newOauthId", expectedIdToken, expectedNonce)).willReturn(new OidcDecodePayload("iss", "aud", "newOauthId", "email")); // IdToken 예상 응답값 설정

    // when
    ResultActions result = performOauthSignUpAccountLinking(provider, expectedCode, "newOauthId"); // ``/v1/auth/oauth/link-auth`로 요청

    // then
    result
        .andExpect(status().isOk()) // 200 OK 응답이어야 함
        .andExpect(header().exists("Set-Cookie")) // Refresh Token을 반환하는 Set-Cookie 헤더가 존재해야 함
        .andExpect(header().exists("Authorization")) // Access Token을 반환하는 Authorization 헤더가 존재해야 함
        .andExpect(jsonPath("$.data.user.id").value(user.getId())) // 사용자 아이디는 given 절의 사용자 아이디와 동일해야 함
        .andDo(print());
    Oauth savedOauth = oauthService.readOauthByOauthIdAndProvider("newOauthId", provider).get(); // 저장된 oauth entity 조회
    assertEquals(user.getId(), savedOauth.getUser().getId()); // given 절의 user id와 저장된 oauth가 가리키는 유저의 아이디가 같아야 함 (새로 생성되지 않고 soft delete된 정보가 복구됐음을 증명)
    assertEquals(oauth.getId(), savedOauth.getId()); // given절에서 삭제한 oauth id가 저장된 oauth id 값과 같아야 함
    assertEquals("newOauthId", savedOauth.getOauthId()); // 복구하면서 새로 제공한 oauth_id가 반영되어 있어야 함
    assertFalse(savedOauth.isDeleted()); // deleted 필드가 null로 바뀌어 있어야 함.
    System.out.println("oauth : " + savedOauth);
}
```

<br/>

> 🤔 소셜 회원가입 요청에는 Soft Delete 테스트를 안 한 이유
>
> 소셜 회원가입은 일반 로그인 유저고 뭐고 정말 아무것도 없는 상황...
> 이 요청이 성공하려면 반드시 `Optional<User> user = userService.readUserByPhone(phone);`가 empty임을 만족해야 하는데
> 이는 Oauth Entity의 Soft Delete와 무관함. (User Entity의 `@SQLRestriction`을 제거하게 된다면 고려할 필요 존재)

<br/>

### 2️⃣ 은근슬쩍 같이 작업한 부분
- `oauthId`를 요청으로 받는 경우도 있고, 안 받는 경우도 있어서 IdToken 파싱할 때 함께 검사를 하지 못 했었는데 idToken 정보를 추출할 때는 언제나 `oauthId`를 함께 받고 추출할 때 검사합니다.
   ```java
   Assert.isTrue(payload.get("sub").equals(sub), "sub is not matched. expected : " + sub + ", actual : " + payload.get("sub"));
   ```
   - 덕분에 UseCase에서 `payload`의 `sub`와 사용자 요청의 `oauthId` 검증 부분이 불필요하게 되었습니다.

이번 작업에 수정 사항 대부분은 저거 때문..테스트 코드는 두 가지만 추가했습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 제 테스트 코드 너무 지저분한 것 같아요 ㅜ. 보면서 불편하거나 개선되었으면 하는 점이 있다면 말씀해주시면 감사드리겠습니다.

<br/>

## 발견한 이슈
- 없음

<br/>

### 이슈 연결
close #68 