### PR TITLE
✨ 인증된 사용자의 OAuth 연동 해지 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -76,4 +76,18 @@ public interface UserAuthApi {
                     """)
     }))
     ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated SignInReq.Oauth request, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "소셜 계정 연동 해제", description = "인증된 사용자의 소셜 계정 연동을 해제한다. 연동되지 않은 계정을 해제하려고 하는 경우에는 404 에러를 반환한다. 미인증 사용자는 해당 API를 사용할 수 없다.")
+    @Parameter(name = "provider", description = "소셜 제공자", examples = {
+            @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
+    }, required = true, in = ParameterIn.QUERY)
+    @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "해당 provider로 로그인한 이력이 없음", value = """
+                    {
+                        "code": "4041",
+                        "message": "해당 제공자로 가입된 사용자가 아닙니다."
+                    }
+                    """)
+    }))
+    ResponseEntity<?> unlinkOauth(@RequestParam Provider provider, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -81,13 +81,23 @@ public interface UserAuthApi {
     @Parameter(name = "provider", description = "소셜 제공자", examples = {
             @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
     }, required = true, in = ParameterIn.QUERY)
-    @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
-            @ExampleObject(name = "해당 provider로 로그인한 이력이 없음", value = """
-                    {
-                        "code": "4041",
-                        "message": "해당 제공자로 가입된 사용자가 아닙니다."
-                    }
-                    """)
-    }))
+    @ApiResponses({
+            @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "해당 provider로 로그인한 이력이 없음", value = """
+                            {
+                                "code": "4040",
+                                "message": "해당 제공자로 가입된 이력을 찾을 수 없습니다."
+                            }
+                            """)
+            })),
+            @ApiResponse(responseCode = "409", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "연결 해제 요청 실패", value = """
+                            {
+                                "code": "4090",
+                                "message": "해당 제공자로만 가입된 사용자는 연동을 해제할 수 없습니다."
+                            }
+                            """, description = "일반 회원 가입 이력이 없고, 연동된 소셜 계정이 해지를 요청하는 제공자 하나 뿐인 경우 -> 계정 삭제 API를 호출해야 한다.")
+            }))
+    })
     ResponseEntity<?> unlinkOauth(@RequestParam Provider provider, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/controller/UserAuthController.java
@@ -53,4 +53,12 @@ public class UserAuthController implements UserAuthApi {
         userAuthUseCase.linkOauth(provider, request, user.getUserId());
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
+
+    @Override
+    @DeleteMapping("/link-oauth")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> unlinkOauth(@RequestParam Provider provider, @AuthenticationPrincipal SecurityUserDetails user) {
+        userAuthUseCase.unlinkOauth(provider, user.getUserId());
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -8,6 +8,8 @@ import kr.co.pennyway.api.apis.auth.helper.OauthOidcHelper;
 import kr.co.pennyway.api.apis.auth.service.UserOauthSignService;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
+import kr.co.pennyway.domain.domains.oauth.service.OauthService;
 import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import kr.co.pennyway.infra.common.jwt.JwtClaims;
 import kr.co.pennyway.infra.common.jwt.JwtProvider;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserAuthUseCase {
     private final UserOauthSignService userOauthSignService;
+    private final OauthService oauthService;
 
     private final JwtAuthHelper jwtAuthHelper;
     private final OauthOidcHelper oauthOidcHelper;
@@ -51,6 +54,7 @@ public class UserAuthUseCase {
 
     @Transactional
     public void unlinkOauth(Provider provider, Long userId) {
-        userOauthSignService.unlinkOauth(userId, provider);
+        Oauth oauth = userOauthSignService.readOauthForUnlink(userId, provider);
+        oauthService.deleteOauth(oauth);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -48,4 +48,9 @@ public class UserAuthUseCase {
         UserSyncDto userSync = userOauthSignService.isLinkAllowed(userId, provider);
         userOauthSignService.saveUser(null, userSync, provider, payload.sub());
     }
+
+    @Transactional
+    public void unlinkOauth(Provider provider, Long userId) {
+        userOauthSignService.unlinkOauth(userId, provider);
+    }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/OAuthControllerIntegrationTest.java
@@ -8,7 +8,6 @@ import kr.co.pennyway.api.apis.auth.helper.OauthOidcHelper;
 import kr.co.pennyway.api.common.exception.PhoneVerificationErrorCode;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
-import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.common.redis.phone.PhoneCodeKeyType;
 import kr.co.pennyway.domain.common.redis.phone.PhoneCodeService;
 import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
@@ -33,7 +32,6 @@ import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ResourceUtils;
@@ -651,133 +649,6 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .param("provider", provider.name())
                     .contentType("application/json")
                     .content(objectMapper.writeValueAsString(request)));
-        }
-    }
-
-    @Nested
-    @Order(5)
-    @DisplayName("[5] 소셜 회원가입 연동 해제")
-    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-    class OauthUnlinkTest {
-        @Test
-        @Order(1)
-        @WithSecurityMockUser(userId = "15")
-        @Transactional
-        @DisplayName("제공자로 연동한 이력이 존재하지 않으면 404 에러가 발생한다.")
-        void unlinkWithNoOauth() throws Exception {
-            // given
-            User user = createGeneralSignedUser();
-            userService.createUser(user);
-
-            // when
-            ResultActions result = performOauthUnlink(Provider.KAKAO);
-
-            // then
-            result
-                    .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.code").value(OauthErrorCode.NOT_FOUND_OAUTH.causedBy().getCode()))
-                    .andExpect(jsonPath("$.message").value(OauthErrorCode.NOT_FOUND_OAUTH.getExplainError()))
-                    .andDo(print());
-        }
-
-        @Test
-        @Order(2)
-        @WithSecurityMockUser(userId = "16")
-        @Transactional
-        @DisplayName("제공자로 연동한 이력이 soft delete 되어 있으면 404 에러가 발생한다.")
-        void unlinkWithSoftDeletedOauth() throws Exception {
-            // given
-            User user = createOauthSignedUser();
-            Oauth oauth = createOauthAccount(user, Provider.KAKAO);
-
-            userService.createUser(user);
-            oauthService.createOauth(oauth);
-            oauthService.deleteOauth(oauth);
-
-            // when
-            ResultActions result = performOauthUnlink(Provider.KAKAO);
-
-            // then
-            result
-                    .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.code").value(OauthErrorCode.NOT_FOUND_OAUTH.causedBy().getCode()))
-                    .andExpect(jsonPath("$.message").value(OauthErrorCode.NOT_FOUND_OAUTH.getExplainError()))
-                    .andDo(print());
-        }
-
-        @Test
-        @Order(3)
-        @WithSecurityMockUser(userId = "17")
-        @Transactional
-        @DisplayName("연동된 Oauth가 1개이고 일반 회원 이력이 없는 경우에는 409 에러가 발생한다.")
-        void unlinkWithOnlyOauthSignedUser() throws Exception {
-            // given
-            Provider provider = Provider.KAKAO;
-            User user = createOauthSignedUser();
-            Oauth oauth = createOauthAccount(user, provider);
-
-            userService.createUser(user);
-            oauthService.createOauth(oauth);
-
-            // when
-            ResultActions result = performOauthUnlink(provider);
-
-            // then
-            result
-                    .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.code").value(OauthErrorCode.CANNOT_UNLINK_OAUTH.causedBy().getCode()))
-                    .andExpect(jsonPath("$.message").value(OauthErrorCode.CANNOT_UNLINK_OAUTH.getExplainError()))
-                    .andDo(print());
-        }
-
-        @Test
-        @Order(4)
-        @WithSecurityMockUser(userId = "18")
-        @Transactional
-        @DisplayName("연동된 Oauth가 1개이고 일반 회원 이력이 있는 경우에는 연동 해제에 성공한다.")
-        void unlinkWithGeneralSignedUser() throws Exception {
-            // given
-            Provider provider = Provider.KAKAO;
-            User user = createGeneralSignedUser();
-            Oauth oauth = createOauthAccount(user, provider);
-
-            userService.createUser(user);
-            oauthService.createOauth(oauth);
-
-            // when
-            ResultActions result = performOauthUnlink(provider);
-
-            // then
-            result.andExpect(status().isOk()).andDo(print());
-            assertTrue(oauthService.readOauthByOauthIdAndProvider(expectedOauthId, provider).get().isDeleted());
-        }
-
-        @Test
-        @Order(5)
-        @WithSecurityMockUser(userId = "19")
-        @Transactional
-        @DisplayName("연동된 Oauth가 2개 이상이고 일반 회원 이력이 없는 경우에는 연동 해제에 성공한다.")
-        void unlinkWithMultipleOauthSignedUser() throws Exception {
-            // given
-            User user = createOauthSignedUser();
-            Oauth oauth1 = createOauthAccount(user, Provider.KAKAO);
-            Oauth oauth2 = createOauthAccount(user, Provider.GOOGLE);
-
-            userService.createUser(user);
-            oauthService.createOauth(oauth1);
-            oauthService.createOauth(oauth2);
-
-            // when
-            ResultActions result = performOauthUnlink(Provider.KAKAO);
-
-            // then
-            result.andExpect(status().isOk()).andDo(print());
-            assertTrue(oauthService.readOauthByOauthIdAndProvider(expectedOauthId, Provider.KAKAO).get().isDeleted());
-        }
-
-        private ResultActions performOauthUnlink(Provider provider) throws Exception {
-            return mockMvc.perform(MockMvcRequestBuilders.delete("/v1/link-oauth")
-                    .param("provider", provider.name()));
         }
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCaseUnitTest.java
@@ -8,6 +8,7 @@ import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenProvider;
 import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
 import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenService;
+import kr.co.pennyway.domain.domains.oauth.service.OauthService;
 import kr.co.pennyway.infra.common.exception.JwtErrorCode;
 import kr.co.pennyway.infra.common.exception.JwtErrorException;
 import kr.co.pennyway.infra.common.jwt.JwtClaims;
@@ -37,6 +38,8 @@ public class UserAuthUseCaseUnitTest {
     @Mock
     private UserOauthSignService userOauthSignService;
     @Mock
+    private OauthService oauthService;
+    @Mock
     private OauthOidcHelper oauthOidcHelper;
     @Mock
     private JwtProvider refreshTokenProvider;
@@ -49,7 +52,7 @@ public class UserAuthUseCaseUnitTest {
     public void setUp() {
         accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMinutes(5));
         jwtAuthHelper = new JwtAuthHelper(accessTokenProvider, refreshTokenProvider, refreshTokenService, forbiddenTokenService);
-        userAuthUseCase = new UserAuthUseCase(userOauthSignService, jwtAuthHelper, oauthOidcHelper, accessTokenProvider);
+        userAuthUseCase = new UserAuthUseCase(userOauthSignService, oauthService, jwtAuthHelper, oauthOidcHelper, accessTokenProvider);
     }
 
     @Test
@@ -57,7 +60,7 @@ public class UserAuthUseCaseUnitTest {
     public void isSignedInWithExpiredToken() {
         // given
         accessTokenProvider = new AccessTokenProvider(secretStr, Duration.ofMillis(0));
-        userAuthUseCase = new UserAuthUseCase(userOauthSignService, jwtAuthHelper, oauthOidcHelper, accessTokenProvider);
+        userAuthUseCase = new UserAuthUseCase(userOauthSignService, oauthService, jwtAuthHelper, oauthOidcHelper, accessTokenProvider);
         String expiredToken = accessTokenProvider.generateToken(jwtClaims);
 
         // when

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/exception/OauthErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/exception/OauthErrorCode.java
@@ -20,6 +20,7 @@ public enum OauthErrorCode implements BaseErrorCode {
     NOT_FOUND_OAUTH(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "해당 제공자로 가입된 이력을 찾을 수 없습니다."),
 
     /* 409 Conflict */
+    CANNOT_UNLINK_OAUTH(StatusCode.CONFLICT, ReasonCode.REQUEST_CONFLICTS_WITH_CURRENT_STATE_OF_RESOURCE, "해당 제공자로만 가입된 사용자는 연동을 해제할 수 없습니다."),
     ALREADY_SIGNUP_OAUTH(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 해당 제공자로 가입된 사용자입니다."),
 
     /* 422 Unprocessable Entity */

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/repository/OauthRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/repository/OauthRepository.java
@@ -5,11 +5,14 @@ import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.Set;
 
 public interface OauthRepository extends JpaRepository<Oauth, Long> {
     Optional<Oauth> findByOauthIdAndProvider(String oauthId, Provider provider);
 
     Optional<Oauth> findByUser_IdAndProvider(Long userId, Provider provider);
+
+    Set<Oauth> findAllByUser_Id(Long userId);
 
     boolean existsByUser_IdAndProvider(Long userId, Provider provider);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.Set;
 
 @DomainService
 @RequiredArgsConstructor
@@ -32,6 +33,11 @@ public class OauthService {
     @Transactional(readOnly = true)
     public Optional<Oauth> readOauthByUserIdAndProvider(Long userId, Provider provider) {
         return oauthRepository.findByUser_IdAndProvider(userId, provider);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Oauth> readOauthsByUserId(Long userId) {
+        return oauthRepository.findAllByUser_Id(userId);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 작업 이유
- 인증된 사용자가 임의의 Provider 계정 연동을 제거하기 위한 Use Case를 실현하는 API

<br/>

## 작업 사항
### 1️⃣ 시나리오
**🟡 요청 스펙**
- method : `Delete`
- url : `/v1/link-oauth`
- parameter : `Provider`
- pre-condition : `isAuthenticated`

<br/>

**🟡 서비스 로직 플로우**
```java
@Transactional(readOnly = true)
public Oauth readOauthForUnlink(Long userId, Provider provider) {
    Set<Oauth> oauths = oauthService.readOauthsByUserId(userId); // 사용자가 가지고 있는 모든 Oauth 정보 조회

    Oauth oauth = oauths.stream()
        .filter(o -> o.getProvider().equals(provider) && !o.isDeleted()) // 삭제되지 않았으면서, Provider가 일치하는 정보 조회
        .findFirst()
        .orElseThrow(() -> new OauthException(OauthErrorCode.NOT_FOUND_OAUTH)); // 없으면 404 에러
    long oauthCount = oauths.stream().filter(o -> !o.isDeleted()).count(); // 삭제되지 않은 Oauth 중 전체 개수 카운트

    User user = oauth.getUser(); // Oauth가 가리키는 유저 조회 (userService.findById(userId)와 동일, but 예외 처리 불필요)

    if (oauthCount == 1 && !user.isGeneralSignedUpUser()) { // 오직 Provider로만 회원가입된 상태면 계정 연동 해제 불가
        throw new OauthException(OauthErrorCode.CANNOT_UNLINK_OAUTH);
    }

    return oauth;
}
```
처음에 `userId`와 `provider`로 Oauth를 조회하지 않고, 바로 모든 Oauth 정보를 조회한 이유는 다음과 같습니다.
- Soft Delete 여부를 판단하는 쿼리를 날리는 메서드를 추가해야 하는 번거로움
- 어차피 유효한 요청이면 모든 Oauth 정보를 가져와야 하는데, 사용자당 기껏 해봐야 최대 3개밖에 가지지 않음

또한 여기서 `oauthCount`를 계산하는 이유는 다음과 같습니다.  
- 사용자가 구글 계정 연동을 해제하려하는데, 일반 회원가입 이력도 없고 구글 계정 연동 이력도 없다면? 계정 삭제로 취급할 것인가?
- 계정 삭제는 보통 사용자가 쉽게 찾지 못 하도록 숨겨두는데, 소셜 계정 연동 해제는 매우 눈에 띄는 곳에 위치함. 차라리 이 경우엔 사용자가 계정 삭제를 하도록 유도하는 것이 낫다고 판단했습니다.

<br/>

### 2️⃣ 테스트 케이스
> ⚠️ 이번 테케는 그리 어렵진 않아서 설명은 패스하겠습니다!
- 제공자로 연동한 이력이 존재하지 않으면 404 에러가 발생한다.
- 제공자로 연동한 이력이 soft delete 되어 있으면 404 에러가 발생한다.
- 연동된 Oauth가 1개이고 일반 회원 이력이 없는 경우에는 409 에러가 발생한다.
- 연동된 Oauth가 1개이고 일반 회원 이력이 있는 경우에는 연동 해제에 성공한다.
- 연동된 Oauth가 2개 이상이고 일반 회원 이력이 없는 경우에는 연동 해제에 성공한다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
1. Service에서 *unlink*() 메서드 하나로 해결하지 않고 둘로 나눈 이유. -> 타당한 이유라고 생각하시나요????
    - 처음에는 UseCase에서 Service의 *unlink*() 메서드를 호출하고 끝냈지만..저 많은 코드 중 정말 삭제를 위한 동작은 고작 `oauthService.delete(oauth)` 뿐입니다.
    - 나머지는 연동 해지를 위한 동작이 아니라, 연동 해지가 가능한 Oauth 존재를 필터링하는 코드라고 판단했습니다.
    - 따라서 `isAllowd~` 구문의 메서드와 비슷하게 *readOauthForUnlink*()를 사용하여 Oauth 조회만 하고, 삭제는 UseCase에서 처리하도록 리팩토링했습니다. 
2. 추가로 고려해야 할 테스트가 있을까요?

<br/>

## 발견한 이슈
- 없음

