### PR TITLE
✨ 당월 목표 금액 삭제 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/TargetAmountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/TargetAmountApi.java
@@ -1,6 +1,8 @@
 package kr.co.pennyway.api.apis.ledger.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -27,6 +29,7 @@ public interface TargetAmountApi {
     ResponseEntity<?> putTargetAmount(TargetAmountDto.UpdateParamReq request, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "당월 목표 금액 삭제", method = "DELETE")
+    @Parameter(name = "date", description = "삭제하려는 목표 금액 날짜 (yyyy-MM-dd)", required = true, example = "2024-05-08", in = ParameterIn.PATH)
     @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
             @ExampleObject(name = "목표 금액 삭제 실패", value = """
                     {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/TargetAmountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/TargetAmountApi.java
@@ -9,6 +9,9 @@ import kr.co.pennyway.api.apis.ledger.dto.TargetAmountDto;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.time.LocalDate;
 
 @Tag(name = "목표금액 API")
 public interface TargetAmountApi {
@@ -22,4 +25,21 @@ public interface TargetAmountApi {
                     """)
     }))
     ResponseEntity<?> putTargetAmount(TargetAmountDto.UpdateParamReq request, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "당월 목표 금액 삭제", method = "DELETE")
+    @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "목표 금액 삭제 실패", value = """
+                    {
+                        "code": "4004",
+                        "message": "당월 목표 금액에 대한 요청이 아닙니다."
+                    }
+                    """),
+            @ExampleObject(name = "목표 금액 조회 실패", description = "목표 금액 데이터가 없거나, 이미 삭제(amount=-1)인 경우", value = """
+                    {
+                        "code": "4040",
+                        "message": "해당 월의 목표 금액이 존재하지 않습니다."
+                    }
+                    """)
+    }))
+    ResponseEntity<?> deleteTargetAmount(@PathVariable LocalDate date, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/TargetAmountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/TargetAmountApi.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.ledger.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.*;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -42,7 +43,7 @@ public interface TargetAmountApi {
     @ApiResponse(responseCode = "200", description = "목표 금액 및 총 사용 금액 리스트 조회 성공", content = @Content(
             schemaProperties = @SchemaProperty(name = "targetAmounts", array = @ArraySchema(schema = @Schema(implementation = TargetAmountDto.WithTotalSpendingRes.class)))))
     ResponseEntity<?> getTargetAmountsAndTotalSpendings(@Validated TargetAmountDto.GetParamReq param, @AuthenticationPrincipal SecurityUserDetails user);
-      
+
     @Operation(summary = "당월 목표 금액 삭제", method = "DELETE")
     @Parameter(name = "date", description = "삭제하려는 목표 금액 날짜 (yyyy-MM-dd)", required = true, example = "2024-05-08", in = ParameterIn.PATH)
     @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/TargetAmountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/TargetAmountController.java
@@ -36,6 +36,7 @@ public class TargetAmountController implements TargetAmountApi {
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 
+    @Override
     @DeleteMapping("/{date}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> deleteTargetAmount(@PathVariable LocalDate date, @AuthenticationPrincipal SecurityUserDetails user) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/TargetAmountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/TargetAmountController.java
@@ -13,9 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 
@@ -35,6 +33,17 @@ public class TargetAmountController implements TargetAmountApi {
         }
 
         targetAmountUseCase.updateTargetAmount(user.getUserId(), request.date(), request.amount());
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+
+    @DeleteMapping("/{date}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> deleteTargetAmount(@PathVariable LocalDate date, @AuthenticationPrincipal SecurityUserDetails user) {
+        if (!isValidDateForYearAndMonth(date)) {
+            throw new TargetAmountErrorException(TargetAmountErrorCode.INVALID_TARGET_AMOUNT_DATE);
+        }
+
+        targetAmountUseCase.deleteTargetAmount(user.getUserId(), date);
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
@@ -28,11 +28,8 @@ public class TargetAmountUseCase {
     @Transactional
     public void deleteTargetAmount(Long userId, LocalDate date) {
         TargetAmount targetAmount = targetAmountService.readTargetAmountThatMonth(userId, date)
+                .filter(target -> !target.isAllocatedAmount())
                 .orElseThrow(() -> new TargetAmountErrorException(TargetAmountErrorCode.NOT_FOUND_TARGET_AMOUNT));
-
-        if (!targetAmount.isAllocatedAmount()) {
-            throw new TargetAmountErrorException(TargetAmountErrorCode.NOT_FOUND_TARGET_AMOUNT);
-        }
 
         targetAmountService.deleteTargetAmount(targetAmount);
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
@@ -28,7 +28,7 @@ public class TargetAmountUseCase {
     @Transactional
     public void deleteTargetAmount(Long userId, LocalDate date) {
         TargetAmount targetAmount = targetAmountService.readTargetAmountThatMonth(userId, date)
-                .filter(target -> !target.isAllocatedAmount())
+                .filter(TargetAmount::isAllocatedAmount)
                 .orElseThrow(() -> new TargetAmountErrorException(TargetAmountErrorCode.NOT_FOUND_TARGET_AMOUNT));
 
         targetAmountService.deleteTargetAmount(targetAmount);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
@@ -2,6 +2,10 @@ package kr.co.pennyway.api.apis.ledger.usecase;
 
 import kr.co.pennyway.api.apis.ledger.service.TargetAmountSaveService;
 import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.domains.target.domain.TargetAmount;
+import kr.co.pennyway.domain.domains.target.exception.TargetAmountErrorCode;
+import kr.co.pennyway.domain.domains.target.exception.TargetAmountErrorException;
+import kr.co.pennyway.domain.domains.target.service.TargetAmountService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,10 +16,24 @@ import java.time.LocalDate;
 @UseCase
 @RequiredArgsConstructor
 public class TargetAmountUseCase {
+    private final TargetAmountService targetAmountService;
+
     private final TargetAmountSaveService targetAmountSaveService;
 
     @Transactional
     public void updateTargetAmount(Long userId, LocalDate date, Integer amount) {
         targetAmountSaveService.saveTargetAmount(userId, date, amount);
+    }
+
+    @Transactional
+    public void deleteTargetAmount(Long userId, LocalDate date) {
+        TargetAmount targetAmount = targetAmountService.readTargetAmountThatMonth(userId, date)
+                .orElseThrow(() -> new TargetAmountErrorException(TargetAmountErrorCode.NOT_FOUND_TARGET_AMOUNT));
+
+        if (!targetAmount.isAllocatedAmount()) {
+            throw new TargetAmountErrorException(TargetAmountErrorCode.NOT_FOUND_TARGET_AMOUNT);
+        }
+
+        targetAmountService.deleteTargetAmount(targetAmount);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/exception/TargetAmountErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/exception/TargetAmountErrorCode.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 public enum TargetAmountErrorCode implements BaseErrorCode {
     /* 400 BAD_REQUEST */
     INVALID_TARGET_AMOUNT_DATE(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "당월 목표 금액에 대한 요청이 아닙니다."),
-    ;
+
+    /* 404 NOT_FOUND */
+    NOT_FOUND_TARGET_AMOUNT(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "해당 달의 목표 금액이 존재하지 않습니다.");
 
     private final StatusCode statusCode;
     private final ReasonCode reasonCode;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/exception/TargetAmountErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/exception/TargetAmountErrorCode.java
@@ -12,7 +12,7 @@ public enum TargetAmountErrorCode implements BaseErrorCode {
     INVALID_TARGET_AMOUNT_DATE(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "당월 목표 금액에 대한 요청이 아닙니다."),
 
     /* 404 NOT_FOUND */
-    NOT_FOUND_TARGET_AMOUNT(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "해당 달의 목표 금액이 존재하지 않습니다.");
+    NOT_FOUND_TARGET_AMOUNT(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "해당 월의 목표 금액이 존재하지 않습니다.");
 
     private final StatusCode statusCode;
     private final ReasonCode reasonCode;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/service/TargetAmountService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/service/TargetAmountService.java
@@ -25,4 +25,9 @@ public class TargetAmountService {
     public Optional<TargetAmount> readTargetAmountThatMonth(Long userId, LocalDate date) {
         return targetAmountRepository.findByUserIdThatMonth(userId, date);
     }
+
+    @Transactional
+    public void deleteTargetAmount(TargetAmount targetAmount) {
+        targetAmountRepository.delete(targetAmount);
+    }
 }


### PR DESCRIPTION
## 작업 이유
- 사용자는 당월 목표 금액을 삭제할 수 있다.

<br/>

## 작업 사항
> 규칙만 알면 너무 간단한 API라, 따로 테케는 작성하지 않았습니다.
### ✅ Target의 데이터 관리
- 사용자가 장기 미접속자인 경우, 기간 내의 데이터가 존재하지 않음.
- 사용자가 접속은 했으나 당월 목표 금액을 등록하지 않거나, 삭제한 상태 → 레코드를 추가하고 `amount = -1`로 저장

이거 이해하면 끝남.

<br/>

### 📝 API Spec
- url : `DELETE /v2/targets/{date}`
- path parma
   - `date` : 시스템 상의 시간과 "년도"와 "월"이 일치해야 함.
- error
   - 당월 요청이 아닌 경우 : 400
   - 당월에 등록한 데이터가 없는 경우 : 404
   - 등록은 했으나 이미 삭제(amount==-1)된 경우 : 404

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 사용자한테 pk를 넘겨주고 있지 않다보니, 경로로 date를 받고 있긴 한데 괜찮은 방법일지?
   - query로 받으면 `/v2/targets?date=`가 돼서 전체 조회 같이 보일 것 같음.

<br/>

## 발견한 이슈
- 없음.

