### PR TITLE
✨ 사용자 정의 지출 카테고리 조회 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingCategoryApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingCategoryApi.java
@@ -4,10 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.media.SchemaProperty;
+import io.swagger.v3.oas.annotations.media.*;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
@@ -31,4 +28,8 @@ public interface SpendingCategoryApi {
     })
     @ApiResponse(responseCode = "200", description = "지출 카테고리 등록 성공", content = @Content(mediaType = "application/json", schemaProperties = @SchemaProperty(name = "spendingCategory", schema = @Schema(implementation = SpendingCategoryDto.Res.class))))
     ResponseEntity<?> postSpendingCategory(@Validated SpendingCategoryDto.CreateParamReq param, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "사용자 정의 지출 카테고리 조회", method = "GET", description = "사용자가 생성한 지출 카테고리 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "지출 카테고리 조회 성공", content = @Content(mediaType = "application/json", schemaProperties = @SchemaProperty(name = "spendingCategories", array = @ArraySchema(schema = @Schema(implementation = SpendingCategoryDto.Res.class)))))
+    ResponseEntity<?> getSpendingCategories(@AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,5 +36,11 @@ public class SpendingCategoryController implements SpendingCategoryApi {
 
         SpendingCategoryDto.Res spendingCategory = spendingCategoryUseCase.createSpendingCategory(user.getUserId(), param.name(), param.icon());
         return ResponseEntity.ok(SuccessResponse.from("spendingCategory", spendingCategory));
+    }
+
+    @GetMapping("")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getSpendingCategories(@AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(SuccessResponse.from("spendingCategories", spendingCategoryUseCase.getSpendingCategories(user.getUserId())));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
@@ -38,6 +38,7 @@ public class SpendingCategoryController implements SpendingCategoryApi {
         return ResponseEntity.ok(SuccessResponse.from("spendingCategory", spendingCategory));
     }
 
+    @Override
     @GetMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getSpendingCategories(@AuthenticationPrincipal SecurityUserDetails user) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingCategoryUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingCategoryUseCase.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
@@ -28,5 +30,14 @@ public class SpendingCategoryUseCase {
         SpendingCustomCategory category = spendingCustomCategoryService.createSpendingCustomCategory(SpendingCustomCategory.of(categoryName, icon, user));
 
         return SpendingCategoryDto.Res.from(CategoryInfo.of(category.getId(), category.getName(), category.getIcon()));
+    }
+
+    @Transactional(readOnly = true)
+    public List<SpendingCategoryDto.Res> getSpendingCategories(Long userId) {
+        List<SpendingCustomCategory> categories = spendingCustomCategoryService.readSpendingCustomCategories(userId);
+
+        return categories.stream()
+                .map(category -> SpendingCategoryDto.Res.from(CategoryInfo.of(category.getId(), category.getName(), category.getIcon())))
+                .toList();
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/converter/SpendingCategoryConverter.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/converter/SpendingCategoryConverter.java
@@ -4,10 +4,10 @@ import jakarta.persistence.Converter;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 
 @Converter
-public class SpendingIconConverter extends AbstractLegacyEnumAttributeConverter<SpendingCategory> {
-    private static final String ENUM_NAME = "지출 아이콘";
+public class SpendingCategoryConverter extends AbstractLegacyEnumAttributeConverter<SpendingCategory> {
+    private static final String ENUM_NAME = "지출 카테고리";
 
-    public SpendingIconConverter() {
+    public SpendingCategoryConverter() {
         super(SpendingCategory.class, false, ENUM_NAME);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/Spending.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/Spending.java
@@ -1,7 +1,7 @@
 package kr.co.pennyway.domain.domains.spending.domain;
 
 import jakarta.persistence.*;
-import kr.co.pennyway.domain.common.converter.SpendingIconConverter;
+import kr.co.pennyway.domain.common.converter.SpendingCategoryConverter;
 import kr.co.pennyway.domain.common.model.DateAuditable;
 import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
@@ -27,7 +27,7 @@ public class Spending extends DateAuditable {
     private Long id;
 
     private Integer amount;
-    @Convert(converter = SpendingIconConverter.class)
+    @Convert(converter = SpendingCategoryConverter.class)
     private SpendingCategory category;
     private LocalDateTime spendAt;
     private String accountName;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/SpendingCustomCategory.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/SpendingCustomCategory.java
@@ -32,14 +32,16 @@ public class SpendingCustomCategory extends DateAuditable {
     private User user;
 
     private SpendingCustomCategory(String name, SpendingCategory icon, User user) {
+        if (icon.equals(SpendingCategory.OTHER)) {
+            throw new IllegalArgumentException("OTHER 아이콘은 커스텀 카테고리의 icon으로 사용할 수 없습니다.");
+        }
+
         this.name = name;
         this.icon = icon;
         this.user = user;
     }
 
     public static SpendingCustomCategory of(String name, SpendingCategory icon, User user) {
-        if (icon.equals(SpendingCategory.OTHER))
-            throw new IllegalArgumentException("OTHER 아이콘은 커스텀 카테고리의 icon으로 사용할 수 없습니다.");
         return new SpendingCustomCategory(name, icon, user);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/SpendingCustomCategory.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/domain/SpendingCustomCategory.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.domain.domains.spending.domain;
 
 import jakarta.persistence.*;
+import kr.co.pennyway.domain.common.converter.SpendingCategoryConverter;
 import kr.co.pennyway.domain.common.model.DateAuditable;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import kr.co.pennyway.domain.domains.user.domain.User;
@@ -24,6 +25,7 @@ public class SpendingCustomCategory extends DateAuditable {
     private Long id;
 
     private String name;
+    @Convert(converter = SpendingCategoryConverter.class)
     private SpendingCategory icon;
     private LocalDateTime deletedAt;
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomCategoryRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomCategoryRepository.java
@@ -4,7 +4,12 @@ import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 public interface SpendingCustomCategoryRepository extends JpaRepository<SpendingCustomCategory, Long> {
     @Transactional(readOnly = true)
     boolean existsByIdAndUser_Id(Long id, Long userId);
+
+    @Transactional(readOnly = true)
+    List<SpendingCustomCategory> findAllByUser_Id(Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -23,6 +24,11 @@ public class SpendingCustomCategoryService {
     @Transactional(readOnly = true)
     public Optional<SpendingCustomCategory> readSpendingCustomCategory(Long id) {
         return spendingCustomCategoryRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SpendingCustomCategory> readSpendingCustomCategories(Long userId) {
+        return spendingCustomCategoryRepository.findAllByUser_Id(userId);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 작업 이유
- 사용자는 본인이 추가한 지출 카테고리를 조회할 수 있다.

<br/>

## 작업 사항
> 너무 단순한 작업이기도 하고, 굳이 테스트 케이스를 보일 이유가 없어서 작성하지 않았습니다.
> 대신 스웨거 이미지로 대체

### API Spec
- url : `GET /v2/spending-categories`
- pre-condition : 사용자는 로그인한 상태여야 한다.
- usecase
   1. 사용자가 등록한 커스텀 카테고리 리스트 조회

<br/>

### 🟡 결과 응답 및 스웨거 성공 예시 문서

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/34310db2-798c-446f-8d06-f01e668d9d18" width="400px"/>
 <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/5de5bbd8-b0ae-49cd-a60c-1fe680585f8a" width="600px"/>
</div>

- 서비스에서 제공해주는 카테고리는 iOS팀에서 기본으로 UI에 출력하고, 추가로 등록한 카테고리만 반환함.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 테스트 케이스...필요하신가요? ㅋㅋㅋ 뭘 써야 할 지 모르겠어서...

<br/>

## 발견한 이슈
일단 현재는 해결한 바보 이슈긴 한데, 디버그 정보 활용하는 걸 좀 알게 돼서 공유드립니다.  

처음에 계속 DB를 조회하는 과정에서 `Out Of Index` 에러가 발생해서 로그를 확인해봤습니다.

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/62f2a575-3c26-4a77-a91e-7135f4dbe227" width="700px"/>
</div>

```sql
SELECT scc.*
FROM spending_custom_category scc
LEFT JOIN user u ON u.id = scc.user_id
WHERE u.deleted_at IS NULL AND scc.deleted_at IS NULL AND u.id=10;
```

- Extracted JDBC value의 키-값은 [`select 절에 정의한 필드 번호`] - [`매칭된 값`]을 의미합니다. (전 귀찮아서 그냥 scc.*로 표현 ㅎ)
- 데이터를 잘 가져오다가 3번 째 인덱스에 해당하는 `icon` 정보를 가져올 때 `Out Of Index`가 발생합니다.
- 해당 필드는 SpendingCategory enum class라서, Conveter 문제겠거니 싶어 확인해보니 필드에 Conveter 등록이 안 되어 있었습니다 ㅎㅎㅎㅎㅎㅎ ^^

여튼 로그 정보가 너무 많아서 헷갈리실 수도 있을 거 같은데, 하나씩 이해해보면 유용한 정보들이 많아서  
이번에 제가 활용한 방법 공유해드립니다.




