### PR TITLE
✨ 사용자 계정 삭제 API 

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -197,6 +197,6 @@ public interface UserAccountApi {
     })
     ResponseEntity<?> deleteNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user);
 
-    @Operation(summary = "사용자 계정 삭제")
+    @Operation(summary = "사용자 계정 삭제", description = "사용자 본인의 계정을 삭제합니다. 채팅방 방장이면 삭제가 안 되는 시나리오는 고려하지 않고 있습니다.")
     ResponseEntity<?> deleteAccount(@AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -196,4 +196,7 @@ public interface UserAccountApi {
             }))
     })
     ResponseEntity<?> deleteNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "사용자 계정 삭제")
+    ResponseEntity<?> deleteAccount(@AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -92,7 +92,9 @@ public class UserAccountController implements UserAccountApi {
     }
 
     @Override
-    public ResponseEntity<?> deleteAccount(SecurityUserDetails user) {
+    @DeleteMapping("")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> deleteAccount(@AuthenticationPrincipal SecurityUserDetails user) {
         userAccountUseCase.deleteAccount(user.getUserId());
         return ResponseEntity.ok(SuccessResponse.noContent());
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -90,4 +90,10 @@ public class UserAccountController implements UserAccountApi {
     public ResponseEntity<?> deleteNotifySetting(@RequestParam NotifySetting.NotifyType type, @AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from("notifySetting", userAccountUseCase.deactivateNotification(user.getUserId(), type)));
     }
+
+    @Override
+    public ResponseEntity<?> deleteAccount(SecurityUserDetails user) {
+        userAccountUseCase.deleteAccount(user.getUserId());
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserDeleteService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserDeleteService.java
@@ -1,0 +1,30 @@
+package kr.co.pennyway.api.apis.users.service;
+
+import kr.co.pennyway.domain.domains.oauth.service.OauthService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 사용자 삭제만을 담당하는 클래스 <br/>
+ * 추후 연관 관계의 데이터가 늘어나면 Template Method Pattern을 적용하여 단위 테스트를 수행할 수 있도록 한다.
+ *
+ * @author YANG JAESEO
+ * @since 2024.05.03
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserDeleteService {
+    private final UserService userService;
+    private final OauthService oauthService;
+
+    @Transactional
+    public void deleteUser(User user) {
+        oauthService.deleteOauthsByUserId(user.getId());
+        userService.deleteUser(user);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserDeleteService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserDeleteService.java
@@ -1,7 +1,6 @@
 package kr.co.pennyway.api.apis.users.service;
 
 import kr.co.pennyway.domain.domains.oauth.service.OauthService;
-import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,8 +22,8 @@ public class UserDeleteService {
     private final OauthService oauthService;
 
     @Transactional
-    public void deleteUser(User user) {
-        oauthService.deleteOauthsByUserId(user.getId());
-        userService.deleteUser(user);
+    public void deleteUser(Long userId) {
+        oauthService.deleteOauthsByUserId(userId);
+        userService.deleteUser(userId);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -6,6 +6,7 @@ import kr.co.pennyway.api.apis.users.dto.UserProfileUpdateDto;
 import kr.co.pennyway.api.apis.users.helper.PasswordEncoderHelper;
 import kr.co.pennyway.api.apis.users.mapper.UserProfileMapper;
 import kr.co.pennyway.api.apis.users.service.DeviceRegisterService;
+import kr.co.pennyway.api.apis.users.service.UserDeleteService;
 import kr.co.pennyway.api.apis.users.service.UserProfileUpdateService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.device.domain.Device;
@@ -35,6 +36,7 @@ public class UserAccountUseCase {
     private final DeviceService deviceService;
 
     private final UserProfileUpdateService userProfileUpdateService;
+    private final UserDeleteService userDeleteService;
     private final DeviceRegisterService deviceRegisterService;
 
     private final PasswordEncoderHelper passwordEncoderHelper;
@@ -121,7 +123,7 @@ public class UserAccountUseCase {
 
         // TODO: [2024-05-03] 하나라도 채팅방의 방장으로 참여하는 경우 삭제 불가능 처리
 
-        userService.deleteUser(user);
+        userDeleteService.deleteUser(user);
     }
 
     private User readUserOrThrow(Long userId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -115,6 +115,13 @@ public class UserAccountUseCase {
         return UserProfileUpdateDto.NotifySettingUpdateReq.of(type, Boolean.FALSE);
     }
 
+    @Transactional
+    public void deleteAccount(Long userId) {
+        User user = readUserOrThrow(userId);
+
+
+    }
+
     private User readUserOrThrow(Long userId) {
         return userService.readUser(userId).orElseThrow(
                 () -> {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -119,11 +119,11 @@ public class UserAccountUseCase {
 
     @Transactional
     public void deleteAccount(Long userId) {
-        User user = readUserOrThrow(userId);
+        if (!userService.isExistUser(userId)) throw new UserErrorException(UserErrorCode.NOT_FOUND);
 
         // TODO: [2024-05-03] 하나라도 채팅방의 방장으로 참여하는 경우 삭제 불가능 처리
 
-        userDeleteService.deleteUser(user);
+        userDeleteService.deleteUser(userId);
     }
 
     private User readUserOrThrow(Long userId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -119,7 +119,9 @@ public class UserAccountUseCase {
     public void deleteAccount(Long userId) {
         User user = readUserOrThrow(userId);
 
+        // TODO: [2024-05-03] 하나라도 채팅방의 방장으로 참여하는 경우 삭제 불가능 처리
 
+        userService.deleteUser(user);
     }
 
     private User readUserOrThrow(Long userId) {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -462,4 +462,44 @@ public class UserAccountControllerUnitTest {
                     .content(objectMapper.writeValueAsString(request)));
         }
     }
+
+    @Nested
+    @Order(6)
+    @DisplayName("[6] 사용자 계정 삭제 테스트")
+    class DeleteAccountTest {
+        @DisplayName("사용자 계정 삭제 요청 시, 삭제된 사용자인 경우 404 에러를 반환한다.")
+        @Test
+        @WithSecurityMockUser
+        void deleteAccountDeletedUser() throws Exception {
+            // given
+            willThrow(new UserErrorException(UserErrorCode.NOT_FOUND)).given(userAccountUseCase).deleteAccount(1L);
+
+            // when
+            ResultActions result = performDeleteAccountRequest();
+
+            // then
+            result.andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(UserErrorCode.NOT_FOUND.causedBy().getCode()))
+                    .andExpect(jsonPath("$.message").value(UserErrorCode.NOT_FOUND.getExplainError()))
+                    .andDo(print());
+        }
+
+        @DisplayName("사용자 계정 삭제 요청 시, 사용자 계정이 정상적으로 삭제되면 200 코드를 반환한다.")
+        @Test
+        @WithSecurityMockUser
+        void deleteAccountSuccess() throws Exception {
+            // when
+            ResultActions result = performDeleteAccountRequest();
+
+            // then
+            result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("2000"))
+                    .andDo(print());
+        }
+
+        private ResultActions performDeleteAccountRequest() throws Exception {
+            return mockMvc.perform(delete("/v2/users/me")
+                    .contentType("application/json"));
+        }
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/repository/OauthRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/repository/OauthRepository.java
@@ -3,6 +3,9 @@ package kr.co.pennyway.domain.domains.oauth.repository;
 import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
 import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 import java.util.Set;
@@ -15,4 +18,9 @@ public interface OauthRepository extends JpaRepository<Oauth, Long> {
     Set<Oauth> findAllByUser_Id(Long userId);
 
     boolean existsByUser_IdAndProvider(Long userId, Provider provider);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Oauth o SET o.deletedAt = NOW() WHERE o.user.id = :userId AND o.deletedAt IS NULL")
+    void deleteAllByUser_IdAndDeletedAtNullInQuery(Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -49,4 +49,9 @@ public class OauthService {
     public void deleteOauth(Oauth oauth) {
         oauthRepository.delete(oauth);
     }
+
+    @Transactional
+    public void deleteOauthsByUserId(Long userId) {
+        oauthRepository.deleteAllByUser_IdAndDeletedAtNullInQuery(userId);
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/repository/UserRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/repository/UserRepository.java
@@ -2,6 +2,9 @@ package kr.co.pennyway.domain.domains.user.repository;
 
 import kr.co.pennyway.domain.domains.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -11,4 +14,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     boolean existsByUsername(String username);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE User u SET u.deletedAt = NOW() WHERE u.id = :userId")
+    void deleteByIdInQuery(Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/service/UserService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/service/UserService.java
@@ -47,4 +47,9 @@ public class UserService {
     public void deleteUser(User user) {
         userRepository.delete(user);
     }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        userRepository.deleteByIdInQuery(userId);
+    }
 }


### PR DESCRIPTION
## 작업 이유
- 사용자 자신의 계정을 삭제하는 UseCase를 실현하는 API

<br/>

## 작업 사항
기능 자체는 간단한데, 몇 가지 의문 사항이 있을 것 같아 작성합니다.

이미 알고 계실 수도 있겠지만, Jpa 메서드의 `delete`나 영속화 관계를 사용하여 연관 관계 정보를 삭제하는 아이디어는 양이 많을 수록 성능 저하를 유발합니다.  
- 혹시 모르는 내용이라면 [참고 블로그](https://jojoldu.tistory.com/235)를 확인해보시면 됩니다.
- `deleteAll` 또한 entityManager를 재생성하지 않을 뿐, 내부적으로 반복문을 사용하기 때문에 쿼리가 엄청 많이 나갑니다.

<br/>

따라서 저는 `@Query`를 사용하여 다음과 같이 처리했습니다.
```java
@Transactional
@Modifying(clearAutomatically = true)
@Query("UPDATE Oauth o SET o.deletedAt = NOW() WHERE o.user.id = :userId AND o.deletedAt IS NULL")
void deleteAllByUser_IdAndDeletedAtNullInQuery(Long userId);
```
- 벌크 연산을 이용해 한 번에 삭제하는 방식입니다.

> 🤔 `deleteAllInBatch`를 쓰지 않은 이유? `clearAutomatically = true`는 또 뭔가요?
> 
> `clearAutomatically = true` 옵션이 없으면 해당 메서드는 `deleteAllInBatch`와 큰 차이가 없습니다.
> 그런데 벌크 연산의 가장 큰 문제는 Jpa의 1차 캐시를 무시하기 때문에 DB와 1차 캐시 데이터 불일치 문제가 발생합니다.
> 하지만 여기서 ``clearAutomatically = true` 옵션을 걸면 벌크 연산 실행 후, 1차 캐시의 모든 영속화 정보를 제거합니다.
> 즉, 삭제 벌크 연산이 발생한 후 다시 조회를 하려고 해도 영속화 단계부터 시작하도록 만드는 것입니다.
> 
> [batch 주의할 점](https://stackoverflow.com/questions/26142261/spring-jparepostory-delete-vs-deleteinbatch)
> [Modifying 주의할 점](https://hstory0208.tistory.com/entry/JPA-Modifying%EC%9D%B4%EB%9E%80-%EA%B7%B8%EB%A6%AC%EA%B3%A0-%EC%A3%BC%EC%9D%98%ED%95%A0%EC%A0%90-%EB%B2%8C%ED%81%AC-%EC%97%B0%EC%82%B0)

<br/>

하지만 위의 방식처럼 1차 캐시 정보를 모두 제거해버리면 user entity를 제거할 때 문제가 발생합니다.  

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/04046b36-dea2-4d63-892d-a3de6dd6559d" width="700px"/>
</div>

- oauth 정보들을 제거하면서 1차 캐시 정보가 모두 제거됨.
- user를 삭제하려고 했으나 얘는 벌크 연산이 아니라서 user entity를 다시 영속화한 후 제거하는 과정을 밟게 됨.

<br/>

이게 마음에 안 들어서 UseCase에서 User를 조회하여 영속화 하는 과정을 `existsBy` 구문으로 대체함.  
그리고 User Entity 또한 벌크 연산을 통해서 영속화 없이 제거하도록 수정하였습니다.

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/21711ddb-6f8e-4e7c-8273-a4121ba8a705" width="700px"/>
</div>

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 사용자 삭제 기능은 추후 기능이 추가될 수록 지속적으로 개선되어야 할 기능 중 하나라고 생각하여 `UserDeleteService`를 별도로 생성하여 템플릿 메서드 패턴으로 관리할 예정입니다. 적절한 접근법이라 생각하시나요?
- Jpa `delete`와 영속성 기반 삭제 대신 벌크 연산을 채택한 이유와 근거가 적절하다고 생각하시나요?
- UserService의 `deleteUser(User user)`는 벌크 연산이 아니지만, `deleteUser(Long userId)`는 벌크 연산입니다. 굳이 영속화된 객체가 아닌 pk값을 사용해 삭제하는 것은 특수한 경우라 판단했기 때문입니다. 
   - `deleteUser(Long userId)`가 벌크 연산을 수행한다는 것을 메서드 명으로 표현하거나, 주석을 다는 것이 적절하다고 보시나요?
   - 개인적으로는 그러한 정보를 외부에 공개할 이유가 없다고 생각해서 감춰둔 상태입니다.


<br/>

## 발견한 이슈
- `existsBy`를 사용할 때 Jpa가 내부적으로 `limit 1`을 사용한다고 알고 있는데 그렇지 않음.
   - QueryDsl 세팅하고 난 후에 해당 메서드를 queryDsl 메서드로 연결하여 개선할 예정.
   - [exists 성능 개선](https://jojoldu.tistory.com/516)