### PR TITLE
✏️ 테스트 작성 시 `@AuthenticatePrincipal` 어노테이션 대응

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/SecurityUserDetails.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authentication/SecurityUserDetails.java
@@ -57,7 +57,7 @@ public final class SecurityUserDetails implements UserDetails {
 
     @Override
     public String getPassword() {
-        throw new UnsupportedOperationException();
+        return null;
     }
 
     @Override

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/filter/JwtAuthenticationFilter.java
@@ -101,6 +101,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private UserDetails getUserDetails(String accessToken) {
         JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
         String userId = (String) claims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue());
+        log.debug("User ID: {}", userId);
 
         return userDetailService.loadUserByUsername(userId);
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/UserAuthControllerIntegrationTest.java
@@ -12,7 +12,6 @@ import kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenProvider;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
 import kr.co.pennyway.api.config.fixture.UserFixture;
-import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.common.redis.forbidden.ForbiddenTokenService;
 import kr.co.pennyway.domain.common.redis.refresh.RefreshToken;
 import kr.co.pennyway.domain.common.redis.refresh.RefreshTokenService;
@@ -81,7 +80,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
     @Nested
     @Order(1)
-    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     @DisplayName("로그아웃")
     class SignOut {
         private String expectedAccessToken;
@@ -103,7 +101,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             expectedRefreshToken = refreshTokenProvider.generateToken(RefreshTokenClaim.of(user.getId(), Role.USER.getType()));
         }
 
-        @Order(1)
         @Test
         @DisplayName("Scenario #1 유효한 accessToken과 refreshToken이 있다면, accessToken은 forbiddenToken으로, refreshToken은 삭제한다.")
         void validAccessTokenAndValidRefreshToken() throws Exception {
@@ -121,7 +118,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             assertThrows(IllegalArgumentException.class, () -> refreshTokenService.delete(userId, expectedRefreshToken));
         }
 
-        @Order(2)
         @Test
         @DisplayName("Scenario #2 유효한 accessToken만 존재한다면, accessToken만 forbiddenToken으로 만든다.")
         void validAccessTokenWithoutRefreshToken() throws Exception {
@@ -133,7 +129,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             assertTrue(forbiddenTokenService.isForbidden(expectedAccessToken));
         }
 
-        @Order(3)
         @Test
         @DisplayName("Scenario #2-1 유효한 accessToken과 다른 사용자의 유효한 refreshToken이 있다면, 401 에러를 반환한다. accessToken이 forbidden 처리되지 않으며, 사용자와 다른 사용자의 refreshToken 정보 모두 삭제되지 않는다.")
         void validAccessTokenAndWithOutOwnershipRefreshToken() throws Exception {
@@ -157,7 +152,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             assertFalse(forbiddenTokenService.isForbidden(expectedAccessToken));
         }
 
-        @Order(4)
         @Test
         @DisplayName("Scenario #2-2 유효한 accessToken과 유효하지 않은 refreshToken이 있다면, 401 에러를 반환한다. accessToken이 forbidden 처리되지 않으며, refreshToken 정보는 삭제되지 않는다.")
         void validAccessTokenAndInvalidRefreshToken() throws Exception {
@@ -180,7 +174,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             assertFalse(forbiddenTokenService.isForbidden(expectedAccessToken));
         }
 
-        @Order(5)
         @Test
         @DisplayName("Scenario #2-3 유효한 accessToken, 유효한 refreshToken을 가진 사용자가 refresh 하기 전의 refreshToken을 사용하는 경우, accessToken을 forbidden에 등록하고 refreshToken을 cache에서 제거한다. (refreshToken 탈취 대체 시나리오)")
         void validAccessTokenAndOldRefreshToken() throws Exception {
@@ -203,7 +196,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             assertTrue(forbiddenTokenService.isForbidden(expectedAccessToken));
         }
 
-        @Order(6)
         @Test
         @DisplayName("Scenario #3 유효하지 않은 accessToken과 유효한 refreshToken이 있다면 401 에러를 반환한다.")
         void invalidAccessTokenAndValidRefreshToken() throws Exception {
@@ -219,7 +211,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             result.andExpect(status().isUnauthorized()).andDo(print());
         }
 
-        @Order(7)
         @Test
         @DisplayName("Scenario #4 유효하지 않은 accessToken과 유효하지 않은 refreshToken이 있다면 401 에러를 반환한다.")
         void invalidAccessTokenAndInvalidRefreshToken() throws Exception {
@@ -238,45 +229,39 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
     }
 
     @Nested
-    @Order(2)
     @DisplayName("소셜 계정 연동")
-    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     class LinkOauth {
-        @Order(1)
         @Test
         @DisplayName("provider로 로그인한 이력이 없다면, 사용자는 계정 연동에 성공한다.")
-        @WithSecurityMockUser(userId = "8")
         @Transactional
         void linkOauthWithNoHistory() throws Exception {
             // given
-            User user = UserFixture.GENERAL_USER.toUser();
-            userService.createUser(user);
+            User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
+
             Provider expectedProvider = Provider.KAKAO;
             given(oauthOidcHelper.getPayload(expectedProvider, "oauthId", "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "oauthId", "email"));
 
             // when
-            ResultActions result = performLinkOauth(expectedProvider, "oauthId");
+            ResultActions result = performLinkOauth(expectedProvider, "oauthId", user);
 
             // then
             result.andExpect(status().isOk()).andDo(print());
             assertTrue(oauthService.isExistOauthAccount(user.getId(), expectedProvider));
         }
 
-        @Order(2)
         @Test
         @DisplayName("provider로 로그인한 이력이 있다면, 사용자는 계정 연동에 실패하고 409 에러를 반환한다.")
-        @WithSecurityMockUser(userId = "9")
         @Transactional
         void linkOauthWithHistory() throws Exception {
             // given
-            User user = UserFixture.GENERAL_USER.toUser();
-            userService.createUser(user);
+            User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
+
             Provider expectedProvider = Provider.KAKAO;
             oauthService.createOauth(Oauth.of(expectedProvider, "oauthId", user));
             given(oauthOidcHelper.getPayload(expectedProvider, "oauthId", "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "oauthId", "email"));
 
             // when
-            ResultActions result = performLinkOauth(expectedProvider, "oauthId");
+            ResultActions result = performLinkOauth(expectedProvider, "oauthId", user);
 
             // then
             result.andExpect(status().isConflict())
@@ -285,23 +270,21 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andDo(print());
         }
 
-        @Order(3)
         @Test
         @DisplayName("해당 provider가 soft delete된 이력이 존재한다면, deleted_at을 null로 업데이트하고 최신 oauth_id를 반영하여 계정 연동에 성공한다.")
-        @WithSecurityMockUser(userId = "10")
         @Transactional
         void linkOauthWithDeletedHistory() throws Exception {
             // given
-            User user = UserFixture.GENERAL_USER.toUser();
-            userService.createUser(user);
+            User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
+
             Provider expectedProvider = Provider.KAKAO;
-            Oauth oauth = Oauth.of(expectedProvider, "oauthId", user);
-            oauthService.createOauth(oauth);
+            Oauth oauth = oauthService.createOauth(Oauth.of(expectedProvider, "oauthId", user));
             oauthService.deleteOauth(oauth);
+
             given(oauthOidcHelper.getPayload(expectedProvider, "newOauthId", "idToken", "nonce")).willReturn(new OidcDecodePayload("iss", "aud", "newOauthId", "email"));
 
             // when
-            ResultActions result = performLinkOauth(expectedProvider, "newOauthId");
+            ResultActions result = performLinkOauth(expectedProvider, "newOauthId", user);
 
             // then
             result.andExpect(status().isOk()).andDo(print());
@@ -312,11 +295,14 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             log.info("연동된 Oauth 정보 : {}", savedOauth);
         }
 
-        private ResultActions performLinkOauth(Provider provider, String oauthId) throws Exception {
+        private ResultActions performLinkOauth(Provider provider, String oauthId, User requestUser) throws Exception {
+            UserDetails userDetails = SecurityUserDetails.from(requestUser);
             SignInReq.Oauth request = new SignInReq.Oauth(oauthId, "idToken", "nonce");
+
             return mockMvc.perform(put("/v1/link-oauth")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
+                    .with(user(userDetails))
                     .queryParam("provider", provider.name())
                     .content(objectMapper.writeValueAsString(request)));
         }
@@ -325,19 +311,16 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
     @Nested
     @Order(5)
     @DisplayName("소셜 연동 해제")
-    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     class OauthUnlinkTest {
         @Test
-        @Order(1)
         @Transactional
         @DisplayName("제공자로 연동한 이력이 존재하지 않으면 404 에러가 발생한다.")
         void unlinkWithNoOauth() throws Exception {
             // given
             User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
-            UserDetails userDetails = SecurityUserDetails.from(user);
 
             // when
-            ResultActions result = performOauthUnlink(Provider.KAKAO, userDetails);
+            ResultActions result = performOauthUnlink(Provider.KAKAO, user);
 
             // then
             result
@@ -348,19 +331,17 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @Order(2)
         @Transactional
         @DisplayName("제공자로 연동한 이력이 soft delete 되어 있으면 404 에러가 발생한다.")
         void unlinkWithSoftDeletedOauth() throws Exception {
             // given
             User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
-            UserDetails userDetails = SecurityUserDetails.from(user);
 
             Oauth oauth = mappingOauthWithUser(user, Provider.KAKAO);
             oauthService.deleteOauth(oauth);
 
             // when
-            ResultActions result = performOauthUnlink(Provider.KAKAO, userDetails);
+            ResultActions result = performOauthUnlink(Provider.KAKAO, user);
 
             // then
             result
@@ -371,19 +352,16 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @Order(3)
-        @WithSecurityMockUser(userId = "13")
         @Transactional
         @DisplayName("연동된 Oauth가 1개이고 일반 회원 이력이 없는 경우에는 409 에러가 발생한다.")
         void unlinkWithOnlyOauthSignedUser() throws Exception {
             // given
             User user = userService.createUser(UserFixture.OAUTH_USER.toUser());
-            UserDetails userDetails = SecurityUserDetails.from(user);
 
             mappingOauthWithUser(user, Provider.KAKAO);
 
             // when
-            ResultActions result = performOauthUnlink(Provider.KAKAO, userDetails);
+            ResultActions result = performOauthUnlink(Provider.KAKAO, user);
 
             // then
             result
@@ -394,18 +372,16 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @Order(4)
         @Transactional
         @DisplayName("연동된 Oauth가 1개이고 일반 회원 이력이 있는 경우에는 연동 해제에 성공한다.")
         void unlinkWithGeneralSignedUser() throws Exception {
             // given
             User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
-            UserDetails userDetails = SecurityUserDetails.from(user);
 
             Oauth oauth = mappingOauthWithUser(user, Provider.KAKAO);
 
             // when
-            ResultActions result = performOauthUnlink(Provider.KAKAO, userDetails);
+            ResultActions result = performOauthUnlink(Provider.KAKAO, user);
 
             // then
             result.andExpect(status().isOk()).andDo(print());
@@ -413,26 +389,26 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @Order(5)
         @Transactional
         @DisplayName("연동된 Oauth가 2개 이상이고 일반 회원 이력이 없는 경우에는 연동 해제에 성공한다.")
         void unlinkWithMultipleOauthSignedUser() throws Exception {
             // given
             User user = userService.createUser(UserFixture.OAUTH_USER.toUser());
-            UserDetails userDetails = SecurityUserDetails.from(user);
 
             Oauth kakao = mappingOauthWithUser(user, Provider.KAKAO);
             Oauth google = mappingOauthWithUser(user, Provider.GOOGLE);
 
             // when
-            ResultActions result = performOauthUnlink(Provider.KAKAO, userDetails);
+            ResultActions result = performOauthUnlink(Provider.KAKAO, user);
 
             // then
             result.andExpect(status().isOk()).andDo(print());
             assertTrue(oauthService.readOauthByOauthIdAndProvider(kakao.getOauthId(), Provider.KAKAO).get().isDeleted());
         }
 
-        private ResultActions performOauthUnlink(Provider provider, UserDetails userDetails) throws Exception {
+        private ResultActions performOauthUnlink(Provider provider, User requestUser) throws Exception {
+            UserDetails userDetails = SecurityUserDetails.from(requestUser);
+
             return mockMvc.perform(MockMvcRequestBuilders.delete("/v1/link-oauth")
                     .with(user(userDetails))
                     .param("provider", provider.name()));

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/AuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/AuthControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-package kr.co.pennyway.api.apis.auth.controller;
+package kr.co.pennyway.api.apis.auth.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/OAuthControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-package kr.co.pennyway.api.apis.auth.controller;
+package kr.co.pennyway.api.apis.auth.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
@@ -1,4 +1,4 @@
-package kr.co.pennyway.api.apis.auth.controller;
+package kr.co.pennyway.api.apis.auth.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingControllerIntegrationTest.java
@@ -2,13 +2,11 @@ package kr.co.pennyway.api.apis.ledger.integration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
-import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
-import kr.co.pennyway.api.apis.ledger.usecase.SpendingUseCase;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
 import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
 import kr.co.pennyway.api.config.fixture.SpendingFixture;
 import kr.co.pennyway.api.config.fixture.UserFixture;
-import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
 import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
@@ -19,6 +17,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -26,15 +25,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
-import static org.springframework.test.util.AssertionErrors.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Slf4j
 @ExternalApiIntegrationTest
 @AutoConfigureMockMvc
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
-public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
+public class SpendingControllerIntegrationTest extends ExternalApiDBTestConfig {
 
     @Autowired
     private MockMvc mockMvc;
@@ -43,8 +43,6 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
     @Autowired
     private UserService userService;
     @Autowired
-    private SpendingUseCase spendingUseCase;
-    @Autowired
     private SpendingCustomCategoryService spendingCustomCategoryService;
     @Autowired
     private NamedParameterJdbcTemplate jdbcTemplate;
@@ -52,12 +50,9 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
     @Order(1)
     @Nested
     @DisplayName("지출 내역 추가하기")
-    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     class CreateSpending {
-        @Order(1)
         @Test
         @DisplayName("request의 categoryId가 -1인 경우, spendingCustomCategory가 null인 Spending을 생성한다.")
-        @WithSecurityMockUser(userId = "1")
         @Transactional
         void createSpendingSuccess() throws Exception {
             // given
@@ -65,18 +60,19 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
             SpendingReq request = new SpendingReq(10000, -1L, SpendingCategory.FOOD, LocalDate.now(), "소비처", "메모");
 
             // when
-            SpendingSearchRes.Individual result = spendingUseCase.createSpending(user.getId(), request);
+            ResultActions result = performCreateSpendingSuccess(request, user);
 
             // then
-            assertEquals("isCustom이 false이어야 한다.", false, result.category().isCustom());
-            assertEquals("categoryId가 -1이어야 한다.", -1L, result.category().id());
-            assertEquals("icon이 FOOD이어야 한다.", SpendingCategory.FOOD, result.category().icon());
+            result.andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.spending.amount").value(10000))
+                    .andExpect(jsonPath("$.data.spending.category.isCustom").value(false))
+                    .andExpect(jsonPath("$.data.spending.category.id").value(-1))
+                    .andExpect(jsonPath("$.data.spending.category.icon").value(SpendingCategory.FOOD.name()));
         }
 
-        @Order(2)
         @Test
         @DisplayName("request의 categoryId가 -1이 아닌 경우, spendingCustomCategory를 참조하는 Spending을 생성한다.")
-        @WithSecurityMockUser(userId = "2")
         @Transactional
         void createSpendingWithCustomCategorySuccess() throws Exception {
             // given
@@ -85,18 +81,19 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
             SpendingReq request = new SpendingReq(10000, category.getId(), SpendingCategory.OTHER, LocalDate.now(), "소비처", "메모");
 
             // when
-            SpendingSearchRes.Individual result = spendingUseCase.createSpending(user.getId(), request);
+            ResultActions result = performCreateSpendingSuccess(request, user);
 
             // then
-            assertEquals("isCustom이 true이어야 한다.", true, result.category().isCustom());
-            assertEquals("categoryId가 spendingCustomCategory의 id와 같아야 한다.", category.getId(), result.category().id());
-            assertEquals("icon이 spendingCustomCategory의 icon과 같아야 한다.", category.getIcon(), result.category().icon());
+            result.andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.spending.amount").value(10000))
+                    .andExpect(jsonPath("$.data.spending.category.isCustom").value(true))
+                    .andExpect(jsonPath("$.data.spending.category.id").value(category.getId()))
+                    .andExpect(jsonPath("$.data.spending.category.icon").value(category.getIcon().name()));
         }
 
-        @Order(3)
         @Test
         @DisplayName("사용자가 categoryId에 해당하는 카테고리 정보의 소유자가 아닌 경우, 403 Forbidden을 반환한다.")
-        @WithSecurityMockUser(userId = "3")
         @Transactional
         void createSpendingWithInvalidCustomCategory() throws Exception {
             // given
@@ -104,16 +101,19 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
             SpendingReq request = new SpendingReq(10000, 1000L, SpendingCategory.OTHER, LocalDate.now(), "소비처", "메모");
 
             // when
-            ResultActions resultActions = performCreateSpendingSuccess(request);
+            ResultActions result = performCreateSpendingSuccess(request, user);
 
             // then
-            resultActions.andDo(print()).andExpect(status().isForbidden());
+            result.andDo(print()).andExpect(status().isForbidden());
         }
 
-        private ResultActions performCreateSpendingSuccess(SpendingReq req) throws Exception {
+        private ResultActions performCreateSpendingSuccess(SpendingReq req, User requestUser) throws Exception {
+            UserDetails userDetails = SecurityUserDetails.from(requestUser);
+
             return mockMvc.perform(MockMvcRequestBuilders
                     .post("/v2/spendings")
                     .contentType("application/json")
+                    .with(user(userDetails))
                     .content(objectMapper.writeValueAsString(req)));
         }
     }
@@ -124,7 +124,6 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
     class GetSpendingListAtYearAndMonth {
         @Test
         @DisplayName("월별 지출 내역 조회")
-        @WithSecurityMockUser(userId = "4")
         @Transactional
         void getSpendingListAtYearAndMonthSuccess() throws Exception {
             // given
@@ -133,7 +132,7 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
 
             // when
             long before = System.currentTimeMillis();
-            ResultActions resultActions = performGetSpendingListAtYearAndMonthSuccess();
+            ResultActions resultActions = performGetSpendingListAtYearAndMonthSuccess(user);
             long after = System.currentTimeMillis();
 
             // then
@@ -143,9 +142,12 @@ public class SpendingUseCaseIntegrationTest extends ExternalApiDBTestConfig {
             log.debug("수행 시간: {}ms", after - before);
         }
 
-        private ResultActions performGetSpendingListAtYearAndMonthSuccess() throws Exception {
+        private ResultActions performGetSpendingListAtYearAndMonthSuccess(User requestUser) throws Exception {
+            UserDetails userDetails = SecurityUserDetails.from(requestUser);
             LocalDate now = LocalDate.now();
+
             return mockMvc.perform(MockMvcRequestBuilders.get("/v2/spendings")
+                    .with(user(userDetails))
                     .param("year", String.valueOf(now.getYear()))
                     .param("month", String.valueOf(now.getMonthValue())));
         }


### PR DESCRIPTION
## 작업 이유
- 기존의 커스텀 어노테이션 `@WithSecurityMockUser`의 한계점 발견
- 테스트에서 요청 사용자 정보를 확보하는 데 있어 일관되고, 안정성을 보장하는 방법으로 수정

<br/>

## 작업 사항
### 🟡 기존 방식의 문제점
- 통합 테스트 환경에서 `@WithSecurityMockUser(userId = "1")`를 사용하여, 요청한 사용자의 정보를 Controller의 `@AuthenticatePrincipal`에 삽입하는 데 성공했습니다.
- 하지만 `userId`의 default가 1이기 때문에 테스트를 작성하는 개발자가 임의의 테스트에 저장된 Mock User의 id를 예측하여 어노테이션에 전달해줘야 하는 리스크가 존재했습니다.

<br/>

### 🟡 해결책
> 매우 간단한 해결책..
```java
User user = userService.createUser(user); // 영속화된 유저 생성

UserDetails userDetails = SecurityUserDetails.from(requestUser); // UserDetails 객체 생성

mockMvc.perform(...)
        .with(user(userDetails));
```
- 기존의 `@WithSecurityMockUser` 어노테이션을 모두 제거하고, `mockMvc`를 요청할 때 UserDetails를 `.with(user())`로 전달하면 끝납니다.
- 더 이상 테스트 순서에 구애받지 않아도 되며, 개발자가 사용자 아이디 예측샷을 할 필요도 없습니다.

<br/>

### 🤔 그럼 `@WithSecurityMockUser` 어노테이션은 안 쓰는 건가요?
- 해당 어노테이션을 통합 테스트에서 사용하는 건 제약이 있을 수 있지만, 여전히 유용한 것은 사실입니다.
- 요청자의 `userId`가 딱히 결과에 영향을 주지 않거나, 컨트롤러 유닛 테스트 시 `@AuthenticatePrincipal`이 매개변수에 있는 경우에 사용하면 좋습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 해결 방법이 이해가 되시나요? 안 되면 다시 설명해드리겠습니다!
- `@WithSecurityMockUser`를 지우지 않아도 되는 이유에 대해서 이해하셨을까요?
- 아...그리고 기존에 controller 패키지에 통합 테스트가 들어가있던 게 거슬려서, integration으로 옮겼어요. 그래서 LoC가 좀 길어보일 수도 있을 거 같아요...^^

<br/>

## 발견한 이슈
- 없음.
