### PR TITLE
✏️ 마이 프로필 조회 시, 소셜 계정 연동 정보 추가

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/OauthAccountDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/OauthAccountDto.java
@@ -1,0 +1,17 @@
+package kr.co.pennyway.api.apis.users.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "Oauth 계정 정보 응답")
+public record OauthAccountDto(
+        @Schema(description = "카카오 계정 연동 여부", example = "true")
+        boolean kakao,
+        @Schema(description = "구글 계정 연동 여부", example = "false")
+        boolean google,
+        @Schema(description = "애플 계정 연동 여부", example = "false")
+        boolean apple
+) {
+    public static OauthAccountDto of(boolean kakao, boolean google, boolean apple) {
+        return new OauthAccountDto(kakao, google, apple);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
@@ -44,7 +44,6 @@ public record UserProfileDto(
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
         @Schema(description = "Oauth 계정 정보")
-        @JsonInclude(JsonInclude.Include.NON_NULL)
         OauthAccountDto oauthAccount
 ) {
     public UserProfileDto {
@@ -57,23 +56,7 @@ public record UserProfileDto(
         Objects.requireNonNull(locked);
         Objects.requireNonNull(notifySetting);
         Objects.requireNonNull(createdAt);
-    }
-
-    public static UserProfileDto from(User user) {
-        return UserProfileDto.builder()
-                .id(user.getId())
-                .username(user.getUsername())
-                .name(user.getName())
-                .passwordUpdatedAt(user.getPasswordUpdatedAt())
-                .profileImageUrl(Objects.toString(user.getProfileImageUrl(), ""))
-                .phone(user.getPhone())
-                .profileVisibility(user.getProfileVisibility())
-                .locked(user.getLocked())
-                .notifySetting(user.getNotifySetting())
-                .isOauthAccount(user.getPassword() == null)
-                .createdAt(user.getCreatedAt())
-                .oauthAccount(null)
-                .build();
+        Objects.requireNonNull(oauthAccount);
     }
 
     public static UserProfileDto from(User user, OauthAccountDto oauthAccount) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
@@ -42,7 +42,10 @@ public record UserProfileDto(
         @Schema(description = "계정 생성 일시", type = "string", example = "yyyy-MM-dd HH:mm:ss")
         @JsonSerialize(using = LocalDateTimeSerializer.class)
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        @Schema(description = "Oauth 계정 정보")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        OauthAccountDto oauthAccount
 ) {
     public UserProfileDto {
         Objects.requireNonNull(id);
@@ -69,6 +72,24 @@ public record UserProfileDto(
                 .notifySetting(user.getNotifySetting())
                 .isOauthAccount(user.getPassword() == null)
                 .createdAt(user.getCreatedAt())
+                .oauthAccount(null)
+                .build();
+    }
+
+    public static UserProfileDto from(User user, OauthAccountDto oauthAccount) {
+        return UserProfileDto.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .name(user.getName())
+                .passwordUpdatedAt(user.getPasswordUpdatedAt())
+                .profileImageUrl(Objects.toString(user.getProfileImageUrl(), ""))
+                .phone(user.getPhone())
+                .profileVisibility(user.getProfileVisibility())
+                .locked(user.getLocked())
+                .notifySetting(user.getNotifySetting())
+                .isOauthAccount(user.getPassword() == null)
+                .createdAt(user.getCreatedAt())
+                .oauthAccount(oauthAccount)
                 .build();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
@@ -22,8 +22,8 @@ public record UserProfileDto(
         String username,
         @Schema(description = "사용자 이름", example = "홍길동")
         String name,
-        @Schema(description = "Oauth 계정 여부. 일반 회원가입 계정이 있으면 true, 없으면 false", example = "false")
-        boolean isOauthAccount,
+        @Schema(description = "일반 회원가입 이력. 일반 회원가입 계정이 있으면 true, 없으면 false", example = "false")
+        boolean isGeneralSignUp,
         @Schema(description = "비밀번호 변경 일시. isOauthAccount가 true면 존재하지 않는 필드", nullable = true, type = "string", example = "yyyy-MM-dd HH:mm:ss")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonSerialize(using = LocalDateTimeSerializer.class)
@@ -70,7 +70,7 @@ public record UserProfileDto(
                 .profileVisibility(user.getProfileVisibility())
                 .locked(user.getLocked())
                 .notifySetting(user.getNotifySetting())
-                .isOauthAccount(user.getPassword() == null)
+                .isGeneralSignUp(user.isGeneralSignedUpUser())
                 .createdAt(user.getCreatedAt())
                 .oauthAccount(oauthAccount)
                 .build();

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/mapper/UserProfileMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/mapper/UserProfileMapper.java
@@ -1,0 +1,27 @@
+package kr.co.pennyway.api.apis.users.mapper;
+
+import kr.co.pennyway.api.apis.users.dto.OauthAccountDto;
+import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
+import kr.co.pennyway.common.annotation.Mapper;
+import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
+import kr.co.pennyway.domain.domains.user.domain.User;
+
+import java.util.Set;
+
+@Mapper
+public class UserProfileMapper {
+    public static UserProfileDto toUserProfileDto(User user, Set<Oauth> oauths) {
+        boolean kakao, google, apple;
+        kakao = google = apple = false;
+
+        for (Oauth oauth : oauths) {
+            switch (oauth.getProvider()) {
+                case KAKAO -> kakao = true;
+                case GOOGLE -> google = true;
+                case APPLE -> apple = true;
+            }
+        }
+
+        return UserProfileDto.from(user, OauthAccountDto.of(kakao, google, apple));
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -4,6 +4,7 @@ import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
 import kr.co.pennyway.api.apis.users.dto.UserProfileUpdateDto;
 import kr.co.pennyway.api.apis.users.helper.PasswordEncoderHelper;
+import kr.co.pennyway.api.apis.users.mapper.UserProfileMapper;
 import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
 import kr.co.pennyway.api.apis.users.service.UserProfileUpdateService;
 import kr.co.pennyway.common.annotation.UseCase;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -11,6 +11,8 @@ import kr.co.pennyway.domain.domains.device.domain.Device;
 import kr.co.pennyway.domain.domains.device.exception.DeviceErrorCode;
 import kr.co.pennyway.domain.domains.device.exception.DeviceErrorException;
 import kr.co.pennyway.domain.domains.device.service.DeviceService;
+import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
+import kr.co.pennyway.domain.domains.oauth.service.OauthService;
 import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
@@ -20,11 +22,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class UserAccountUseCase {
     private final UserService userService;
+    private final OauthService oauthService;
     private final DeviceService deviceService;
 
     private final UserProfileUpdateService userProfileUpdateService;
@@ -55,8 +61,9 @@ public class UserAccountUseCase {
     @Transactional(readOnly = true)
     public UserProfileDto getMyAccount(Long userId) {
         User user = readUserOrThrow(userId);
+        Set<Oauth> oauths = oauthService.readOauthsByUserId(userId).stream().filter(oauth -> !oauth.isDeleted()).collect(Collectors.toUnmodifiableSet());
 
-        return UserProfileDto.from(user);
+        return UserProfileMapper.toUserProfileDto(user, oauths);
     }
 
     @Transactional

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -12,6 +12,7 @@ import kr.co.pennyway.domain.domains.device.domain.Device;
 import kr.co.pennyway.domain.domains.device.exception.DeviceErrorCode;
 import kr.co.pennyway.domain.domains.device.exception.DeviceErrorException;
 import kr.co.pennyway.domain.domains.device.service.DeviceService;
+import kr.co.pennyway.domain.domains.oauth.service.OauthService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
@@ -55,6 +56,9 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
 
     @MockBean
     private PasswordEncoderHelper passwordEncoderHelper;
+
+    @MockBean
+    private OauthService oauthService;
 
     @Order(1)
     @Nested


### PR DESCRIPTION
## 작업 이유

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/7af5b3b9-a9fa-4d05-ac94-56ae624c43d7" width="600px"/>
</div>

- 소셜 계정 연동 정보를 위한 응답 개선

<br/>

## 작업 사항
1. `OauthService`를 사용하여 delete 되지 않은 사용자의 연동 provider 정보 조회
2. `UserProfileMapper`를 사용하여 Entity를 Dto와 binding

<br/>

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/2b1f3ef0-dadb-4f34-be73-1e9431ac998b" width="600px"/>
</div>

제건 소셜 계정 연동이 안 되어 있어서 희진님 걸로 확인해봤더니 잘 동작하네요.  
soft delete 처리하면 마찬가지로 false로 나옵니다.  

왜 테스트 케이스를 안 썼냐구요? 그러게요..  
테케 없이도 쉽게 확인 가능한 부분이라 굳이 작성하지 않았습니다.

<br/>

### 💡추가 변경 사항!!!! (위 이미지에 반영 안 되어 있음)

기존에 사용자가 소셜 계정만 있는 유저인지 판단하는 `isOauthUser` 필드값이 있었는데, 이게 다소 모호한 표현이라 생각했습니다.  
예를 들어, 구글 계정을 연동했는데 일반 회원가입을 하면 `isOauthUser == false`라고 반환이 되었거든요.  

그래서 현재는 `isGeneralSignUp` 필드로 수정했습니다.  
이러면 일반 회원 가입 이력이 존재하는지 안 하는지만을 분명하게 표현 가능하다고 판단했습니다. 

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
Mapper를 이렇게 써보면 좋지 않을까..싶어서 사용해봤습니다.  
Mapper를 활용하지 않으면 아래처럼 작성해줘야 합니다.

```java
@Transactional(readOnly = true)
public UserProfileDto getMyAccount(Long userId) {
    User user = readUserOrThrow(userId);
    Set<Oauth> oauths = oauthService.readOauthsByUserId(userId).stream().filter(oauth -> !oauth.isDeleted()).collect(Collectors.toUnmodifiableSet());

    boolean kakao, google, apple;
    kakao = google = apple = false;

    for (Oauth oauth : oauths) {
        switch (oauth.getProvider()) {
            case KAKAO -> kakao = true;
            case GOOGLE -> google = true;
            case APPLE -> apple = true;
        }
    }

    return UserProfileDto.from(user, OauthAccountDto.of(kakao, google, apple));
}
```

혹은

```java
public static UserProfileDto from(User user, Set<Oauth> oauths) {
    boolean kakao, google, apple;
    kakao = google = apple = false;

    for (Oauth oauth : oauths) {
        switch (oauth.getProvider()) {
            case KAKAO -> kakao = true;
            case GOOGLE -> google = true;
            case APPLE -> apple = true;
        }
    }

    return UserProfileDto.from(user, OauthAccountDto.of(kakao, google, apple));
}
```

하지만 단순히 정보를 Dto로 바인딩 시켜주는 것이 Service 로직에 포함되는 것도 이상하고,  
Dto 팩토리 메서드에서 처리하는 것도 깔끔하진 않은 것 같았습니다.  

그래서 Dto를 바인딩하기 위한 목적만을 갖는 Mapper를 사용해봤는데 어떤가요??

<br/>

## 발견한 이슈
- 없음

