### PR TITLE
🐛 사용자 삭제 시나리오 개선

### DIFF
--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -489,6 +489,23 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
             assertTrue("구글 계정이 삭제되어 있어야 한다.", oauthService.readOauth(google.getId()).get().isDeleted());
         }
 
+        @Test
+        @Transactional
+        @DisplayName("사용자 삭제 시, 디바이스 정보는 CASCADE로 삭제되어야 한다.")
+        void deleteAccountWithDevices() {
+            // given
+            User user = UserFixture.GENERAL_USER.toUser();
+            userService.createUser(user);
+
+            Device device = DeviceFixture.ORIGIN_DEVICE.toDevice(user);
+            deviceService.createDevice(device);
+
+            // when - then
+            assertDoesNotThrow(() -> userAccountUseCase.deleteAccount(user.getId()));
+            assertTrue("사용자가 삭제되어 있어야 한다.", userService.readUser(user.getId()).isEmpty());
+            assertTrue("디바이스가 삭제되어 있어야 한다.", deviceService.readDeviceByUserIdAndToken(user.getId(), device.getToken()).isEmpty());
+        }
+
         private Oauth createOauth(Provider provider, String providerId, User user) {
             Oauth oauth = Oauth.of(provider, providerId, user);
             return oauthService.createOauth(oauth);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCaseTest.java
@@ -446,7 +446,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
     class DeleteAccountTest {
         @Test
         @Transactional
-        @DisplayName("사용자가 삭제된 유저인 경우 NOT_FOUND 에러를 반환한다.")
+        @DisplayName("사용자가 삭제된 유저를 조회하려는 경우 NOT_FOUND 에러를 반환한다.")
         void deleteAccountWhenUserIsDeleted() {
             // given
             User user = UserFixture.GENERAL_USER.toUser();
@@ -473,7 +473,7 @@ class UserAccountUseCaseTest extends ExternalApiDBTestConfig {
 
         @Test
         @Transactional
-        @DisplayName("삭제 시, 연동된 모든 소셜 계정은 soft delete 처리되어야 한다.")
+        @DisplayName("사용자 계정 삭제 시, 연동된 모든 소셜 계정은 soft delete 처리되어야 한다.")
         void deleteAccountWithSocialAccounts() {
             // given
             User user = UserFixture.OAUTH_USER.toUser();

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/Device.java
@@ -23,7 +23,7 @@ public class Device extends DateAuditable {
     @ColumnDefault("true")
     private Boolean activated;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -66,6 +66,7 @@ public class Device extends DateAuditable {
                 "id=" + id +
                 ", token='" + token + '\'' +
                 ", model='" + model + '\'' +
-                ", os='" + os + '}';
+                ", os='" + os + '\'' +
+                ", activated=" + activated + '}';
     }
 }


### PR DESCRIPTION
## 작업 이유
- 사용자 삭제 시, 매핑된 device 정보 삭제 확인
- unique 필드에 해당하는 phone과 username의 처리

<br/>

## 작업 사항
코드는 딱히 수정된 게 없습니다.  

Device에서 User 매핑을 할 때 `CaseCade.Remove` 속성을 줌으로써 삭제가 되는 것을 확인했습니다.
```java
@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
@JoinColumn(name = "user_id")
private User user;
```

<br/>

User의 `phone`과 `username`의 경우, 삭제가 되면 null로 수정하려고 했는데 문제가 있었습니다.  
> 현재는 DB에서 두 필드 모두 unique로 설정되어 있어서, 회원 탈퇴한 유저가 동일한 번호로 회원가입하거나, 다른 사용자가 탈퇴한 사용자의 닉네임을 사용하려 하는 경우 문제가 발생합니다.

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/9659e19e-61e2-470b-9b1d-ff1ee2ec6803" width="500px"/>
</div>

1. null로 수정하려면 `phone`과 `username`의 not null 옵션을 해제해야 합니다.
2. null로 수정하면 unique한 값이 되지 않으므로 이 또한 해제해야 합니다.

즉, 전화번호와 아이디를 null로 처리하는 방식은 두 필드의 not null과 unique를 옵션을 모두 제거해야 합니다.  
하지만 not null을 제거하는 건 데이터를 저장할 때 위험하지 않을까 싶어서 `unique` 옵션만을 해제하고, 사용자가 계정을 삭제해도 전화번호와 아이디를 삭제하지 않는 방향으로 수정하려 합니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 두 번째 unique 필드를 해제하는 방식으로 처리하는 것이 적절하다고 보시나요??

<br/>

## 발견한 이슈
이슈라기 보다는 의문에 가까운데, 사용자 계정을 삭제할 때 벌크 연산을 하므로 JPA의 1차 캐시를 넘어서 User를 바로 삭제하고 있습니다.  
DB 상에선 Device의 `user_id` 필드에 `CASCADE` 옵션을 걸어놨기 때문에 User가 삭제되면 함께 삭제되겠지만, DB 입장에선 삭제가 아니라 수정이니까 해당 옵션이 동작하지 않을 거라 생각했습니다. (테스트 환경에서도 문제..해당 필드에 CASCADE 옵션이 걸릴 지, 다른 게 걸릴 지 모르겠음)  

그래서 Device의 매핑 관계로 우선 CaseCade Remove 옵션을 걸어보긴 했는데, 이게 왜 되는지 모르겠네요 ㅎㅎ;


