### PR TITLE
✨ 지출 내역 등록 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
@@ -5,9 +5,11 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
@@ -20,8 +22,34 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "지출 내역 API")
 public interface SpendingApi {
-    @Operation(summary = "지출 내역 추가", method = "POST", description = "사용자의 지출 내역을 추가하고 추가된 지출 내역을 반환합니다.")
-    @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "spending", schema = @Schema(implementation = SpendingSearchRes.Individual.class))))
+    @Operation(summary = "지출 내역 추가", method = "POST", description = """
+            사용자의 지출 내역을 추가하고 추가된 지출 내역을 반환합니다. <br/>
+            서비스에서 제공하는 지출 카테고리를 사용하는 경우 categoryId는 -1이어야 하며, icon은 OTHER가 될 수 없습니다. <br/>
+            사용자가 정의한 지출 카테고리를 사용하는 경우 categoryId는 -1이 아니어야 하며, icon은 OTHER여야 합니다.
+            """)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "spending", schema = @Schema(implementation = SpendingSearchRes.Individual.class)))),
+            @ApiResponse(responseCode = "400", description = "지출 카테고리 ID와 아이콘의 조합이 올바르지 않습니다.", content = @Content(examples = {
+                    @ExampleObject(name = "카테고리 id, 아이콘 조합 오류", description = "categoryId가 -1인데 icon이 OTHER이거나, categoryId가 -1이 아닌데 icon이 OTHER가 아닙니다.",
+                            value = """
+                                    {
+                                    "code": "4005",
+                                    "message": "icon의 정보와 categoryId의 정보가 존재할 수 없는 조합입니다."
+                                    }
+                                    """
+                    )
+            })),
+            @ApiResponse(responseCode = "403", description = "지출 카테고리에 대한 권한이 없습니다.", content = @Content(examples = {
+                    @ExampleObject(name = "지출 카테고리 권한 오류", description = "지출 카테고리에 대한 권한이 없습니다.",
+                            value = """
+                                    {
+                                    "code": "4030",
+                                    "message": "ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN"
+                                    }
+                                    """
+                    )
+            }))
+    })
     ResponseEntity<?> postSpending(@RequestBody @Validated SpendingReq request, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "지출 내역 조회", method = "GET", description = "사용자의 해당 년/월 지출 내역을 조회하고 월/일별 지출 총합을 반환합니다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
@@ -9,14 +9,21 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "지출 내역 API")
 public interface SpendingApi {
+    @Operation(summary = "지출 내역 추가", method = "POST", description = "사용자의 지출 내역을 추가하고 추가된 지출 내역을 반환합니다.")
+    @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "spending", schema = @Schema(implementation = SpendingSearchRes.Individual.class))))
+    ResponseEntity<?> postSpending(@RequestBody @Validated SpendingReq request, @AuthenticationPrincipal SecurityUserDetails user);
+
     @Operation(summary = "지출 내역 조회", method = "GET", description = "사용자의 해당 년/월 지출 내역을 조회하고 월/일별 지출 총합을 반환합니다.")
     @Parameters({
             @Parameter(name = "year", description = "년도", required = true, in = ParameterIn.HEADER),

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -24,7 +24,7 @@ public class SpendingController implements SpendingApi {
     private final SpendingUseCase spendingUseCase;
 
     @PostMapping("")
-    @PreAuthorize("isAuthenticated()") // categoryId가 -1이 아니면 사용자가 정의한 것인지 확인 필요함
+    @PreAuthorize("isAuthenticated() and @spendingCategoryManager.hasPermission(#user.getUserId(), #request.categoryId())")
     public ResponseEntity<?> postSpending(@RequestBody @Validated SpendingReq request, @AuthenticationPrincipal SecurityUserDetails user) {
         if (!isValidCategoryIdAndIcon(request.categoryId(), request.icon())) {
             throw new SpendingErrorException(SpendingErrorCode.INVALID_ICON_WITH_CATEGORY_ID);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -1,18 +1,20 @@
 package kr.co.pennyway.api.apis.ledger.controller;
 
 import kr.co.pennyway.api.apis.ledger.api.SpendingApi;
+import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
 import kr.co.pennyway.api.apis.ledger.usecase.SpendingUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
+import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -20,6 +22,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v2/spendings")
 public class SpendingController implements SpendingApi {
     private final SpendingUseCase spendingUseCase;
+
+    @PostMapping("")
+    @PreAuthorize("isAuthenticated()") // categoryId가 -1이 아니면 사용자가 정의한 것인지 확인 필요함
+    public ResponseEntity<?> postSpending(@RequestBody @Validated SpendingReq request, @AuthenticationPrincipal SecurityUserDetails user) {
+        if (request.icon().equals(SpendingCategory.OTHER) && request.categoryId().equals(-1L)) {
+            throw new SpendingErrorException(SpendingErrorCode.INVALID_ICON);
+        }
+
+        return ResponseEntity.ok(SuccessResponse.from("spending", spendingUseCase.createSpending(user.getUserId(), request)));
+    }
 
     @Override
     @GetMapping("")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class SpendingController implements SpendingApi {
     private final SpendingUseCase spendingUseCase;
 
+    @Override
     @PostMapping("")
     @PreAuthorize("isAuthenticated() and @spendingCategoryManager.hasPermission(#user.getUserId(), #request.categoryId())")
     public ResponseEntity<?> postSpending(@RequestBody @Validated SpendingReq request, @AuthenticationPrincipal SecurityUserDetails user) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
@@ -68,4 +68,8 @@ public record SpendingReq(
                 .spendingCustomCategory(spendingCustomCategory)
                 .build();
     }
+
+    public boolean isCustomCategory() {
+        return categoryId.equals(-1L);
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
@@ -69,6 +69,7 @@ public record SpendingReq(
                 .build();
     }
 
+    @Schema(hidden = true)
     public boolean isCustomCategory() {
         return !categoryId.equals(-1L);
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
+import kr.co.pennyway.domain.domains.spending.domain.Spending;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 
 import java.time.LocalDate;
@@ -37,4 +38,13 @@ public record SpendingReq(
         @Size(max = 100, message = "메모는 100자 이하로 입력해야 합니다.")
         String memo
 ) {
+    public Spending toEntity() {
+        return Spending.builder()
+                .amount(amount)
+                .category(icon)
+                .spendAt(spendAt.atStartOfDay())
+                .accountName(accountName)
+                .memo(memo)
+                .build();
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
@@ -70,6 +70,6 @@ public record SpendingReq(
     }
 
     public boolean isCustomCategory() {
-        return categoryId.equals(-1L);
+        return !categoryId.equals(-1L);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
@@ -1,0 +1,40 @@
+package kr.co.pennyway.api.apis.ledger.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Size;
+import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
+
+import java.time.LocalDate;
+
+@Schema(title = "지출 내역 추가 요청")
+public record SpendingReq(
+        @Schema(description = "지출 금액. int 범위 최대값까지 허용", example = "10000")
+        @Min(value = 1, message = "지출 금액은 1 이상이어야 합니다.")
+        int amount,
+        @Schema(description = "지출 카테고리 ID. 사용자가 정의한 카테고리가 아닌 경우 -1. icon이 OTHER이면서 categoryId가 -1일 수는 없다.", example = "-1")
+        @NotNull(message = "지출 카테고리 ID는 필수입니다.")
+        @Min(value = -1, message = "지출 카테고리 ID는 -1 이상이어야 합니다.")
+        Long categoryId,
+        @Schema(description = "지출 카테고리 아이콘", example = "FOOD")
+        @NotNull(message = "지출 카테고리 아이콘은 필수입니다.")
+        SpendingCategory icon,
+        @Schema(description = "지출 일자", example = "2021-08-01")
+        @NotNull(message = "지출 일자는 필수입니다.")
+        @JsonSerialize(using = LocalDateSerializer.class)
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        @PastOrPresent(message = "지출 일자는 과거 또는 현재여야 합니다.")
+        LocalDate spendAt,
+        @Schema(description = "소비처", example = "카페인 수혈")
+        @Size(max = 20, message = "소비처는 20자 이하로 입력해야 합니다.")
+        String accountName,
+        @Schema(description = "메모", example = "아메리카노 1잔")
+        @Size(max = 100, message = "메모는 100자 이하로 입력해야 합니다.")
+        String memo
+) {
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
+import kr.co.pennyway.domain.domains.user.domain.User;
 
 import java.time.LocalDate;
 
@@ -38,13 +39,14 @@ public record SpendingReq(
         @Size(max = 100, message = "메모는 null 혹은 100자 이하로 입력해야 합니다.")
         String memo
 ) {
-    public Spending toEntity() {
+    public Spending toEntity(User user) {
         return Spending.builder()
                 .amount(amount)
                 .category(icon)
                 .spendAt(spendAt.atStartOfDay())
                 .accountName(accountName)
                 .memo(memo)
+                .user(user)
                 .build();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
@@ -32,10 +32,10 @@ public record SpendingReq(
         @PastOrPresent(message = "지출 일자는 과거 또는 현재여야 합니다.")
         LocalDate spendAt,
         @Schema(description = "소비처", example = "카페인 수혈")
-        @Size(max = 20, message = "소비처는 20자 이하로 입력해야 합니다.")
+        @Size(max = 20, message = "소비처는 null 혹은 20자 이하로 입력해야 합니다.")
         String accountName,
         @Schema(description = "메모", example = "아메리카노 1잔")
-        @Size(max = 100, message = "메모는 100자 이하로 입력해야 합니다.")
+        @Size(max = 100, message = "메모는 null 혹은 100자 이하로 입력해야 합니다.")
         String memo
 ) {
     public Spending toEntity() {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
+import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import kr.co.pennyway.domain.domains.user.domain.User;
 
@@ -39,6 +40,9 @@ public record SpendingReq(
         @Size(max = 100, message = "메모는 null 혹은 100자 이하로 입력해야 합니다.")
         String memo
 ) {
+    /**
+     * 서비스에서 제공하는 지출 카테고리를 사용하는 지출 내역으로 변환
+     */
     public Spending toEntity(User user) {
         return Spending.builder()
                 .amount(amount)
@@ -47,6 +51,21 @@ public record SpendingReq(
                 .accountName(accountName)
                 .memo(memo)
                 .user(user)
+                .build();
+    }
+
+    /**
+     * 사용자가 정의한 지출 카테고리를 사용하는 지출 내역으로 변환
+     */
+    public Spending toEntity(User user, SpendingCustomCategory spendingCustomCategory) {
+        return Spending.builder()
+                .amount(amount)
+                .category(icon)
+                .spendAt(spendAt.atStartOfDay())
+                .accountName(accountName)
+                .memo(memo)
+                .user(user)
+                .spendingCustomCategory(spendingCustomCategory)
                 .build();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
@@ -51,14 +51,14 @@ public class SpendingSearchRes {
             @Schema(description = "지출 카테고리 정보")
             @NotNull
             CategoryInfo category,
-            @Schema(description = "지출 일시", example = "2024-05-09")
+            @Schema(description = "지출 일시", pattern = "yyyy-MM-dd HH:mm:ss", example = "2021-08-01 00:00:00")
             @NotNull
             @JsonSerialize(using = LocalDateTimeSerializer.class)
-            @JsonFormat(pattern = "yyyy-MM-dd")
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime spendAt,
-            @Schema(description = "계좌명. 없으면 빈 문자열")
+            @Schema(description = "계좌명. 없으면 빈 문자열", example = "카페인 수혈")
             String accountName,
-            @Schema(description = "메모. 없으면 빈 문자열")
+            @Schema(description = "메모. 없으면 빈 문자열", example = "아메리카노 1잔")
             String memo
     ) {
         public Individual(Long id, Integer amount, CategoryInfo category, LocalDateTime spendAt, String accountName, String memo) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
+import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -48,9 +48,9 @@ public class SpendingSearchRes {
             @Schema(description = "지출 금액")
             @NotNull
             Integer amount,
-            @Schema(description = "지출 카테고리 아이콘")
+            @Schema(description = "지출 카테고리 정보")
             @NotNull
-            SpendingCategory category,
+            CategoryInfo category,
             @Schema(description = "지출 일시", example = "2024-05-09")
             @NotNull
             @JsonSerialize(using = LocalDateTimeSerializer.class)
@@ -61,7 +61,7 @@ public class SpendingSearchRes {
             @Schema(description = "메모. 없으면 빈 문자열")
             String memo
     ) {
-        public Individual(Long id, Integer amount, SpendingCategory category, LocalDateTime spendAt, String accountName, String memo) {
+        public Individual(Long id, Integer amount, CategoryInfo category, LocalDateTime spendAt, String accountName, String memo) {
             this.id = id;
             this.amount = amount;
             this.category = category;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
@@ -41,7 +41,7 @@ public class SpendingMapper {
         return SpendingSearchRes.Individual.builder()
                 .id(spending.getId())
                 .amount(spending.getAmount())
-                .category(spending.getCategory().icon())
+                .category(spending.getCategory())
                 .spendAt(spending.getSpendAt())
                 .accountName(spending.getAccountName())
                 .memo(spending.getMemo())

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
@@ -37,7 +37,7 @@ public class SpendingMapper {
                 .build();
     }
 
-    private static SpendingSearchRes.Individual toSpendingSearchResIndividual(Spending spending) {
+    public static SpendingSearchRes.Individual toSpendingSearchResIndividual(Spending spending) {
         return SpendingSearchRes.Individual.builder()
                 .id(spending.getId())
                 .amount(spending.getAmount())

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/SpendingSaveService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/SpendingSaveService.java
@@ -1,0 +1,38 @@
+package kr.co.pennyway.api.apis.ledger.service;
+
+import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
+import kr.co.pennyway.domain.domains.spending.domain.Spending;
+import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
+import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
+import kr.co.pennyway.domain.domains.spending.service.SpendingService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SpendingSaveService {
+    private final SpendingService spendingService;
+    private final SpendingCustomCategoryService spendingCustomCategoryService;
+
+    @Transactional
+    public Spending createSpending(User user, SpendingReq request) {
+        Spending spending;
+
+        if (request.categoryId().equals(-1L)) {
+            spending = spendingService.createSpending(request.toEntity(user));
+        } else {
+            SpendingCustomCategory customCategory = spendingCustomCategoryService.readSpendingCustomCategory(request.categoryId())
+                    .orElseThrow(() -> new SpendingErrorException(SpendingErrorCode.NOT_FOUND_CUSTOM_CATEGORY));
+
+            spending = spendingService.createSpending(request.toEntity(user, customCategory));
+        }
+
+        return spending;
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/SpendingSaveService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/SpendingSaveService.java
@@ -24,7 +24,7 @@ public class SpendingSaveService {
     public Spending createSpending(User user, SpendingReq request) {
         Spending spending;
 
-        if (request.categoryId().equals(-1L)) {
+        if (!request.isCustomCategory()) {
             spending = spendingService.createSpending(request.toEntity(user));
         } else {
             SpendingCustomCategory customCategory = spendingCustomCategoryService.readSpendingCustomCategory(request.categoryId())

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
@@ -3,14 +3,10 @@ package kr.co.pennyway.api.apis.ledger.usecase;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
 import kr.co.pennyway.api.apis.ledger.mapper.SpendingMapper;
+import kr.co.pennyway.api.apis.ledger.service.SpendingSaveService;
 import kr.co.pennyway.api.apis.ledger.service.SpendingSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
-import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
-import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
-import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
-import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
-import kr.co.pennyway.domain.domains.spending.service.SpendingService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
@@ -25,25 +21,17 @@ import java.util.List;
 @UseCase
 @RequiredArgsConstructor
 public class SpendingUseCase {
+    private final SpendingSaveService spendingSaveService;
     private final SpendingSearchService spendingSearchService;
 
     private final UserService userService;
-    private final SpendingService spendingService;
-    private final SpendingCustomCategoryService spendingCustomCategoryService;
+
 
     @Transactional
     public SpendingSearchRes.Individual createSpending(Long userId, SpendingReq request) {
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
 
-        Spending spending;
-        if (request.categoryId().equals(-1L)) {
-            spending = spendingService.createSpending(request.toEntity(user));
-        } else {
-            SpendingCustomCategory customCategory = spendingCustomCategoryService.readSpendingCustomCategory(request.categoryId())
-                    .orElseThrow(() -> new SpendingErrorException(SpendingErrorCode.NOT_FOUND_CUSTOM_CATEGORY));
-
-            spending = spendingService.createSpending(request.toEntity(user, customCategory));
-        }
+        Spending spending = spendingSaveService.createSpending(user, request);
 
         return SpendingMapper.toSpendingSearchResIndividual(spending);
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
@@ -35,15 +35,14 @@ public class SpendingUseCase {
     public SpendingSearchRes.Individual createSpending(Long userId, SpendingReq request) {
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
 
-        Spending spending = request.toEntity(user);
+        Spending spending;
         if (request.categoryId().equals(-1L)) {
-            spendingService.createSpending(spending);
+            spending = spendingService.createSpending(request.toEntity(user));
         } else {
             SpendingCustomCategory customCategory = spendingCustomCategoryService.readSpendingCustomCategory(request.categoryId())
                     .orElseThrow(() -> new SpendingErrorException(SpendingErrorCode.NOT_FOUND_CUSTOM_CATEGORY));
 
-            spending.updateSpendingCustomCategory(customCategory);
-            spendingService.createSpending(spending);
+            spending = spendingService.createSpending(request.toEntity(user, customCategory));
         }
 
         return SpendingMapper.toSpendingSearchResIndividual(spending);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
@@ -7,6 +7,7 @@ import kr.co.pennyway.api.apis.ledger.service.SpendingSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
 import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
 import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
 import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
 import kr.co.pennyway.domain.domains.spending.service.SpendingService;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
@@ -1,10 +1,19 @@
 package kr.co.pennyway.api.apis.ledger.usecase;
 
+import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
 import kr.co.pennyway.api.apis.ledger.mapper.SpendingMapper;
 import kr.co.pennyway.api.apis.ledger.service.SpendingSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
+import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
+import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
+import kr.co.pennyway.domain.domains.spending.service.SpendingService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
+import kr.co.pennyway.domain.domains.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +25,28 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SpendingUseCase {
     private final SpendingSearchService spendingSearchService;
+
+    private final UserService userService;
+    private final SpendingService spendingService;
+    private final SpendingCustomCategoryService spendingCustomCategoryService;
+
+    @Transactional
+    public SpendingSearchRes.Individual createSpending(Long userId, SpendingReq request) {
+        User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
+
+        Spending spending = request.toEntity(user);
+        if (request.categoryId().equals(-1L)) {
+            spendingService.createSpending(spending);
+        } else {
+            SpendingCustomCategory customCategory = spendingCustomCategoryService.readSpendingCustomCategory(request.categoryId())
+                    .orElseThrow(() -> new SpendingErrorException(SpendingErrorCode.NOT_FOUND_CUSTOM_CATEGORY));
+
+            spending.updateSpendingCustomCategory(customCategory);
+            spendingService.createSpending(spending);
+        }
+
+        return SpendingMapper.toSpendingSearchResIndividual(spending);
+    }
 
     @Transactional(readOnly = true)
     public SpendingSearchRes.Month getSpendingsAtYearAndMonth(Long userId, int year, int month) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/SpendingCategoryManager.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/SpendingCategoryManager.java
@@ -1,0 +1,29 @@
+package kr.co.pennyway.api.common.security.authorization;
+
+import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component("spendingCategoryManager")
+@RequiredArgsConstructor
+public class SpendingCategoryManager {
+    private final SpendingCustomCategoryService spendingCustomCategoryService;
+
+    /**
+     * 사용자가 커스텀 지출 카테고리에 대한 권한이 있는지 확인한다. <br>
+     * -1L이면 서비스에서 제공하는 기본 카테고리를 사용하는 것이므로 무시한다.
+     *
+     * @return 권한이 있으면 true, 없으면 false
+     */
+    @Transactional(readOnly = true)
+    public boolean hasPermission(Long userId, Long categoryId) {
+        if (categoryId.equals(-1L)) {
+            return true;
+        }
+
+        return spendingCustomCategoryService.isExistsSpendingCustomCategory(userId, categoryId);
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingControllerUnitTest.java
@@ -6,6 +6,7 @@ import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
 import kr.co.pennyway.api.apis.ledger.usecase.SpendingUseCase;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -21,6 +22,7 @@ import java.time.LocalDate;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles("test")
@@ -62,7 +64,7 @@ public class SpendingControllerUnitTest {
             ResultActions result = performPostSpending(request);
 
             // then
-            result.andExpect(status().isUnprocessableEntity());
+            result.andDo(print()).andExpect(status().isUnprocessableEntity());
         }
 
         @Test
@@ -79,7 +81,7 @@ public class SpendingControllerUnitTest {
             ResultActions result = performPostSpending(request);
 
             // then
-            result.andExpect(status().isUnprocessableEntity());
+            result.andDo(print()).andExpect(status().isBadRequest());
         }
 
         @Test
@@ -95,7 +97,7 @@ public class SpendingControllerUnitTest {
             ResultActions result = performPostSpending(request);
 
             // then
-            result.andExpect(status().isUnprocessableEntity());
+            result.andDo(print()).andExpect(status().isUnprocessableEntity());
         }
 
         @Test
@@ -111,7 +113,7 @@ public class SpendingControllerUnitTest {
             ResultActions result = performPostSpending(request);
 
             // then
-            result.andExpect(status().isUnprocessableEntity());
+            result.andDo(print()).andExpect(status().isUnprocessableEntity());
         }
 
         @Test
@@ -119,7 +121,7 @@ public class SpendingControllerUnitTest {
         @WithSecurityMockUser
         void whenMemoIsNotNullAndOver100() throws Exception {
             // given
-            String memo = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+            String memo = RandomStringUtils.random(101);
             SpendingReq request = new SpendingReq(10000, -1L, SpendingCategory.FOOD, LocalDate.now(), "소비처", memo);
             given(spendingUseCase.createSpending(1L, request)).willReturn(SpendingSearchRes.Individual.builder().build());
 
@@ -127,7 +129,7 @@ public class SpendingControllerUnitTest {
             ResultActions result = performPostSpending(request);
 
             // then
-            result.andExpect(status().isUnprocessableEntity());
+            result.andDo(print()).andExpect(status().isUnprocessableEntity());
         }
 
         private ResultActions performPostSpending(SpendingReq request) throws Exception {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingControllerUnitTest.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.ledger.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
 import kr.co.pennyway.api.apis.ledger.usecase.SpendingUseCase;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingControllerUnitTest.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.ledger.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
+import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
 import kr.co.pennyway.api.apis.ledger.usecase.SpendingUseCase;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
@@ -12,14 +13,18 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDate;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = SpendingController.class)
 @ActiveProfiles("test")
+@WebMvcTest(controllers = SpendingController.class)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class SpendingControllerUnitTest {
     @Autowired
@@ -30,6 +35,14 @@ public class SpendingControllerUnitTest {
 
     @MockBean
     private SpendingUseCase spendingUseCase;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .defaultRequest(post("/**").with(csrf()))
+                .build();
+    }
 
     @Order(1)
     @Nested
@@ -43,6 +56,7 @@ public class SpendingControllerUnitTest {
             // given
             int amount = 0;
             SpendingReq request = new SpendingReq(amount, -1L, SpendingCategory.FOOD, LocalDate.now(), "소비처", "메모");
+            given(spendingUseCase.createSpending(1L, request)).willReturn(SpendingSearchRes.Individual.builder().build());
 
             // when
             ResultActions result = performPostSpending(request);
@@ -59,6 +73,7 @@ public class SpendingControllerUnitTest {
             Long categoryId = -1L;
             SpendingCategory icon = SpendingCategory.OTHER;
             SpendingReq request = new SpendingReq(10000, categoryId, icon, LocalDate.now(), "소비처", "메모");
+            given(spendingUseCase.createSpending(1L, request)).willReturn(SpendingSearchRes.Individual.builder().build());
 
             // when
             ResultActions result = performPostSpending(request);
@@ -74,6 +89,7 @@ public class SpendingControllerUnitTest {
             // given
             LocalDate spendAt = LocalDate.now().plusDays(1);
             SpendingReq request = new SpendingReq(10000, -1L, SpendingCategory.FOOD, spendAt, "소비처", "메모");
+            given(spendingUseCase.createSpending(1L, request)).willReturn(SpendingSearchRes.Individual.builder().build());
 
             // when
             ResultActions result = performPostSpending(request);
@@ -89,6 +105,7 @@ public class SpendingControllerUnitTest {
             // given
             String accountName = "123456789012345678901";
             SpendingReq request = new SpendingReq(10000, -1L, SpendingCategory.FOOD, LocalDate.now(), accountName, "메모");
+            given(spendingUseCase.createSpending(1L, request)).willReturn(SpendingSearchRes.Individual.builder().build());
 
             // when
             ResultActions result = performPostSpending(request);
@@ -104,6 +121,7 @@ public class SpendingControllerUnitTest {
             // given
             String memo = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
             SpendingReq request = new SpendingReq(10000, -1L, SpendingCategory.FOOD, LocalDate.now(), "소비처", memo);
+            given(spendingUseCase.createSpending(1L, request)).willReturn(SpendingSearchRes.Individual.builder().build());
 
             // when
             ResultActions result = performPostSpending(request);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingControllerUnitTest.java
@@ -1,0 +1,120 @@
+package kr.co.pennyway.api.apis.ledger.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.ledger.usecase.SpendingUseCase;
+import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
+import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SpendingController.class)
+@ActiveProfiles("test")
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+public class SpendingControllerUnitTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private SpendingUseCase spendingUseCase;
+
+    @Order(1)
+    @Nested
+    @DisplayName("지출 내역 추가하기")
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class postSpending {
+        @Test
+        @DisplayName("금액이 0이하의 정수인 경우 422 Unprocessable Entity를 반환한다.")
+        @WithSecurityMockUser
+        void whenAmountIsZeroOrNegative() throws Exception {
+            // given
+            int amount = 0;
+            SpendingReq request = new SpendingReq(amount, -1L, SpendingCategory.FOOD, LocalDate.now(), "소비처", "메모");
+
+            // when
+            ResultActions result = performPostSpending(request);
+
+            // then
+            result.andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        @DisplayName("아이콘이 OTHER이면서 categoryId가 -1인 경우 400 Bad Request를 반환한다.")
+        @WithSecurityMockUser
+        void whenCategoryIsNotDefined() throws Exception {
+            // given
+            Long categoryId = -1L;
+            SpendingCategory icon = SpendingCategory.OTHER;
+            SpendingReq request = new SpendingReq(10000, categoryId, icon, LocalDate.now(), "소비처", "메모");
+
+            // when
+            ResultActions result = performPostSpending(request);
+
+            // then
+            result.andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        @DisplayName("지출일이 현재보다 미래인 경우 422 Unprocessable Entity를 반환한다.")
+        @WithSecurityMockUser
+        void whenSpendAtIsFuture() throws Exception {
+            // given
+            LocalDate spendAt = LocalDate.now().plusDays(1);
+            SpendingReq request = new SpendingReq(10000, -1L, SpendingCategory.FOOD, spendAt, "소비처", "메모");
+
+            // when
+            ResultActions result = performPostSpending(request);
+
+            // then
+            result.andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        @DisplayName("소비처가 null이 아니면서 20자를 초과하는 경우 422 Unprocessable Entity를 반환한다.")
+        @WithSecurityMockUser
+        void whenAccountNameIsNotNullAndOver20() throws Exception {
+            // given
+            String accountName = "123456789012345678901";
+            SpendingReq request = new SpendingReq(10000, -1L, SpendingCategory.FOOD, LocalDate.now(), accountName, "메모");
+
+            // when
+            ResultActions result = performPostSpending(request);
+
+            // then
+            result.andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        @DisplayName("메모가 null이 아니면서 100자를 초과하는 경우 422 Unprocessable Entity를 반환한다.")
+        @WithSecurityMockUser
+        void whenMemoIsNotNullAndOver100() throws Exception {
+            // given
+            String memo = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+            SpendingReq request = new SpendingReq(10000, -1L, SpendingCategory.FOOD, LocalDate.now(), "소비처", memo);
+
+            // when
+            ResultActions result = performPostSpending(request);
+
+            // then
+            result.andExpect(status().isUnprocessableEntity());
+        }
+
+        private ResultActions performPostSpending(SpendingReq request) throws Exception {
+            return mockMvc.perform(post("/v2/spendings")
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(request)));
+        }
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingUseCaseIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingUseCaseIntegrationTest.java
@@ -79,7 +79,7 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
             // given
             User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
             SpendingCustomCategory category = spendingCustomCategoryService.createSpendingCustomCategory(SpendingCustomCategory.of("잉여비", SpendingCategory.LIVING, user));
-            SpendingReq request = new SpendingReq(10000, category.getId(), category.getIcon(), LocalDate.now(), "소비처", "메모");
+            SpendingReq request = new SpendingReq(10000, category.getId(), SpendingCategory.OTHER, LocalDate.now(), "소비처", "메모");
 
             // when
             ResultActions resultActions = performCreateSpendingSuccess(request);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingUseCaseIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingUseCaseIntegrationTest.java
@@ -1,10 +1,13 @@
 package kr.co.pennyway.api.apis.ledger.integration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
 import kr.co.pennyway.api.config.fixture.SpendingFixture;
 import kr.co.pennyway.api.config.fixture.UserFixture;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
+import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.service.UserService;
 import lombok.extern.slf4j.Slf4j;
@@ -30,17 +33,46 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
     @Autowired
     private MockMvc mockMvc;
     @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
     private UserService userService;
     @Autowired
     private NamedParameterJdbcTemplate jdbcTemplate;
 
     @Order(1)
     @Nested
+    @DisplayName("지출 내역 추가하기")
+    class CreateSpending {
+        @Test
+        @DisplayName("request의 categoryId가 -1인 경우, spendingCustomCategory가 null인 Spending을 생성한다.")
+        @WithSecurityMockUser(userId = "1")
+        void createSpendingSuccess() throws Exception {
+            // given
+            userService.createUser(UserFixture.GENERAL_USER.toUser());
+            SpendingReq request = new SpendingReq(10000, -1L, SpendingCategory.FOOD, LocalDate.now(), "소비처", "메모");
+
+            // when
+            ResultActions resultActions = performCreateSpendingSuccess(request);
+
+            // then
+            resultActions.andDo(print()).andExpect(status().isOk());
+        }
+
+        private ResultActions performCreateSpendingSuccess(SpendingReq req) throws Exception {
+            return mockMvc.perform(MockMvcRequestBuilders
+                    .post("/v2/spendings")
+                    .contentType("application/json")
+                    .content(objectMapper.writeValueAsString(req)));
+        }
+    }
+
+    @Order(2)
+    @Nested
     @DisplayName("월별 지출 내역 조회")
     class GetSpendingListAtYearAndMonth {
         @Test
         @DisplayName("월별 지출 내역 조회")
-        @WithSecurityMockUser
+        @WithSecurityMockUser(userId = "2")
         void getSpendingListAtYearAndMonthSuccess() throws Exception {
             // given
             User user = userService.createUser(UserFixture.GENERAL_USER.toUser());

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingUseCaseIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingUseCaseIntegrationTest.java
@@ -91,6 +91,22 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(jsonPath("$.data.spending.category.icon").value(category.getIcon().name()));
         }
 
+        @Order(3)
+        @Test
+        @DisplayName("사용자가 categoryId에 해당하는 카테고리 정보의 소유자가 아닌 경우, 403 Forbidden을 반환한다.")
+        @WithSecurityMockUser(userId = "3")
+        @Transactional
+        void createSpendingWithInvalidCustomCategory() throws Exception {
+            // given
+            User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
+            SpendingReq request = new SpendingReq(10000, 1000L, SpendingCategory.OTHER, LocalDate.now(), "소비처", "메모");
+
+            // when
+            ResultActions resultActions = performCreateSpendingSuccess(request);
+
+            // then
+            resultActions.andDo(print()).andExpect(status().isForbidden());
+        }
 
         private ResultActions performCreateSpendingSuccess(SpendingReq req) throws Exception {
             return mockMvc.perform(MockMvcRequestBuilders
@@ -106,7 +122,7 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
     class GetSpendingListAtYearAndMonth {
         @Test
         @DisplayName("월별 지출 내역 조회")
-        @WithSecurityMockUser(userId = "3")
+        @WithSecurityMockUser(userId = "4")
         @Transactional
         void getSpendingListAtYearAndMonthSuccess() throws Exception {
             // given

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/Spending.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/Spending.java
@@ -45,6 +45,12 @@ public class Spending extends DateAuditable {
 
     @Builder
     private Spending(Integer amount, SpendingCategory category, LocalDateTime spendAt, String accountName, String memo, User user, SpendingCustomCategory spendingCustomCategory) {
+        if (category.equals(SpendingCategory.OTHER) && spendingCustomCategory == null) {
+            throw new IllegalArgumentException("OTHER 아이콘의 경우 SpendingCustomCategory는 null일 수 없습니다.");
+        } else if (!category.equals(SpendingCategory.OTHER) && spendingCustomCategory != null) {
+            throw new IllegalArgumentException("OTHER 아이콘이 아닌 경우 SpendingCustomCategory는 null이어야 합니다.");
+        }
+
         this.amount = amount;
         this.category = category;
         this.spendAt = spendAt;
@@ -71,5 +77,15 @@ public class Spending extends DateAuditable {
         }
 
         return CategoryInfo.of(-1L, this.category.getType(), this.category);
+    }
+
+    public void updateSpendingCustomCategory(SpendingCustomCategory spendingCustomCategory) {
+        if (this.category.equals(SpendingCategory.OTHER) && spendingCustomCategory == null) {
+            throw new IllegalArgumentException("OTHER 아이콘의 경우 SpendingCustomCategory는 null일 수 없습니다.");
+        } else if (!this.category.equals(SpendingCategory.OTHER) && spendingCustomCategory != null) {
+            throw new IllegalArgumentException("OTHER 아이콘이 아닌 경우 SpendingCustomCategory는 null이어야 합니다.");
+        }
+
+        this.spendingCustomCategory = spendingCustomCategory;
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
@@ -24,7 +24,7 @@ public record CategoryInfo(
         Objects.requireNonNull(icon, "icon은 null일 수 없습니다.");
 
         if (isCustom && id < 0 || !isCustom && id != -1) {
-            throw new IllegalArgumentException("isCustom과 id 정보가 일치하지 않습니다.");
+            throw new IllegalArgumentException("isCustom이 " + isCustom + "일 때 id는 " + (isCustom ? "0 이상" : "-1") + "이어야 합니다.");
         }
 
         if (isCustom && icon.equals(SpendingCategory.OTHER)) {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/CategoryInfo.java
@@ -37,6 +37,6 @@ public record CategoryInfo(
     }
 
     public static CategoryInfo of(Long id, String name, SpendingCategory icon) {
-        return new CategoryInfo(id != null, id, name, icon);
+        return new CategoryInfo(!id.equals(-1L), id, name, icon);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
@@ -11,7 +11,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SpendingErrorCode implements BaseErrorCode {
     /* 400 Bad Request */
-    INVALID_ICON(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "OTHER 아이콘은 커스텀 카테고리의 icon으로 사용할 수 없습니다.");
+    INVALID_ICON(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "OTHER 아이콘은 커스텀 카테고리의 icon으로 사용할 수 없습니다."),
+
+    /* 404 Not Found */
+    NOT_FOUND_CUSTOM_CATEGORY(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "존재하지 않는 커스텀 카테고리입니다.");
 
     private final StatusCode statusCode;
     private final ReasonCode reasonCode;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 public enum SpendingErrorCode implements BaseErrorCode {
     /* 400 Bad Request */
     INVALID_ICON(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "OTHER 아이콘은 커스텀 카테고리의 icon으로 사용할 수 없습니다."),
+    INVALID_ICON_WITH_CATEGORY_ID(StatusCode.BAD_REQUEST, ReasonCode.CLIENT_ERROR, "icon의 정보와 categoryId의 정보가 존재할 수 없는 조합입니다."),
 
     /* 404 Not Found */
     NOT_FOUND_CUSTOM_CATEGORY(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "존재하지 않는 커스텀 카테고리입니다.");

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomCategoryRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomCategoryRepository.java
@@ -2,6 +2,9 @@ package kr.co.pennyway.domain.domains.spending.repository;
 
 import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface SpendingCustomCategoryRepository extends JpaRepository<SpendingCustomCategory, Long> {
+    @Transactional(readOnly = true)
+    boolean existsByIdAndUser_Id(Long id, Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Slf4j
 @DomainService
 @RequiredArgsConstructor
@@ -16,5 +18,10 @@ public class SpendingCustomCategoryService {
     @Transactional
     public SpendingCustomCategory createSpendingCustomCategory(SpendingCustomCategory spendingCustomCategory) {
         return spendingCustomCategoryRepository.save(spendingCustomCategory);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<SpendingCustomCategory> readSpendingCustomCategory(Long id) {
+        return spendingCustomCategoryRepository.findById(id);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
@@ -24,4 +24,9 @@ public class SpendingCustomCategoryService {
     public Optional<SpendingCustomCategory> readSpendingCustomCategory(Long id) {
         return spendingCustomCategoryRepository.findById(id);
     }
+
+    @Transactional(readOnly = true)
+    public boolean isExistsSpendingCustomCategory(Long userId, Long categoryId) {
+        return spendingCustomCategoryRepository.existsByIdAndUser_Id(categoryId, userId);
+    }
 }


### PR DESCRIPTION
## 작업 이유
> 엄청 금방 끝낼 줄 알았던 기능인데, 고려할 게 생각보다 너무 많아서 죽는 줄..
- 사용자가 지출 내역을 등록하기 위한 Usecase를 실현하는 API

<br/>

## 작업 사항
### 1️⃣ API Spec
- url : `POST /v2/spendings`
- pre-condition
   - 사용자는 로그인한 상태여야 한다.
   - 사용자가 커스텀 카테고리를 선택한 경우, 해당 카테고리의 소유권이 있어야 한다.
- usecase
   1. 사용자 데이터를 조회한다.
   2. 사용자에게 지출 내역을 등록한다.

<br/>

*🟡 통합 테스트 항목*
1. request의 categoryId가 -1인 경우, spendingCustomCategory가 null인 Spending을 생성한다.
2. request의 categoryId가 -1이 아닌 경우, spendingCustomCategory를 참조하는 Spending을 생성한다.
3. 사용자가 categoryId에 해당하는 카테고리 정보의 소유자가 아닌 경우, 403 Forbidden을 반환한다.

<br/>

### 2️⃣ 엄청나게 많은 조건식들에 대해서...
- `Spending` 생성자, 카테고리 업데이트 메서드에 상태 조건문 추가
- `Dto` 매핑 시 상태 조건문 추가

너무 과하게 한 감이 없지 않아 있긴 한데, 혹시라도 발생할 수 있는 상태 불일치 문제를 예방하기 위함입니다.  
라고 하기엔 중복적인 부분도 많은 거 같아서 나름 덜어낸다고 덜어낸 건데..^^  

참고로 상태 불일치라고 하면 `Spending` entity의 `category`가 "Other"이라서 `customCategory`를 참조하려고 보니 null이라던가..그런 문제를 이야기 합니다.

- 읽다가 -1이냐 아니냐를 따지는 조건식이 계속 나올 텐데, 모두 사용자가 시스템에서 제공해주는 기본 카테고리를 사용하는지, 커스텀 카테고리를 사용하는 지를 판단하기 위함입니다.
   - categoryId가 -1이면, 참조할 카테고리가 없음을 의미합니다. 즉, 시스템에서 제공해주는 카테고리를 사용할 것이므로 icon은 OTHER이 될 수 없습니다.
   - categoryId가 0보다 큰 수면, 커스텀 카테고리 자원 소유 검증을 수행 후 지출 내역을 매핑합니다. 요청 시, icon은 반드시 Other여야 합니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- categoryId를 `-1`로 다루는 방법과 코드 구현이 올바르다고 보시나요?
- 혹시 더 테스트 해봐야 할 케이스가 존재할까요?
- `SpendingCategoryManager`를 사용한 자원 검증에 대해서 이해하셨나요? (그보다 저거 Manager라는 네이밍 괜찮아 보이나요..? ㅎㅎ..)

<br/>

## 발견한 이슈
- SpendingUseCase 통합 테스트만 따로 실행하면 통과하는데, gradlew로 테스트하면 실패하는 중. 아마 이것도 실패할 예정..^^
