### PR TITLE
📝 Spring Docs Swagger UI 수정 및 API 그룹 매핑

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/SwaggerConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/SwaggerConfig.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -40,6 +41,56 @@ public class SwaggerConfig {
                 .addServersItem(new io.swagger.v3.oas.models.servers.Server().url(""))
                 .addSecurityItem(securityRequirement)
                 .components(securitySchemes());
+    }
+
+    @Bean
+    public GroupedOpenApi allApi() {
+        String[] targets = {"kr.co.pennyway.api.apis"};
+
+        return GroupedOpenApi.builder()
+                .packagesToScan(targets)
+                .group("전체 보기")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi authApi() {
+        String[] targets = {"kr.co.pennyway.api.apis.auth"};
+
+        return GroupedOpenApi.builder()
+                .packagesToScan(targets)
+                .group("사용자 인증")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi userApi() {
+        String[] targets = {"kr.co.pennyway.api.apis.users"};
+
+        return GroupedOpenApi.builder()
+                .packagesToScan(targets)
+                .group("사용자 기본 기능")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi ledgerApi() {
+        String[] targets = {"kr.co.pennyway.api.apis.ledger"};
+
+        return GroupedOpenApi.builder()
+                .packagesToScan(targets)
+                .group("지출 관리")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi backOfficeApi() {
+        String[] targets = {"kr.co.pennyway.api.apis.question"};
+
+        return GroupedOpenApi.builder()
+                .packagesToScan(targets)
+                .group("백오피스")
+                .build();
     }
 
     @Bean


### PR DESCRIPTION
## 작업 이유
- Swagger 응답 예시가 "string"으로 뜨는 문제 수정
- Api 갯수가 늘어남에 따라 도메인 별로 분리하는 작업 수 

<br/>

## 작업 사항
### 도메인 별로 분리하기 위해 Swagger Config 설정

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/668f569b-fe17-49bb-a737-7fd4093786e8" width="600px"/>
</div>

- "전체 보기"를 포함하여 현재는 총 4가지로 분리했습니다.
- 아이러니하게도...전 분리만 했을 뿐인데 응답이 정상적으로 출력되기 시작함;

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 딱히 없음.

<br/>

## 발견한 이슈

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/5e478f1f-e585-420f-a273-8bec27e79658" width="400px"/>
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/e77495b3-faa6-437e-8934-2f68b274b95d" width="400px"/>
</div>

- 전체 보기에선 응답 예시 에러가 해결되지 않음.
- 개별 보기에선 해결됨.
- 이유를 모르겠으나..전체 보기는 말 그대로 api 파악용으로 만든 거라 딱히 상관 없다고 생각해서 별도로 수정하지 않을 예정. 