### PR TITLE
✏️ QueryDsl 확장 Repository의 Dto 불변성 보장을 위한 분기 처리

### DIFF
--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/repository/QueryDslSearchRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/repository/QueryDslSearchRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -13,6 +14,7 @@ import java.util.Map;
  * QueryDsl을 이용한 검색 조건을 처리하는 기본적인 메서드를 선언한 인터페이스
  *
  * @author YANG JAESEO
+ * @version 1.1
  */
 public interface QueryDslSearchRepository<T> {
 
@@ -87,11 +89,13 @@ public interface QueryDslSearchRepository<T> {
     Page<T> findPage(Predicate predicate, QueryHandler queryHandler, Pageable pageable);
 
     /**
-     * 검색 조건에 해당하는 DTO 리스트를 조회하는 메서드
+     * 검색 조건에 해당하는 DTO 리스트를 조회하는 메서드 <br/>
+     * bindings가 {@link LinkedHashMap}을 구현체로 사용하는 경우 Dto 생성자 파라미터 순서에 맞게 삽입하면, Dto의 불변성을 유지할 수 있다. <br/>
+     * 만약 bindings가 삽입 순서를 보장하지 않을 경우, Dto는 기본 생성자와 setter 메서드를 제공해야 하며, 모든 필드의 final 키워드를 제거해야 한다.
      *
      * @param predicate : 검색 조건
      * @param type : 조회할 도메인(혹은 DTO) 타입
-     * @param bindings : 검색 조건에 해당하는 도메인(혹은 DTO)의 필드
+     * @param bindings : 검색 조건에 해당하는 도메인(혹은 DTO)의 필드. {@link LinkedHashMap}을 구현체로 사용하는 경우 Dto 생성자 파라미터 순서에 맞게 삽입해야 한다.
      * @param queryHandler : 검색 조건에 추가적으로 적용할 조건
      * @param sort : 정렬 조건
      *
@@ -134,10 +138,12 @@ public interface QueryDslSearchRepository<T> {
 
     /**
      * 검색 조건에 해당하는 DTO 페이지를 조회하는 메서드
+     * bindings가 {@link LinkedHashMap}을 구현체로 사용하는 경우 Dto 생성자 파라미터 순서에 맞게 삽입하면, Dto의 불변성을 유지할 수 있다. <br/>
+     * 만약 bindings가 삽입 순서를 보장하지 않을 경우, Dto는 기본 생성자와 setter 메서드를 제공해야 하며, 모든 필드의 final 키워드를 제거해야 한다.
      *
      * @param predicate : 검색 조건
      * @param type : 조회할 도메인(혹은 DTO) 타입
-     * @param bindings : 검색 조건에 해당하는 도메인(혹은 DTO)의 필드
+     * @param bindings : 검색 조건에 해당하는 도메인(혹은 DTO)의 필드. {@link LinkedHashMap}을 구현체로 사용하는 경우 Dto 생성자 파라미터 순서에 맞게 삽입해야 한다.
      * @param queryHandler : 검색 조건에 추가적으로 적용할 조건
      * @param pageable : 페이지 정보
      *

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/repository/QueryHandler.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/repository/QueryHandler.java
@@ -3,7 +3,7 @@ package kr.co.pennyway.domain.common.repository;
 import com.querydsl.jpa.impl.JPAQuery;
 
 /**
- * QueryDsl을 이용한 검색 조건을 처리하는 기본적인 메서드를 선언한 인터페이스
+ * QueryDsl의 명시적 조인을 위한 함수형 인터페이스
  *
  * @author YANG JAESEO
  */

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/user/repository/UserExtendedRepositoryTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/user/repository/UserExtendedRepositoryTest.java
@@ -132,9 +132,43 @@ public class UserExtendedRepositoryTest extends ContainerMySqlTestConfig {
     @Test
     @DisplayName("""
             Dto selectList 테스트: 사용자 이름이 양재서인 사용자의 username, name, phone 그리고 연동된 Oauth 정보를 조회한다.
+            LinkedHashMap을 사용하여 Dto 생성자 파라미터 순서에 맞게 삽입하면, Dto의 불변성을 유지할 수 있다.
             """)
     @Transactional
-    public void selectList() {
+    public void selectListUseLinkedHashMap() {
+        // given
+        Predicate predicate = qUser.name.eq("양재서");
+
+        QueryHandler queryHandler = query -> query.leftJoin(qOauth).on(qUser.id.eq(qOauth.user.id));
+        Sort sort = null;
+
+        Map<String, Expression<?>> bindings = new LinkedHashMap<>();
+
+        bindings.put("userId", qUser.id);
+        bindings.put("username", qUser.username);
+        bindings.put("name", qUser.name);
+        bindings.put("phone", qUser.phone);
+        bindings.put("oauthId", qOauth.id);
+        bindings.put("provider", qOauth.provider);
+
+        // when
+        List<UserAndOauthInfo> userAndOauthInfos = userRepository.selectList(predicate, UserAndOauthInfo.class, bindings, queryHandler, sort);
+
+        // then
+        userAndOauthInfos.forEach(userAndOauthInfo -> {
+            log.debug("userAndOauthInfo: {}", userAndOauthInfo);
+            assertEquals("이름이 양재서인 사용자만 조회되어야 한다.", "양재서", userAndOauthInfo.name());
+            assertEquals("provider는 KAKAO여야 한다.", Provider.KAKAO, userAndOauthInfo.provider());
+        });
+    }
+
+    @Test
+    @DisplayName("""
+            Dto selectList 테스트: 사용자 이름이 양재서인 사용자의 username, name, phone 그리고 연동된 Oauth 정보를 조회한다.
+            HashMap을 사용하더라도 Dto의 setter를 명시하고 final 키워드를 제거하면 결과를 조회할 수 있다.
+            """)
+    @Transactional
+    public void selectListUseHashMap() {
         // given
         Predicate predicate = qUser.name.eq("양재서");
 
@@ -151,7 +185,7 @@ public class UserExtendedRepositoryTest extends ContainerMySqlTestConfig {
         bindings.put("provider", qOauth.provider);
 
         // when
-        List<UserAndOauthInfo> userAndOauthInfos = userRepository.selectList(predicate, UserAndOauthInfo.class, bindings, queryHandler, sort);
+        List<UserAndOauthInfoNotImmutable> userAndOauthInfos = userRepository.selectList(predicate, UserAndOauthInfoNotImmutable.class, bindings, queryHandler, sort);
 
         // then
         userAndOauthInfos.forEach(userAndOauthInfo -> {
@@ -218,9 +252,13 @@ public class UserExtendedRepositoryTest extends ContainerMySqlTestConfig {
         jdbcTemplate.batchUpdate(sql, params);
     }
 
+    public record UserAndOauthInfo(Long userId, String username, String name, String phone, Long oauthId,
+                                   Provider provider) {
+    }
+
     @Setter
     @Getter
-    public static class UserAndOauthInfo {
+    public static class UserAndOauthInfoNotImmutable {
         private Long userId;
         private String username;
         private String name;
@@ -228,28 +266,7 @@ public class UserExtendedRepositoryTest extends ContainerMySqlTestConfig {
         private Long oauthId;
         private Provider provider;
 
-        public UserAndOauthInfo() {
-        }
-
-        public UserAndOauthInfo(Long userId, String username, String name, String phone, Long oauthId, Provider provider) {
-            this.userId = userId;
-            this.username = username;
-            this.name = name;
-            this.phone = phone;
-            this.oauthId = oauthId;
-            this.provider = provider;
-        }
-
-        @Override
-        public String toString() {
-            return "UserAndOauthInfo{" +
-                    "userId=" + userId +
-                    ", username='" + username + '\'' +
-                    ", name='" + name + '\'' +
-                    ", phone='" + phone + '\'' +
-                    ", oauthId=" + oauthId +
-                    ", provider=" + provider +
-                    '}';
+        public UserAndOauthInfoNotImmutable() {
         }
     }
 }

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/user/repository/UserExtendedRepositoryTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/user/repository/UserExtendedRepositoryTest.java
@@ -254,6 +254,17 @@ public class UserExtendedRepositoryTest extends ContainerMySqlTestConfig {
 
     public record UserAndOauthInfo(Long userId, String username, String name, String phone, Long oauthId,
                                    Provider provider) {
+        @Override
+        public String toString() {
+            return "UserAndOauthInfo{" +
+                    "userId=" + userId +
+                    ", username='" + username + '\'' +
+                    ", name='" + name + '\'' +
+                    ", phone='" + phone + '\'' +
+                    ", oauthId=" + oauthId +
+                    ", provider=" + provider +
+                    '}';
+        }
     }
 
     @Setter
@@ -267,6 +278,18 @@ public class UserExtendedRepositoryTest extends ContainerMySqlTestConfig {
         private Provider provider;
 
         public UserAndOauthInfoNotImmutable() {
+        }
+
+        @Override
+        public String toString() {
+            return "UserAndOauthInfoNotImmutable{" +
+                    "userId=" + userId +
+                    ", username='" + username + '\'' +
+                    ", name='" + name + '\'' +
+                    ", phone='" + phone + '\'' +
+                    ", oauthId=" + oauthId +
+                    ", provider=" + provider +
+                    '}';
         }
     }
 }


### PR DESCRIPTION
## 작업 이유
- #76 의 Dto 불변성 보장 실패를 개선

<br/>

## 작업 사항

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/5b74153e-842d-419f-b85a-d1ec29e5e264" width="700px"/>
</div>

- 만약 `bindings`의 구현체가 `LinkedHashMap`인 경우 입력 순서를 보장할 수 있기 때문에 `Projections.bean()`이 아닌 `Projections.construtor()`을 사용할 수 있습니다.
- 생성자를 사용할 수 있다면 더 이상 Reflection을 사용한 주입 방법을 고수할 필요가 없어지므로 `record`를 사용하여 Dto의 불변성 또한 유지할 수 있습니다.
- 단, 구현체가 LinkedHashMap이 아닐 수 있기에 예외적으로 핸들링하고 있으며, LinkedHashMap을 사용하더라도 "반드시 생성자 순서에 맞게" 자료구조에 값을 담아야 합니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 테스트 코드에 HashMap을 사용한 방식과 LinkedHashMap을 사용한 방법 모두 명시해두었습니다. 확인해보시고 이해가 안 가는 부분에 대해서 질문해주세요!

<br/>

## 발견한 이슈
- 없음

