### PR TITLE
✨ 사용자 커스텀 지출 카테고리 등록 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
@@ -5,33 +5,18 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "지출 내역 API")
 public interface SpendingApi {
-    @Operation(summary = "지출 내역 카테고리 등록", method = "POST", description = "사용자 커스텀 지출 카테고리를 생성합니다.")
-    @Parameters({
-            @Parameter(name = "name", description = "카테고리 이름", required = true, in = ParameterIn.QUERY),
-            @Parameter(name = "icon", description = "카테고리 아이콘", required = true, in = ParameterIn.QUERY, examples = {
-                    @ExampleObject(name = "식사", value = "FOOD"), @ExampleObject(name = "교통", value = "TRANSPORTATION"), @ExampleObject(name = "뷰티/패션", value = "BEAUTY_OR_FASHION"),
-                    @ExampleObject(name = "편의점/마트", value = "CONVENIENCE_STORE"), @ExampleObject(name = "교육", value = "EDUCATION"), @ExampleObject(name = "생활", value = "LIVING"),
-                    @ExampleObject(name = "건강", value = "HEALTH"), @ExampleObject(name = "취미/여가", value = "HOBBY"), @ExampleObject(name = "여행/숙박", value = "TRAVEL"),
-                    @ExampleObject(name = "술/유흥", value = "ALCOHOL_OR_ENTERTAINMENT"), @ExampleObject(name = "회비/경조사", value = "MEMBERSHIP_OR_FAMILY_EVENT")
-            })
-    })
-    ResponseEntity<?> postSpendingCategory(@Validated SpendingCategoryDto.CreateParamReq param, @AuthenticationPrincipal SecurityUserDetails user);
-
     @Operation(summary = "지출 내역 조회", method = "GET", description = "사용자의 해당 년/월 지출 내역을 조회하고 월/일별 지출 총합을 반환합니다.")
     @Parameters({
             @Parameter(name = "year", description = "년도", required = true, in = ParameterIn.HEADER),

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
@@ -5,18 +5,33 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "지출 내역 API")
 public interface SpendingApi {
+    @Operation(summary = "지출 내역 카테고리 등록", method = "POST", description = "사용자 커스텀 지출 카테고리를 생성합니다.")
+    @Parameters({
+            @Parameter(name = "name", description = "카테고리 이름", required = true, in = ParameterIn.QUERY),
+            @Parameter(name = "icon", description = "카테고리 아이콘", required = true, in = ParameterIn.QUERY, examples = {
+                    @ExampleObject(name = "식사", value = "FOOD"), @ExampleObject(name = "교통", value = "TRANSPORTATION"), @ExampleObject(name = "뷰티/패션", value = "BEAUTY_OR_FASHION"),
+                    @ExampleObject(name = "편의점/마트", value = "CONVENIENCE_STORE"), @ExampleObject(name = "교육", value = "EDUCATION"), @ExampleObject(name = "생활", value = "LIVING"),
+                    @ExampleObject(name = "건강", value = "HEALTH"), @ExampleObject(name = "취미/여가", value = "HOBBY"), @ExampleObject(name = "여행/숙박", value = "TRAVEL"),
+                    @ExampleObject(name = "술/유흥", value = "ALCOHOL_OR_ENTERTAINMENT"), @ExampleObject(name = "회비/경조사", value = "MEMBERSHIP_OR_FAMILY_EVENT")
+            })
+    })
+    ResponseEntity<?> postSpendingCategory(@Validated SpendingCategoryDto.CreateParamReq param, @AuthenticationPrincipal SecurityUserDetails user);
+
     @Operation(summary = "지출 내역 조회", method = "GET", description = "사용자의 해당 년/월 지출 내역을 조회하고 월/일별 지출 총합을 반환합니다.")
     @Parameters({
             @Parameter(name = "year", description = "년도", required = true, in = ParameterIn.HEADER),

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingCategoryApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingCategoryApi.java
@@ -1,0 +1,28 @@
+package kr.co.pennyway.api.apis.ledger.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+
+@Tag(name = "지출 카테고리 API")
+public interface SpendingCategoryApi {
+    @Operation(summary = "지출 내역 카테고리 등록", method = "POST", description = "사용자 커스텀 지출 카테고리를 생성합니다.")
+    @Parameters({
+            @Parameter(name = "name", description = "카테고리 이름", required = true, in = ParameterIn.QUERY),
+            @Parameter(name = "icon", description = "카테고리 아이콘", required = true, in = ParameterIn.QUERY, examples = {
+                    @ExampleObject(name = "식사", value = "FOOD"), @ExampleObject(name = "교통", value = "TRANSPORTATION"), @ExampleObject(name = "뷰티/패션", value = "BEAUTY_OR_FASHION"),
+                    @ExampleObject(name = "편의점/마트", value = "CONVENIENCE_STORE"), @ExampleObject(name = "교육", value = "EDUCATION"), @ExampleObject(name = "생활", value = "LIVING"),
+                    @ExampleObject(name = "건강", value = "HEALTH"), @ExampleObject(name = "취미/여가", value = "HOBBY"), @ExampleObject(name = "여행/숙박", value = "TRAVEL"),
+                    @ExampleObject(name = "술/유흥", value = "ALCOHOL_OR_ENTERTAINMENT"), @ExampleObject(name = "회비/경조사", value = "MEMBERSHIP_OR_FAMILY_EVENT")
+            })
+    })
+    ResponseEntity<?> postSpendingCategory(@Validated SpendingCategoryDto.CreateParamReq param, @AuthenticationPrincipal SecurityUserDetails user);
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingCategoryApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingCategoryApi.java
@@ -17,12 +17,13 @@ public interface SpendingCategoryApi {
     @Operation(summary = "지출 내역 카테고리 등록", method = "POST", description = "사용자 커스텀 지출 카테고리를 생성합니다.")
     @Parameters({
             @Parameter(name = "name", description = "카테고리 이름", required = true, in = ParameterIn.QUERY),
-            @Parameter(name = "icon", description = "카테고리 아이콘", required = true, in = ParameterIn.QUERY, examples = {
+            @Parameter(name = "icon", description = "카테고리 아이콘. 대문자만 허용합니다.", required = true, in = ParameterIn.QUERY, examples = {
                     @ExampleObject(name = "식사", value = "FOOD"), @ExampleObject(name = "교통", value = "TRANSPORTATION"), @ExampleObject(name = "뷰티/패션", value = "BEAUTY_OR_FASHION"),
                     @ExampleObject(name = "편의점/마트", value = "CONVENIENCE_STORE"), @ExampleObject(name = "교육", value = "EDUCATION"), @ExampleObject(name = "생활", value = "LIVING"),
                     @ExampleObject(name = "건강", value = "HEALTH"), @ExampleObject(name = "취미/여가", value = "HOBBY"), @ExampleObject(name = "여행/숙박", value = "TRAVEL"),
                     @ExampleObject(name = "술/유흥", value = "ALCOHOL_OR_ENTERTAINMENT"), @ExampleObject(name = "회비/경조사", value = "MEMBERSHIP_OR_FAMILY_EVENT")
-            })
+            }),
+            @Parameter(name = "param", hidden = true)
     })
     ResponseEntity<?> postSpendingCategory(@Validated SpendingCategoryDto.CreateParamReq param, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
@@ -5,6 +5,8 @@ import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
 import kr.co.pennyway.api.apis.ledger.usecase.SpendingCategoryUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
@@ -5,6 +5,7 @@ import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
 import kr.co.pennyway.api.apis.ledger.usecase.SpendingCategoryUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,10 @@ public class SpendingCategoryController implements SpendingCategoryApi {
     @PostMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> postSpendingCategory(@Validated SpendingCategoryDto.CreateParamReq param, @AuthenticationPrincipal SecurityUserDetails user) {
+        if (param.icon().equals(SpendingCategory.OTHER)) {
+            throw new SpendingErrorException(SpendingErrorCode.INVALID_ICON);
+        }
+
         SpendingCategoryDto.Res spendingCategory = spendingCategoryUseCase.createSpendingCategory(user.getUserId(), param.name(), param.icon());
         return ResponseEntity.ok(SuccessResponse.from("spendingCategory", spendingCategory));
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.ledger.controller;
 
 import kr.co.pennyway.api.apis.ledger.api.SpendingCategoryApi;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
+import kr.co.pennyway.api.apis.ledger.usecase.SpendingCategoryUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class SpendingCategoryController implements SpendingCategoryApi {
     @PostMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> postSpendingCategory(@Validated SpendingCategoryDto.CreateParamReq param, @AuthenticationPrincipal SecurityUserDetails user) {
-        return ResponseEntity.ok(SuccessResponse.from("spendingCategory", spendingCategoryUseCase.createSpendingCategory(user.getUserId(), param)));
+        SpendingCategoryDto.Res spendingCategory = spendingCategoryUseCase.createSpendingCategory(user.getUserId(), param.name(), param.icon());
+        return ResponseEntity.ok(SuccessResponse.from("spendingCategory", spendingCategory));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
@@ -1,0 +1,30 @@
+package kr.co.pennyway.api.apis.ledger.controller;
+
+import kr.co.pennyway.api.apis.ledger.api.SpendingCategoryApi;
+import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/spending-categories")
+public class SpendingCategoryController implements SpendingCategoryApi {
+    private final SpendingCategoryUseCase spendingCategoryUseCase;
+
+    @Override
+    @PostMapping("")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> postSpendingCategory(@Validated SpendingCategoryDto.CreateParamReq param, @AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(SuccessResponse.from("spendingCategory", spendingCategoryUseCase.createSpendingCategory(user.getUserId(), param)));
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingCategoryDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingCategoryDto.java
@@ -1,0 +1,55 @@
+package kr.co.pennyway.api.apis.ledger.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
+import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
+import org.springframework.util.StringUtils;
+
+import java.util.Objects;
+
+public class SpendingCategoryDto {
+    public record CreateParamReq(
+            @NotEmpty(message = "카테고리 이름은 필수입니다.")
+            @Size(max = 15, message = "카테고리 이름은 15자 이하로 입력해주세요.")
+            String name,
+            @NotNull(message = "카테고리 아이콘은 필수입니다.")
+            SpendingCategory icon
+    ) {
+    }
+
+    @Schema(title = "지출 카테고리 정보")
+    public record Res(
+            @Schema(description = "사용자 정의 카테고리 여부")
+            boolean isCustom,
+            @Schema(description = "카테고리 ID. 사용자 정의 카테고리가 아니라면 -1, 사용자 정의 카테고리라면 0 이상의 값을 갖는다.")
+            Long id,
+            @Schema(description = "카테고리 이름")
+            String name,
+            @Schema(description = "카테고리 아이콘", examples = {"FOOD", "TRANSPORTATION", "BEAUTY_OR_FASHION", "CONVENIENCE_STORE", "EDUCATION", "LIVING", "HEALTH", "HOBBY", "TRAVEL", "ALCOHOL_OR_ENTERTAINMENT", "MEMBERSHIP_OR_FAMILY_EVENT"})
+            SpendingCategory icon
+    ) {
+        public Res {
+            Objects.requireNonNull(id, "id는 null일 수 없습니다.");
+            Objects.requireNonNull(icon, "icon은 null일 수 없습니다.");
+
+            if (isCustom && id < 0 || !isCustom && id != -1) {
+                throw new IllegalArgumentException("isCustom과 id 정보가 일치하지 않습니다.");
+            }
+
+            if (isCustom && icon.equals(SpendingCategory.OTHER)) {
+                throw new IllegalArgumentException("사용자 정의 카테고리는 OTHER가 될 수 없습니다.");
+            }
+
+            if (!StringUtils.hasText(name)) {
+                throw new IllegalArgumentException("name은 null이거나 빈 문자열일 수 없습니다.");
+            }
+        }
+
+        public static Res from(CategoryInfo category) {
+            return new Res(category.isCustom(), category.id(), category.name(), category.icon());
+        }
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingCategoryDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingCategoryDto.java
@@ -1,7 +1,7 @@
 package kr.co.pennyway.api.apis.ledger.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
@@ -12,7 +12,7 @@ import java.util.Objects;
 
 public class SpendingCategoryDto {
     public record CreateParamReq(
-            @NotEmpty(message = "카테고리 이름은 필수입니다.")
+            @NotBlank(message = "카테고리 이름은 필수입니다.")
             @Size(max = 15, message = "카테고리 이름은 15자 이하로 입력해주세요.")
             String name,
             @NotNull(message = "카테고리 아이콘은 필수입니다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
+import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -48,9 +48,9 @@ public class SpendingSearchRes {
             @Schema(description = "지출 금액")
             @NotNull
             Integer amount,
-            @Schema(description = "지출 아이콘")
+            @Schema(description = "지출 카테고리 정보")
             @NotNull
-            SpendingCategory icon,
+            CategoryInfo category,
             @Schema(description = "지출 일시", example = "2024-05-09")
             @NotNull
             @JsonSerialize(using = LocalDateTimeSerializer.class)
@@ -61,10 +61,10 @@ public class SpendingSearchRes {
             @Schema(description = "메모. 없으면 빈 문자열")
             String memo
     ) {
-        public Individual(Long id, Integer amount, SpendingCategory icon, LocalDateTime spendAt, String accountName, String memo) {
+        public Individual(Long id, Integer amount, CategoryInfo category, LocalDateTime spendAt, String accountName, String memo) {
             this.id = id;
             this.amount = amount;
-            this.icon = icon;
+            this.category = category;
             this.spendAt = spendAt;
             this.accountName = Objects.toString(accountName, "");
             this.memo = Objects.toString(memo, "");

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
+import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -48,9 +48,9 @@ public class SpendingSearchRes {
             @Schema(description = "지출 금액")
             @NotNull
             Integer amount,
-            @Schema(description = "지출 카테고리 정보")
+            @Schema(description = "지출 카테고리 아이콘")
             @NotNull
-            CategoryInfo category,
+            SpendingCategory category,
             @Schema(description = "지출 일시", example = "2024-05-09")
             @NotNull
             @JsonSerialize(using = LocalDateTimeSerializer.class)
@@ -61,7 +61,7 @@ public class SpendingSearchRes {
             @Schema(description = "메모. 없으면 빈 문자열")
             String memo
     ) {
-        public Individual(Long id, Integer amount, CategoryInfo category, LocalDateTime spendAt, String accountName, String memo) {
+        public Individual(Long id, Integer amount, SpendingCategory category, LocalDateTime spendAt, String accountName, String memo) {
             this.id = id;
             this.amount = amount;
             this.category = category;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
@@ -41,7 +41,7 @@ public class SpendingMapper {
         return SpendingSearchRes.Individual.builder()
                 .id(spending.getId())
                 .amount(spending.getAmount())
-                .icon(spending.getCategory())
+                .category(spending.getCategory())
                 .spendAt(spending.getSpendAt())
                 .accountName(spending.getAccountName())
                 .memo(spending.getMemo())

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
@@ -41,7 +41,7 @@ public class SpendingMapper {
         return SpendingSearchRes.Individual.builder()
                 .id(spending.getId())
                 .amount(spending.getAmount())
-                .category(spending.getCategory())
+                .category(spending.getCategory().icon())
                 .spendAt(spending.getSpendAt())
                 .accountName(spending.getAccountName())
                 .memo(spending.getMemo())

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingCategoryUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingCategoryUseCase.java
@@ -1,0 +1,32 @@
+package kr.co.pennyway.api.apis.ledger.usecase;
+
+import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
+import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
+import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
+import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
+import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class SpendingCategoryUseCase {
+    private final UserService userService;
+    private final SpendingCustomCategoryService spendingCustomCategoryService;
+
+    @Transactional
+    public SpendingCategoryDto.Res createSpendingCategory(Long userId, String categoryName, SpendingCategory icon) {
+        User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
+
+        SpendingCustomCategory category = spendingCustomCategoryService.save(SpendingCustomCategory.of(categoryName, icon, user));
+
+        return SpendingCategoryDto.Res.from(CategoryInfo.of(category.getId(), category.getName(), category.getIcon()));
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingCategoryUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingCategoryUseCase.java
@@ -25,7 +25,7 @@ public class SpendingCategoryUseCase {
     public SpendingCategoryDto.Res createSpendingCategory(Long userId, String categoryName, SpendingCategory icon) {
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
 
-        SpendingCustomCategory category = spendingCustomCategoryService.save(SpendingCustomCategory.of(categoryName, icon, user));
+        SpendingCustomCategory category = spendingCustomCategoryService.createSpendingCustomCategory(SpendingCustomCategory.of(categoryName, icon, user));
 
         return SpendingCategoryDto.Res.from(CategoryInfo.of(category.getId(), category.getName(), category.getIcon()));
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryControllerUnitTest.java
@@ -4,6 +4,7 @@ import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
 import kr.co.pennyway.api.apis.ledger.usecase.SpendingCategoryUseCase;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +23,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = {SpendingCategoryController.class})
@@ -79,6 +81,26 @@ public class SpendingCategoryControllerUnitTest {
         result2.andDo(print()).andExpect(status().isUnprocessableEntity());
         result3.andDo(print()).andExpect(status().isUnprocessableEntity());
     }
+
+    @Test
+    @DisplayName("OTHER 아이콘을 입력하면 400 BAD_REQUEST 에러 응답을 반환한다.")
+    @WithSecurityMockUser
+    void postSpendingCategoryWithOtherIcon() throws Exception {
+        // given
+        String name = "식비";
+        String icon = "OTHER";
+
+        // when
+        ResultActions result = performPostSpendingCategory(name, icon);
+
+        // then
+        result
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(SpendingErrorCode.INVALID_ICON.causedBy().getCode()))
+                .andExpect(jsonPath("$.message").value(SpendingErrorCode.INVALID_ICON.getExplainError()));
+    }
+
 
     @Test
     @DisplayName("카테고리명과 아이콘을 입력하면 200 OK 응답을 반환한다.")

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryControllerUnitTest.java
@@ -1,7 +1,10 @@
 package kr.co.pennyway.api.apis.ledger.controller;
 
+import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
 import kr.co.pennyway.api.apis.ledger.usecase.SpendingCategoryUseCase;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
+import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
+import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +17,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -52,6 +57,43 @@ public class SpendingCategoryControllerUnitTest {
         // then
         result1.andDo(print()).andExpect(status().isUnprocessableEntity());
         result2.andDo(print()).andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 아이콘을 입력하면 422 Unprocessable Entity 에러 응답을 반환한다.")
+    @WithSecurityMockUser
+    void postSpendingCategoryWithInvalidIcon() throws Exception {
+        // given
+        String name = "식비";
+        String whiteSpaceIcon = " ";
+        String invalidIcon = "INVALID";
+        String lowerCaseIcon = "food";
+
+        // when
+        ResultActions result1 = performPostSpendingCategory(name, whiteSpaceIcon);
+        ResultActions result2 = performPostSpendingCategory(name, invalidIcon);
+        ResultActions result3 = performPostSpendingCategory(name, lowerCaseIcon);
+
+        // then
+        result1.andDo(print()).andExpect(status().isUnprocessableEntity());
+        result2.andDo(print()).andExpect(status().isUnprocessableEntity());
+        result3.andDo(print()).andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    @DisplayName("카테고리명과 아이콘을 입력하면 200 OK 응답을 반환한다.")
+    @WithSecurityMockUser
+    void postSpendingCategory() throws Exception {
+        // given
+        String name = "식비";
+        String icon = "FOOD";
+        given(spendingCategoryUseCase.createSpendingCategory(any(), any(), any())).willReturn(SpendingCategoryDto.Res.from(CategoryInfo.of(1L, name, SpendingCategory.FOOD)));
+
+        // when
+        ResultActions result = performPostSpendingCategory(name, icon);
+
+        // then
+        result.andDo(print()).andExpect(status().isOk());
     }
 
     private ResultActions performPostSpendingCategory(String name, String icon) throws Exception {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryControllerUnitTest.java
@@ -1,0 +1,62 @@
+package kr.co.pennyway.api.apis.ledger.controller;
+
+import kr.co.pennyway.api.apis.ledger.usecase.SpendingCategoryUseCase;
+import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {SpendingCategoryController.class})
+@ActiveProfiles("test")
+public class SpendingCategoryControllerUnitTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SpendingCategoryUseCase spendingCategoryUseCase;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .defaultRequest(post("/**").with(csrf()))
+                .build();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 카테고리명을 입력하면 422 Unprocessable Entity 에러 응답을 반환한다.")
+    @WithSecurityMockUser
+    void postSpendingCategoryWithInvalidName() throws Exception {
+        // given
+        String icon = "FOOD";
+        String whiteSpaceName = " ";
+        String sixteenLengthName = "1234567890123456";
+
+        // when
+        ResultActions result1 = performPostSpendingCategory(whiteSpaceName, icon);
+        ResultActions result2 = performPostSpendingCategory(sixteenLengthName, icon);
+
+        // then
+        result1.andDo(print()).andExpect(status().isUnprocessableEntity());
+        result2.andDo(print()).andExpect(status().isUnprocessableEntity());
+    }
+
+    private ResultActions performPostSpendingCategory(String name, String icon) throws Exception {
+        return mockMvc.perform(post("/v2/spending-categories")
+                .param("name", name)
+                .param("icon", icon));
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/Spending.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/Spending.java
@@ -61,6 +61,8 @@ public class Spending extends DateAuditable {
     /**
      * 지출 내역의 소비 카테고리를 조회하는 메서드 <br>
      * SpendingCategory가 OTHER일 경우 SpendingCustomCategory를 정보를 조회하여 반환한다.
+     *
+     * @return {@link CategoryInfo}
      */
     public CategoryInfo getCategory() {
         if (this.category.equals(SpendingCategory.OTHER)) {
@@ -68,6 +70,6 @@ public class Spending extends DateAuditable {
             return CategoryInfo.of(category.getId(), category.getName(), category.getIcon().name());
         }
 
-        return CategoryInfo.of(this.id, this.category.getType(), this.category.name());
+        return CategoryInfo.of(-1L, this.category.getType(), this.category.name());
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/Spending.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/Spending.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.domain.domains.spending.domain;
 import jakarta.persistence.*;
 import kr.co.pennyway.domain.common.converter.SpendingIconConverter;
 import kr.co.pennyway.domain.common.model.DateAuditable;
+import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import lombok.AccessLevel;
@@ -55,5 +56,18 @@ public class Spending extends DateAuditable {
 
     public int getDay() {
         return spendAt.getDayOfMonth();
+    }
+
+    /**
+     * 지출 내역의 소비 카테고리를 조회하는 메서드 <br>
+     * SpendingCategory가 OTHER일 경우 SpendingCustomCategory를 정보를 조회하여 반환한다.
+     */
+    public CategoryInfo getCategory() {
+        if (this.category.equals(SpendingCategory.OTHER)) {
+            SpendingCustomCategory category = getSpendingCustomCategory();
+            return CategoryInfo.of(category.getId(), category.getName(), category.getIcon().name());
+        }
+
+        return CategoryInfo.of(this.id, this.category.getType(), this.category.name());
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/Spending.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/Spending.java
@@ -67,9 +67,9 @@ public class Spending extends DateAuditable {
     public CategoryInfo getCategory() {
         if (this.category.equals(SpendingCategory.OTHER)) {
             SpendingCustomCategory category = getSpendingCustomCategory();
-            return CategoryInfo.of(category.getId(), category.getName(), category.getIcon().name());
+            return CategoryInfo.of(category.getId(), category.getName(), category.getIcon());
         }
 
-        return CategoryInfo.of(-1L, this.category.getType(), this.category.name());
+        return CategoryInfo.of(-1L, this.category.getType(), this.category);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/SpendingCustomCategory.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/SpendingCustomCategory.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "spending_category")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE spending_category SET deleted_at = NOW() WHERE id = ?")
 public class SpendingCustomCategory extends DateAuditable {
     @Id

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/SpendingCustomCategory.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/SpendingCustomCategory.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Table(name = "spending_category")
+@Table(name = "spending_custom_category")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE spending_category SET deleted_at = NOW() WHERE id = ?")

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
@@ -6,6 +6,11 @@ import java.util.Objects;
 
 /**
  * 지출 카테고리 정보를 담은 DTO
+ *
+ * @param isCustom boolean : 사용자 정의 카테고리 여부
+ * @param id       Long : 카테고리 ID. 사용자 정의 카테고리가 아니라면 -1, 사용자 정의 카테고리라면 0 이상의 값을 갖는다.
+ * @param name     String : 카테고리 이름
+ * @param icon     String : 카테고리 아이콘
  */
 public record CategoryInfo(
         boolean isCustom,
@@ -14,7 +19,12 @@ public record CategoryInfo(
         String icon
 ) {
     public CategoryInfo {
-        Objects.requireNonNull(id, "id은 null일 수 없습니다.");
+        Objects.requireNonNull(id, "id는 null일 수 없습니다.");
+
+        if (isCustom && id < 0 || !isCustom && id != -1) {
+            throw new IllegalArgumentException("isCustom과 id 정보가 일치하지 않습니다.");
+        }
+
         if (!StringUtils.hasText(name) || !StringUtils.hasText(icon)) {
             throw new IllegalArgumentException("name, icon은 null이거나 빈 문자열일 수 없습니다.");
         }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
@@ -1,0 +1,28 @@
+package kr.co.pennyway.domain.domains.spending.dto;
+
+import org.springframework.util.StringUtils;
+
+import java.util.Objects;
+
+/**
+ * 지출 카테고리 정보를 담은 DTO
+ *
+ * @param name : 카테고리 이름. null 불가
+ * @param icon : 카테고리 아이콘. null 불가
+ */
+public record CategoryInfo(
+        Long id,
+        String name,
+        String icon
+) {
+    public CategoryInfo {
+        Objects.requireNonNull(id, "id은 null일 수 없습니다.");
+        if (!StringUtils.hasText(name) || !StringUtils.hasText(icon)) {
+            throw new IllegalArgumentException("name, icon은 null이거나 빈 문자열일 수 없습니다.");
+        }
+    }
+
+    public static CategoryInfo of(Long id, String name, String icon) {
+        return new CategoryInfo(id, name, icon);
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.domain.domains.spending.dto;
 
+import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import org.springframework.util.StringUtils;
 
 import java.util.Objects;
@@ -16,21 +17,26 @@ public record CategoryInfo(
         boolean isCustom,
         Long id,
         String name,
-        String icon
+        SpendingCategory icon
 ) {
     public CategoryInfo {
         Objects.requireNonNull(id, "id는 null일 수 없습니다.");
+        Objects.requireNonNull(icon, "icon은 null일 수 없습니다.");
 
         if (isCustom && id < 0 || !isCustom && id != -1) {
             throw new IllegalArgumentException("isCustom과 id 정보가 일치하지 않습니다.");
         }
 
-        if (!StringUtils.hasText(name) || !StringUtils.hasText(icon)) {
-            throw new IllegalArgumentException("name, icon은 null이거나 빈 문자열일 수 없습니다.");
+        if (isCustom && icon.equals(SpendingCategory.OTHER)) {
+            throw new IllegalArgumentException("사용자 정의 카테고리는 OTHER가 될 수 없습니다.");
+        }
+
+        if (!StringUtils.hasText(name)) {
+            throw new IllegalArgumentException("name은 null이거나 빈 문자열일 수 없습니다.");
         }
     }
 
-    public static CategoryInfo of(Long id, String name, String icon) {
+    public static CategoryInfo of(Long id, String name, SpendingCategory icon) {
         return new CategoryInfo(id != null, id, name, icon);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
@@ -6,11 +6,9 @@ import java.util.Objects;
 
 /**
  * 지출 카테고리 정보를 담은 DTO
- *
- * @param name : 카테고리 이름. null 불가
- * @param icon : 카테고리 아이콘. null 불가
  */
 public record CategoryInfo(
+        boolean isCustom,
         Long id,
         String name,
         String icon
@@ -23,6 +21,6 @@ public record CategoryInfo(
     }
 
     public static CategoryInfo of(Long id, String name, String icon) {
-        return new CategoryInfo(id, name, icon);
+        return new CategoryInfo(id != null, id, name, icon);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
@@ -1,0 +1,29 @@
+package kr.co.pennyway.domain.domains.spending.exception;
+
+import kr.co.pennyway.common.exception.BaseErrorCode;
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.ReasonCode;
+import kr.co.pennyway.common.exception.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SpendingErrorCode implements BaseErrorCode {
+    /* 400 Bad Request */
+    INVALID_ICON(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "OTHER 아이콘은 커스텀 카테고리의 icon으로 사용할 수 없습니다.");
+
+    private final StatusCode statusCode;
+    private final ReasonCode reasonCode;
+    private final String message;
+
+    @Override
+    public CausedBy causedBy() {
+        return CausedBy.of(statusCode, reasonCode);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldError {
+        return message;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorException.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorException.java
@@ -1,0 +1,22 @@
+package kr.co.pennyway.domain.domains.spending.exception;
+
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.GlobalErrorException;
+
+public class SpendingErrorException extends GlobalErrorException {
+    private final SpendingErrorCode errorCode;
+
+    public SpendingErrorException(SpendingErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public CausedBy causedBy() {
+        return errorCode.causedBy();
+    }
+
+    public String getExplainError() {
+        return errorCode.getExplainError();
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
@@ -14,7 +14,7 @@ public class SpendingCustomCategoryService {
     private final SpendingCustomCategoryRepository spendingCustomCategoryRepository;
 
     @Transactional
-    public SpendingCustomCategory save(SpendingCustomCategory spendingCustomCategory) {
+    public SpendingCustomCategory createSpendingCustomCategory(SpendingCustomCategory spendingCustomCategory) {
         return spendingCustomCategoryRepository.save(spendingCustomCategory);
     }
 }


### PR DESCRIPTION
## 작업 이유
- 사용자가 본인만의 지출 카테고리 등록을 하려고 할 때 사용하는 Usecase를 실현한다.

<br/>

## 작업 사항
### 1️⃣ API Spec
- url: `POST /v2/spending-categories?name=&icon=`
- parameter
   - `name`: 커스텀 카테고리 이름. 15자 이하로 구성된 문자열이어야 하며, 공백 문자나 null은 비허용
   - `icon`: 서비스에서 제공하는 11가지 아이콘 중 택1. 아이콘 이름을 따르며, 대문자만 인식한다. (단, "OTHER"은 400 에러)
- usecase
   1. 요청을 보낸 사용자 정보를 조회한다.
   2. 커스텀 카테고리를 기록한다.
   3. 생성한 카테고리 정보를 반환한다.
       - `isCustom`: 사용자 정의 카테고리 여부
       - `id`: 사용자 정의 카테고리라면 `pk`. 서비스에서 제공하는 카테고리라면 `-1`
       - `name`: 카테고리 이름
       - `icon`: 카테고리 아이콘 정보

<br/>

### 2️⃣ Spending Entity에서 category 조회 핸들링

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/6be135db-2545-4499-93bc-73cd60e2fe0c" width="600px"/>
</div>

사전에 합의한 방식 대로 사용자가 지출 내역(Spending)의 카테고리를 조회했을 때, 카테고리가 "0". 즉, "OTHER"이면 참조하고 있는 커스텀 카테고리 정보를 조회해야 합니다.  
이를 구현하기 위해서는 개발자가 다음과 같은 예외 처리를 잊어먹지 않고 지켜주어야 한다는 문제가 발생합니다.

```java
Spending spending = spendingService.readSpending(spendingId);

if (spending.getCategory.equals(SpendingCategory.OTHER)) {
    SpendingCustomCategory category = spending.getSpendingCustomCategory();
    return category.getIcon();
}

return spending.getCategory();
```

위 방식은 중복이 심하며, 개발자가 지속적으로 해당 예외 처리를 잊지 않고 수행해야 한다는 휴먼 에러 위험성이 존재합니다.  
따라서 `Spending` 엔티티의 *getCategory*()를 내부적으로 다음과 같이 수정했습니다.  

```java
/**
  * 지출 내역의 소비 카테고리를 조회하는 메서드 <br>
  * SpendingCategory가 OTHER일 경우 SpendingCustomCategory를 정보를 조회하여 반환한다.
  *
  * @return {@link CategoryInfo}
  */
public CategoryInfo getCategory() {
    if (this.category.equals(SpendingCategory.OTHER)) {
        SpendingCustomCategory category = getSpendingCustomCategory();
        return CategoryInfo.of(category.getId(), category.getName(), category.getIcon());
    }

    return CategoryInfo.of(-1L, this.category.getType(), this.category);
}
```
즉, `Spending` 엔티티의 *getCategory*()를 호출하면, 내부적으로 알아서 커스텀 카테고리 여부를 판단하여 카테고리 정보를 담은 Dto로 결과를 반환합니다.

<br/>

CategoryInfo Dto는 다음과 같은 정보를 포합합니다.
- isCustom: 사용자 정의 카테고리 여부
- id: 카테고리 ID. 사용자 정의 카테고리가 아니라면 -1, 사용자 정의 카테고리라면 0 이상의 값을 갖는다.
- name: 카테고리 이름
- icon: 카테고리 아이콘

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- Spending Entity의 *getCategory*()가 적절하게 처리되고 있으며, `CategoryInfo`라는 네이밍이 괜찮은지??
- 사용할 icon를 쿼리로 받을 때, 평소와 다르게 소문자를 허용하지 않았습니다. 통일성을 위해 처리해두는 게 안전할까요?
- UseCase 테스트는 따로 해보지 않고(메서드가 워낙 단순해서), Controller에서 유효성 검사가 잘 수행되는 것만 확인했습니다.
- `Spending`과 `SpendingCustomCategory` 모두 삭제 후, 상태가 변경될 일이 없다고 생각해서 `@SQLRestriction`을 걸어버렸는데 괜찮을까요??

<br/>

## 발견한 이슈
- 없음