### PR TITLE
🐛 지출 내역 조회 응답 및 스웨거 버그 픽스

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
@@ -55,13 +55,14 @@ public interface SpendingApi {
 
     @Operation(summary = "지출 내역 조회", method = "GET", description = "사용자의 해당 년/월 지출 내역을 조회하고 월/일별 지출 총합을 반환합니다.")
     @Parameters({
-            @Parameter(name = "year", description = "년도", required = true, in = ParameterIn.HEADER),
-            @Parameter(name = "month", description = "월", required = true, in = ParameterIn.HEADER)
+            @Parameter(name = "year", description = "년도", example = "2024", required = true, in = ParameterIn.QUERY),
+            @Parameter(name = "month", description = "월", example = "5", required = true, in = ParameterIn.QUERY)
     })
     @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "spendings", schema = @Schema(implementation = SpendingSearchRes.Month.class))))
     ResponseEntity<?> getSpendingListAtYearAndMonth(@RequestParam("year") int year, @RequestParam("date") int month, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "지출 내역 상세 조회", method = "GET", description = "지출 내역의 ID값으로 해당 지출의 상세 내역을 반환합니다.")
+    @Parameter(name = "spendingId", description = "지출 내역 ID", example = "1", required = true, in = ParameterIn.PATH)
     @ApiResponses({
             @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "spending", schema = @Schema(implementation = SpendingSearchRes.Individual.class)))),
             @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(examples = {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
@@ -58,7 +58,7 @@ public interface SpendingApi {
             @Parameter(name = "year", description = "년도", example = "2024", required = true, in = ParameterIn.QUERY),
             @Parameter(name = "month", description = "월", example = "5", required = true, in = ParameterIn.QUERY)
     })
-    @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "spendings", schema = @Schema(implementation = SpendingSearchRes.Month.class))))
+    @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "spending", schema = @Schema(implementation = SpendingSearchRes.Month.class))))
     ResponseEntity<?> getSpendingListAtYearAndMonth(@RequestParam("year") int year, @RequestParam("date") int month, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "지출 내역 상세 조회", method = "GET", description = "지출 내역의 ID값으로 해당 지출의 상세 내역을 반환합니다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -38,7 +38,7 @@ public class SpendingController implements SpendingApi {
     @GetMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getSpendingListAtYearAndMonth(@RequestParam("year") int year, @RequestParam("month") int month, @AuthenticationPrincipal SecurityUserDetails user) {
-        return ResponseEntity.ok(SuccessResponse.from("spendings", spendingUseCase.getSpendingsAtYearAndMonth(user.getUserId(), year, month)));
+        return ResponseEntity.ok(SuccessResponse.from("spending", spendingUseCase.getSpendingsAtYearAndMonth(user.getUserId(), year, month)));
     }
 
     @Override

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
@@ -20,8 +20,6 @@ public class SpendingSearchRes {
             int year,
             @Schema(description = "월", example = "5")
             int month,
-            @Schema(description = "월별 총 지출 금액", example = "100000")
-            int monthlyTotalAmount,
             @Schema(description = "일별 지출 내역")
             List<Daily> dailySpendings
     ) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
@@ -20,7 +20,6 @@ public class SpendingMapper {
         return SpendingSearchRes.Month.builder()
                 .year(year)
                 .month(month)
-                .monthlyTotalAmount(calculateMonthlyTotalAmount(groupSpendingsByDay))
                 .dailySpendings(dailySpendings)
                 .build();
     }
@@ -46,13 +45,6 @@ public class SpendingMapper {
                 .accountName(spending.getAccountName())
                 .memo(spending.getMemo())
                 .build();
-    }
-
-    /**
-     * 월별 지출 내역의 총 금액을 계산하는 메서드
-     */
-    private static int calculateMonthlyTotalAmount(ConcurrentMap<Integer, List<Spending>> spendings) {
-        return spendings.values().stream().flatMap(List::stream).mapToInt(Spending::getAmount).sum();
     }
 
     /**


### PR DESCRIPTION
## 작업 이유
- 지출 내역 조회 시, Swagger에서 param을 query가 아닌 header로 받는 오류
- `monthlySpendingAmount` 필드 제거

<br/>

## 작업 사항
![image](https://github.com/CollaBu/pennyway-was/assets/96044622/585f359b-6651-4621-82d1-d8e7ec24b5c8)

- header로 값을 받던 부분을 query로 수정

<br/>

![image](https://github.com/CollaBu/pennyway-was/assets/96044622/f259b6ef-0b09-4dcb-8656-25921b2e0dc6)

- key를 `spendings`에서 `spending`으로 수정
- 지출 목록 조회 시, 월별 총 소비 금액 계산 로직 제거.
- 이 부분은 목표 금액 조회할 때 어차피 조회가 가능하며, 목표 금액과 월별 총 소비 금액은 언제나 함께 요청이 되기 때문에 그쪽 api로 묶음.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 해당 요청에서 월별 총합을 계산하는 로직을 제거하기로 한 것에 대해서 사전에 이야기를 하긴 했으나, 혹시나 지금이라도 포함되는 게 맞다고 생각하신다면 말씀해주세요!

<br/>

## 발견한 이슈
- 없음

