### PR TITLE
✨ 지출 내역 상세 조회 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
@@ -64,16 +64,6 @@ public interface SpendingApi {
     @Operation(summary = "지출 내역 상세 조회", method = "GET", description = "지출 내역의 ID값으로 해당 지출의 상세 내역을 반환합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "spending", schema = @Schema(implementation = SpendingSearchRes.Individual.class)))),
-            @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(examples = {
-                    @ExampleObject(name = "지출 상세 내역 권한 오류",
-                            value = """
-                                    {
-                                    "code" : "4030",
-                                    "message" : "접근할 수 없는 지출 내역입니다."
-                                    }
-                                    """
-                    )
-            })),
             @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(examples = {
                     @ExampleObject(name = "지출 내역 조회 오류",
                             value = """

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
@@ -17,6 +17,7 @@ import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -59,4 +60,30 @@ public interface SpendingApi {
     })
     @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "spendings", schema = @Schema(implementation = SpendingSearchRes.Month.class))))
     ResponseEntity<?> getSpendingListAtYearAndMonth(@RequestParam("year") int year, @RequestParam("date") int month, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "지출 내역 상세 조회", method = "GET", description = "지출 내역의 ID값으로 해당 지출의 상세 내역을 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "spending", schema = @Schema(implementation = SpendingSearchRes.Individual.class)))),
+            @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(examples = {
+                    @ExampleObject(name = "지출 상세 내역 권한 오류",
+                            value = """
+                                    {
+                                    "code" : "4030",
+                                    "message" : "접근할 수 없는 지출 내역입니다."
+                                    }
+                                    """
+                    )
+            })),
+            @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(examples = {
+                    @ExampleObject(name = "지출 내역 조회 오류",
+                            value = """
+                                    {
+                                    "code": "4040",
+                                    "message": "존재하지 않는 지출 내역입니다."
+                                    }
+                                    """
+                    )
+            }))
+    })
+    ResponseEntity<?> getSpendingDetail(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -43,7 +43,7 @@ public class SpendingController implements SpendingApi {
 
     @Override
     @GetMapping("/{spendingId}")
-    @PreAuthorize("isAuthenticated() and @spendingCategoryManager.hasPermission(#user.getUserId(), #spendingId)")
+    @PreAuthorize("isAuthenticated() and @spendingManager.hasPermission(#user.getUserId(), #spendingId)")
     public ResponseEntity<?> getSpendingDetail(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from("spending", spendingUseCase.getSpedingDetail(user.getUserId(), spendingId)));
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -41,6 +41,12 @@ public class SpendingController implements SpendingApi {
         return ResponseEntity.ok(SuccessResponse.from("spendings", spendingUseCase.getSpendingsAtYearAndMonth(user.getUserId(), year, month)));
     }
 
+    @GetMapping("/{spendingId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getSpendingDetail(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(SuccessResponse.from(spendingUseCase.getSpedingDetail(user.getUserId(), spendingId)));
+    }
+
     /**
      * categoryId가 -1이면 서비스에서 정의한 카테고리를 사용하므로 저장하려는 지출 내역의 icon은 OTHER가 될 수 없고, <br/>
      * categoryId가 -1이 아니면 사용자가 정의한 카테고리를 사용하므로 저장하려는 지출 내역의 icon은 OTHER임을 확인한다.

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -41,6 +41,7 @@ public class SpendingController implements SpendingApi {
         return ResponseEntity.ok(SuccessResponse.from("spendings", spendingUseCase.getSpendingsAtYearAndMonth(user.getUserId(), year, month)));
     }
 
+    @Override
     @GetMapping("/{spendingId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getSpendingDetail(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -43,7 +43,7 @@ public class SpendingController implements SpendingApi {
 
     @Override
     @GetMapping("/{spendingId}")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("isAuthenticated() and @spendingCategoryManager.hasPermission(#user.getUserId(), #spendingId)")
     public ResponseEntity<?> getSpendingDetail(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from("spending", spendingUseCase.getSpedingDetail(user.getUserId(), spendingId)));
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -45,7 +45,7 @@ public class SpendingController implements SpendingApi {
     @GetMapping("/{spendingId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getSpendingDetail(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user) {
-        return ResponseEntity.ok(SuccessResponse.from(spendingUseCase.getSpedingDetail(user.getUserId(), spendingId)));
+        return ResponseEntity.ok(SuccessResponse.from("spending", spendingUseCase.getSpedingDetail(user.getUserId(), spendingId)));
     }
 
     /**

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/SpendingSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/SpendingSearchService.java
@@ -4,8 +4,6 @@ import com.querydsl.core.types.Predicate;
 import kr.co.pennyway.domain.common.repository.QueryHandler;
 import kr.co.pennyway.domain.domains.spending.domain.QSpending;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
-import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
-import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
 import kr.co.pennyway.domain.domains.spending.service.SpendingService;
 import kr.co.pennyway.domain.domains.user.domain.QUser;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -40,16 +37,5 @@ public class SpendingSearchService {
         Sort sort = Sort.by(Sort.Order.desc("spendAt"));
 
         return spendingService.readSpendings(predicate, queryHandler, sort);
-    }
-
-    @Transactional(readOnly = true)
-    public Spending readSpending(Long spendingId) {
-        Optional<Spending> spending = spendingService.readSpending(spendingId);
-
-        if (!spending.isPresent()) {
-            throw new SpendingErrorException(SpendingErrorCode.NOT_FOUND_SPENDING);
-        }
-
-        return spending.get();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/SpendingSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/SpendingSearchService.java
@@ -4,6 +4,8 @@ import com.querydsl.core.types.Predicate;
 import kr.co.pennyway.domain.common.repository.QueryHandler;
 import kr.co.pennyway.domain.domains.spending.domain.QSpending;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
 import kr.co.pennyway.domain.domains.spending.service.SpendingService;
 import kr.co.pennyway.domain.domains.user.domain.QUser;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -37,5 +40,16 @@ public class SpendingSearchService {
         Sort sort = Sort.by(Sort.Order.desc("spendAt"));
 
         return spendingService.readSpendings(predicate, queryHandler, sort);
+    }
+
+    @Transactional(readOnly = true)
+    public Spending readSpending(Long spendingId) {
+        Optional<Spending> spending = spendingService.readSpending(spendingId);
+
+        if (!spending.isPresent()) {
+            throw new SpendingErrorException(SpendingErrorCode.NOT_FOUND_SPENDING);
+        }
+
+        return spending.get();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
@@ -7,8 +7,6 @@ import kr.co.pennyway.api.apis.ledger.service.SpendingSaveService;
 import kr.co.pennyway.api.apis.ledger.service.SpendingSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
-import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
-import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
@@ -48,10 +46,6 @@ public class SpendingUseCase {
     @Transactional(readOnly = true)
     public SpendingSearchRes.Individual getSpedingDetail(Long userId, Long spendingId) {
         Spending spending = spendingSearchService.readSpending(spendingId);
-
-        if (!(userId == spending.getUser().getId())) {
-            throw new SpendingErrorException(SpendingErrorCode.FORBIDDEN_SPENDING);
-        }
 
         return SpendingMapper.toSpendingSearchResIndividual(spending);
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
@@ -7,6 +7,8 @@ import kr.co.pennyway.api.apis.ledger.service.SpendingSaveService;
 import kr.co.pennyway.api.apis.ledger.service.SpendingSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
@@ -41,5 +43,16 @@ public class SpendingUseCase {
         List<Spending> spendings = spendingSearchService.readSpendings(userId, year, month);
 
         return SpendingMapper.toSpendingSearchResMonth(spendings, year, month);
+    }
+
+    @Transactional(readOnly = true)
+    public SpendingSearchRes.Individual getSpedingDetail(Long userId, Long spendingId) {
+        Spending spending = spendingSearchService.readSpending(spendingId);
+
+        if (!(userId == spending.getUser().getId())) {
+            throw new SpendingErrorException(SpendingErrorCode.FORBIDDEN_SPENDING);
+        }
+
+        return SpendingMapper.toSpendingSearchResIndividual(spending);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
@@ -7,6 +7,9 @@ import kr.co.pennyway.api.apis.ledger.service.SpendingSaveService;
 import kr.co.pennyway.api.apis.ledger.service.SpendingSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
+import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorException;
+import kr.co.pennyway.domain.domains.spending.service.SpendingService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
@@ -23,6 +26,7 @@ import java.util.List;
 public class SpendingUseCase {
     private final SpendingSaveService spendingSaveService;
     private final SpendingSearchService spendingSearchService;
+    private final SpendingService spendingService;
 
     private final UserService userService;
 
@@ -45,7 +49,8 @@ public class SpendingUseCase {
 
     @Transactional(readOnly = true)
     public SpendingSearchRes.Individual getSpedingDetail(Long userId, Long spendingId) {
-        Spending spending = spendingSearchService.readSpending(spendingId);
+        Spending spending = spendingService.readSpending(spendingId)
+                .orElseThrow(() -> new SpendingErrorException(SpendingErrorCode.NOT_FOUND_SPENDING));
 
         return SpendingMapper.toSpendingSearchResIndividual(spending);
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/SpendingManager.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/SpendingManager.java
@@ -19,7 +19,6 @@ public class SpendingManager {
      */
     @Transactional(readOnly = true)
     public boolean hasPermission(Long userId, Long spendingId) {
-        log.info("spending is Exists {}", spendingService.isExistsSpending(userId, spendingId));
         return spendingService.isExistsSpending(userId, spendingId);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/SpendingManager.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/SpendingManager.java
@@ -1,0 +1,26 @@
+package kr.co.pennyway.api.common.security.authorization;
+
+import kr.co.pennyway.domain.domains.spending.service.SpendingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component("spendingManager")
+@RequiredArgsConstructor
+public class SpendingManager {
+    private final SpendingService spendingService;
+
+    /**
+     * 사용자가 해당 상세 지출 내역에 대한 권한이 있는지 확인한다. <br>
+     *
+     * @return 권한이 있으면 true, 없으면 false
+     */
+    @Transactional(readOnly = true)
+    public boolean hasPermission(Long userId, Long spendingId) {
+
+        return spendingService.isExistsSpending(userId, spendingId);
+    }
+}
+

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/SpendingManager.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/SpendingManager.java
@@ -19,7 +19,7 @@ public class SpendingManager {
      */
     @Transactional(readOnly = true)
     public boolean hasPermission(Long userId, Long spendingId) {
-
+        log.info("spending is Exists {}", spendingService.isExistsSpending(userId, spendingId));
         return spendingService.isExistsSpending(userId, spendingId);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
@@ -14,9 +14,6 @@ public enum SpendingErrorCode implements BaseErrorCode {
     INVALID_ICON(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "OTHER 아이콘은 커스텀 카테고리의 icon으로 사용할 수 없습니다."),
     INVALID_ICON_WITH_CATEGORY_ID(StatusCode.BAD_REQUEST, ReasonCode.CLIENT_ERROR, "icon의 정보와 categoryId의 정보가 존재할 수 없는 조합입니다."),
 
-    /* 403 Forbidden */
-    FORBIDDEN_SPENDING(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "접근할 수 없는 지출 내역입니다."),
-
     /* 404 Not Found */
     NOT_FOUND_SPENDING(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "존재하지 않는 지출 내역입니다."),
     NOT_FOUND_CUSTOM_CATEGORY(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "존재하지 않는 커스텀 카테고리입니다.");

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
@@ -15,6 +15,7 @@ public enum SpendingErrorCode implements BaseErrorCode {
     INVALID_ICON_WITH_CATEGORY_ID(StatusCode.BAD_REQUEST, ReasonCode.CLIENT_ERROR, "icon의 정보와 categoryId의 정보가 존재할 수 없는 조합입니다."),
 
     /* 404 Not Found */
+    NOT_FOUND_SPENDING(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "존재하지 않는 지출 내역입니다."),
     NOT_FOUND_CUSTOM_CATEGORY(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "존재하지 않는 커스텀 카테고리입니다.");
 
     private final StatusCode statusCode;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/exception/SpendingErrorCode.java
@@ -14,9 +14,13 @@ public enum SpendingErrorCode implements BaseErrorCode {
     INVALID_ICON(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "OTHER 아이콘은 커스텀 카테고리의 icon으로 사용할 수 없습니다."),
     INVALID_ICON_WITH_CATEGORY_ID(StatusCode.BAD_REQUEST, ReasonCode.CLIENT_ERROR, "icon의 정보와 categoryId의 정보가 존재할 수 없는 조합입니다."),
 
+    /* 403 Forbidden */
+    FORBIDDEN_SPENDING(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "접근할 수 없는 지출 내역입니다."),
+
     /* 404 Not Found */
     NOT_FOUND_SPENDING(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "존재하지 않는 지출 내역입니다."),
     NOT_FOUND_CUSTOM_CATEGORY(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "존재하지 않는 커스텀 카테고리입니다.");
+
 
     private final StatusCode statusCode;
     private final ReasonCode reasonCode;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingRepository.java
@@ -2,6 +2,10 @@ package kr.co.pennyway.domain.domains.spending.repository;
 
 import kr.co.pennyway.domain.common.repository.ExtendedRepository;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface SpendingRepository extends ExtendedRepository<Spending, Long> {
+    @Transactional(readOnly = true)
+    boolean existsByIdAndUser_Id(Long id, Long userId);
+
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
@@ -33,4 +33,10 @@ public class SpendingService {
     public Optional<Spending> readSpending(Long spendingId) {
         return spendingRepository.findById(spendingId);
     }
+
+    @Transactional(readOnly = true)
+    public boolean isExistsSpending(Long userId, Long spendingId) {
+        return spendingRepository.existsByIdAndUser_Id(userId, spendingId);
+    }
+
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
@@ -36,7 +36,7 @@ public class SpendingService {
 
     @Transactional(readOnly = true)
     public boolean isExistsSpending(Long userId, Long spendingId) {
-        return spendingRepository.existsByIdAndUser_Id(userId, spendingId);
+        return spendingRepository.existsByIdAndUser_Id(spendingId, userId);
     }
 
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @DomainService
@@ -26,5 +27,10 @@ public class SpendingService {
     @Transactional(readOnly = true)
     public List<Spending> readSpendings(Predicate predicate, QueryHandler queryHandler, Sort sort) {
         return spendingRepository.findList(predicate, queryHandler, sort);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Spending> readSpending(Long spendingId) {
+        return spendingRepository.findById(spendingId);
     }
 }


### PR DESCRIPTION
## 작업 이유
- 사용자는 본인이 작성한 지출내역을 상세 조회 할 수있다.

<br/>

## 작업 사항
> 간단한 동작이어서 테스트케이스를 아직 작성하지 않았습니다. 다만, 조회를 시도하는 사용자의 ID가 지출 내역의 작성자 ID와 일치하지 않을 때에 대한 통합 test 를 작성해야할지 고민중에 있습니다.

test 케이스를 작성하지 않은 대신에, 로컬환경에서 정상적인 조회 및 예외처리가 발생함을 확인하였습니다.

### API Spec
- url : `GET /v2/{지출내역 ID}`
- pre-condition : 사용자는 로그인 한 상태이고, 조회하고자 하는 지출 내역의 작성자 여야 한다.

결과 응답
```json
{
    "code": "2000",
    "data": {
        "id": 1,
        "amount": 10000,
        "category": {
            "isCustom": false,
            "id": -1,
            "name": "식비",
            "icon": "FOOD"
        },
        "spendAt": "2021-08-01 00:00:00",
        "accountName": "카페인 수혈",
        "memo": "아메리카노 1잔"
    }
}
```
응답은 기존에 작성되어있는 `SpendingSearchRes.Individual`을 사용하였습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- **"`SecurityUserDetails` 유저와 지출 상세내역 작성자가 같은지?"** 를 검사하는 로직이 `UseCase`단에 위치하는게 옳은가? 에 대해서 고민했던 것 같은데. 이 부분에 대해서 어떻게 생각하시는지 궁금합니다.

<br/>

## 발견한 이슈
X

