### PR TITLE
✨ 사용자 로그인 로그를 위한 Interceptor 및 환경 구축 

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.auth.helper;
 
 import kr.co.pennyway.api.common.annotation.AccessTokenStrategy;
 import kr.co.pennyway.api.common.annotation.RefreshTokenStrategy;
+import kr.co.pennyway.api.common.security.jwt.JwtClaimsParserUtil;
 import kr.co.pennyway.api.common.security.jwt.Jwts;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
 import kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaim;
@@ -20,7 +21,6 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.function.Function;
 
 @Slf4j
 @Helper
@@ -43,34 +43,6 @@ public class JwtAuthHelper {
     }
 
     /**
-     * JwtClaims에서 key에 해당하는 값을 반환하는 메서드
-     *
-     * @return key에 해당하는 값이 없거나, 타입이 일치하지 않을 경우 null을 반환한다.
-     */
-    @SuppressWarnings("unchecked")
-    public <T> T getClaimsValue(JwtClaims claims, String key, Class<T> type) {
-        Object value = claims.getClaims().get(key);
-        if (value != null && type.isAssignableFrom(value.getClass())) {
-            return (T) value;
-        }
-        return null;
-    }
-
-    /**
-     * JwtClaims에서 valueConverter를 이용하여 key에 해당하는 값을 반환하는 메서드
-     *
-     * @param valueConverter : String 타입의 값을 T 타입으로 변환하는 함수
-     * @return key에 해당하는 값이 없을 경우 null을 반환한다.
-     */
-    public <T> T getClaimsValue(JwtClaims claims, String key, Function<String, T> valueConverter) {
-        Object value = claims.getClaims().get(key);
-        if (value != null) {
-            return valueConverter.apply((String) value);
-        }
-        return null;
-    }
-
-    /**
      * 사용자 정보 기반으로 access token과 refresh token을 생성하는 메서드 <br/>
      * refresh token은 redis에 저장된다.
      *
@@ -88,8 +60,8 @@ public class JwtAuthHelper {
     public Pair<Long, Jwts> refresh(String refreshToken) {
         JwtClaims claims = refreshTokenProvider.getJwtClaimsFromToken(refreshToken);
 
-        Long userId = getClaimsValue(claims, RefreshTokenClaimKeys.USER_ID.getValue(), Long::parseLong);
-        String role = getClaimsValue(claims, RefreshTokenClaimKeys.ROLE.getValue(), String.class);
+        Long userId = JwtClaimsParserUtil.getClaimsValue(claims, RefreshTokenClaimKeys.USER_ID.getValue(), Long::parseLong);
+        String role = JwtClaimsParserUtil.getClaimsValue(claims, RefreshTokenClaimKeys.ROLE.getValue(), String.class);
         log.debug("refresh token userId : {}, role : {}", userId, role);
 
         RefreshToken newRefreshToken;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -6,6 +6,7 @@ import kr.co.pennyway.api.apis.auth.dto.UserSyncDto;
 import kr.co.pennyway.api.apis.auth.helper.JwtAuthHelper;
 import kr.co.pennyway.api.apis.auth.helper.OauthOidcHelper;
 import kr.co.pennyway.api.apis.auth.service.UserOauthSignService;
+import kr.co.pennyway.api.common.security.jwt.JwtClaimsParserUtil;
 import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
@@ -33,7 +34,7 @@ public class UserAuthUseCase {
     public AuthStateDto isSignIn(String authHeader) {
         String accessToken = accessTokenProvider.resolveToken(authHeader);
         JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
-        Long userId = jwtAuthHelper.getClaimsValue(claims, AccessTokenClaimKeys.USER_ID.getValue(), Long::parseLong);
+        Long userId = JwtClaimsParserUtil.getClaimsValue(claims, AccessTokenClaimKeys.USER_ID.getValue(), Long::parseLong);
 
         log.info("auth_id {} 사용자는 로그인 중입니다.", userId);
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/interceptor/SignEventLogInterceptor.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/interceptor/SignEventLogInterceptor.java
@@ -1,0 +1,115 @@
+package kr.co.pennyway.api.common.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.co.pennyway.api.common.security.jwt.JwtClaimsParserUtil;
+import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaimKeys;
+import kr.co.pennyway.domain.common.redis.sign.SignEventLog;
+import kr.co.pennyway.domain.common.redis.sign.SignEventLogService;
+import kr.co.pennyway.domain.domains.sign.type.IpAddressHeader;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.http.HttpHeaders;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
+
+@Slf4j
+public class SignEventLogInterceptor implements HandlerInterceptor {
+    /**
+     * <p>
+     * User-Agent에서 앱 버전을 추출하기 위한 정규식 패턴이다.
+     * User-Agent는 "AppName/Version (platform; os; deviceModel)" 형식으로 되어있는 문자열이다.
+     * </p>
+     */
+    private static final Pattern pattern = Pattern.compile("^(\\w+)/(\\d+\\.\\d+) \\((\\w+); (\\w+ \\d+\\.\\d+); (\\w+\\d+,\\d+)\\)$");
+    private final SignEventLogService signEventLogService;
+    private final JwtProvider accessTokenProvider;
+
+    public SignEventLogInterceptor(SignEventLogService signEventLogService, JwtProvider accessTokenProvider) {
+        this.signEventLogService = signEventLogService;
+        this.accessTokenProvider = accessTokenProvider;
+    }
+
+    @Override
+    public void postHandle(@NonNull HttpServletRequest request, HttpServletResponse response, @NonNull Object handler, ModelAndView modelAndView) {
+        if (response.getStatus() != 200) {
+            return;
+        }
+
+        String accessToken = response.getHeader(HttpHeaders.AUTHORIZATION);
+        Long userId = JwtClaimsParserUtil.getClaimsValue(accessTokenProvider.getJwtClaimsFromToken(accessToken), AccessTokenClaimKeys.USER_ID.getValue(), Long::parseLong);
+
+        UserAgentInfo userAgent = getUserAgentInfo(request.getHeader(HttpHeaders.USER_AGENT));
+        Pair<IpAddressHeader, String> ipAddress = getClientIP(request);
+
+        SignEventLog signEventLog = SignEventLog.builder()
+                .userId(userId)
+                .ipAddressHeader(ipAddress.getKey().getType())
+                .ipAddress(ipAddress.getValue())
+                .appVersion(userAgent.appVersion())
+                .deviceModel(userAgent.deviceModel())
+                .os(userAgent.os())
+                .signedAt(LocalDateTime.now())
+                .build();
+        log.debug("SignEventLog: {}", signEventLog);
+
+        signEventLogService.create(signEventLog);
+    }
+
+    private Pair<IpAddressHeader, String> getClientIP(HttpServletRequest request) {
+        IpAddressHeader headerType = IpAddressHeader.X_FORWARDED_FOR;
+        String ip = request.getHeader(headerType.getType());
+
+        if (ip == null) {
+            headerType = IpAddressHeader.PROXY_CLIENT_IP;
+            ip = request.getHeader(headerType.getType());
+        }
+        if (ip == null) {
+            headerType = IpAddressHeader.WL_PROXY_CLIENT_IP;
+            ip = request.getHeader(headerType.getType());
+        }
+        if (ip == null) {
+            headerType = IpAddressHeader.HTTP_CLIENT_IP;
+            ip = request.getHeader(headerType.getType());
+        }
+        if (ip == null) {
+            headerType = IpAddressHeader.HTTP_X_FORWARDED_FOR;
+            ip = request.getHeader(headerType.getType());
+        }
+        if (ip == null) {
+            headerType = IpAddressHeader.REMOTE_ADDR;
+            ip = request.getRemoteAddr();
+        }
+
+        return Pair.of(headerType, ip);
+    }
+
+    private UserAgentInfo getUserAgentInfo(String userAgent) {
+        var matcher = pattern.matcher(userAgent);
+        if (!matcher.matches()) {
+            return new UserAgentInfo("", "", "", "", "");
+        }
+
+        return new UserAgentInfo(
+                matcher.group(1),
+                matcher.group(2),
+                matcher.group(3),
+                matcher.group(5),
+                matcher.group(4)
+        );
+    }
+
+    private record UserAgentInfo(
+            String appName,
+            String appVersion,
+            String platform,
+            String deviceModel,
+            String os
+    ) {
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/interceptor/SignEventLogInterceptor.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/interceptor/SignEventLogInterceptor.java
@@ -37,7 +37,7 @@ public class SignEventLogInterceptor implements HandlerInterceptor {
 
     @Override
     public void postHandle(@NonNull HttpServletRequest request, HttpServletResponse response, @NonNull Object handler, ModelAndView modelAndView) {
-        if (response.getStatus() != 200) {
+        if (response.getStatus() != 200 || response.getHeader(HttpHeaders.AUTHORIZATION) == null) {
             return;
         }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/interceptor/SignEventLogInterceptor.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/interceptor/SignEventLogInterceptor.java
@@ -111,5 +111,15 @@ public class SignEventLogInterceptor implements HandlerInterceptor {
             String deviceModel,
             String os
     ) {
+        @Override
+        public String toString() {
+            return "UserAgentInfo{" +
+                    "appName='" + appName + '\'' +
+                    ", appVersion='" + appVersion + '\'' +
+                    ", platform='" + platform + '\'' +
+                    ", deviceModel='" + deviceModel + '\'' +
+                    ", os='" + os + '\'' +
+                    '}';
+        }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/JwtClaimsParserUtil.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/JwtClaimsParserUtil.java
@@ -1,0 +1,35 @@
+package kr.co.pennyway.api.common.security.jwt;
+
+import kr.co.pennyway.infra.common.jwt.JwtClaims;
+
+import java.util.function.Function;
+
+public class JwtClaimsParserUtil {
+    /**
+     * JwtClaims에서 key에 해당하는 값을 반환하는 메서드
+     *
+     * @return key에 해당하는 값이 없거나, 타입이 일치하지 않을 경우 null을 반환한다.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T getClaimsValue(JwtClaims claims, String key, Class<T> type) {
+        Object value = claims.getClaims().get(key);
+        if (value != null && type.isAssignableFrom(value.getClass())) {
+            return (T) value;
+        }
+        return null;
+    }
+
+    /**
+     * JwtClaims에서 valueConverter를 이용하여 key에 해당하는 값을 반환하는 메서드
+     *
+     * @param valueConverter : String 타입의 값을 T 타입으로 변환하는 함수
+     * @return key에 해당하는 값이 없을 경우 null을 반환한다.
+     */
+    public static <T> T getClaimsValue(JwtClaims claims, String key, Function<String, T> valueConverter) {
+        Object value = claims.getClaims().get(key);
+        if (value != null) {
+            return valueConverter.apply((String) value);
+        }
+        return null;
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/WebConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/WebConfig.java
@@ -3,7 +3,9 @@ package kr.co.pennyway.api.config;
 import kr.co.pennyway.api.common.converter.NotifyTypeConverter;
 import kr.co.pennyway.api.common.converter.ProviderConverter;
 import kr.co.pennyway.api.common.converter.VerificationTypeConverter;
+import kr.co.pennyway.api.common.interceptor.SignEventLogInterceptor;
 import kr.co.pennyway.domain.common.redis.sign.SignEventLogService;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
@@ -14,6 +16,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
     private final SignEventLogService signEventLogService;
+    private final JwtProvider accessTokenProvider;
 
     @Override
     public void addFormatters(FormatterRegistry registrar) {
@@ -25,7 +28,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new SignEventLogInterceptor(signEventLogService))
+        registry.addInterceptor(new SignEventLogInterceptor(signEventLogService, accessTokenProvider))
                 .addPathPatterns("/v1/auth/sign-in", "/v1/auth/oauth/sign-up", "/v1/auth/refresh");
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/WebConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/WebConfig.java
@@ -3,17 +3,29 @@ package kr.co.pennyway.api.config;
 import kr.co.pennyway.api.common.converter.NotifyTypeConverter;
 import kr.co.pennyway.api.common.converter.ProviderConverter;
 import kr.co.pennyway.api.common.converter.VerificationTypeConverter;
+import kr.co.pennyway.domain.common.redis.sign.SignEventLogService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+    private final SignEventLogService signEventLogService;
+
     @Override
     public void addFormatters(FormatterRegistry registrar) {
 
         registrar.addConverter(new ProviderConverter());
         registrar.addConverter(new VerificationTypeConverter());
         registrar.addConverter(new NotifyTypeConverter());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new SignEventLogInterceptor(signEventLogService))
+                .addPathPatterns("/v1/auth/sign-in", "/v1/auth/oauth/sign-up", "/v1/auth/refresh");
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthCheckControllerTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthCheckControllerTest.java
@@ -1,106 +1,110 @@
 package kr.co.pennyway.api.apis.auth.controller;
 
-import static kr.co.pennyway.common.exception.ReasonCode.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.auth.dto.AuthFindDto;
+import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
+import kr.co.pennyway.api.apis.auth.usecase.AuthCheckUseCase;
+import kr.co.pennyway.api.config.WebConfig;
+import kr.co.pennyway.common.exception.StatusCode;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static kr.co.pennyway.common.exception.ReasonCode.REQUIRED_PARAMETERS_MISSING_IN_REQUEST_BODY;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import kr.co.pennyway.api.apis.auth.dto.AuthFindDto;
-import kr.co.pennyway.api.apis.auth.dto.PhoneVerificationDto;
-import kr.co.pennyway.api.apis.auth.usecase.AuthCheckUseCase;
-import kr.co.pennyway.common.exception.StatusCode;
-import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
-import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
-
-@WebMvcTest(controllers = {AuthCheckController.class})
+@WebMvcTest(controllers = {AuthCheckController.class}, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
 @ActiveProfiles("local")
 class AuthCheckControllerTest {
-	private final String inputPhone = "010-1234-5678";
-	private final String expectedUsername = "pennyway";
-	private final String code = "123456";
+    private final String inputPhone = "010-1234-5678";
+    private final String expectedUsername = "pennyway";
+    private final String code = "123456";
 
-	@Autowired
-	private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
-	@Autowired
-	private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
-	@MockBean
-	private AuthCheckUseCase authCheckUseCase;
+    @MockBean
+    private AuthCheckUseCase authCheckUseCase;
 
-	@BeforeEach
-	void setUp(WebApplicationContext webApplicationContext) {
-		this.mockMvc = MockMvcBuilders
-				.webAppContextSetup(webApplicationContext)
-				.defaultRequest(post("/**").with(csrf()))
-				.build();
-	}
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .defaultRequest(post("/**").with(csrf()))
+                .build();
+    }
 
-	@Test
-	@DisplayName("일반 회원의 휴대폰 번호로 아이디를 찾을 때 200 응답을 반환한다.")
-	void findUsername() throws Exception {
-		// given
-		given(authCheckUseCase.findUsername(new PhoneVerificationDto.VerifyCodeReq(inputPhone, code))).willReturn(
-				new AuthFindDto.FindUsernameRes(expectedUsername));
+    @Test
+    @DisplayName("일반 회원의 휴대폰 번호로 아이디를 찾을 때 200 응답을 반환한다.")
+    void findUsername() throws Exception {
+        // given
+        given(authCheckUseCase.findUsername(new PhoneVerificationDto.VerifyCodeReq(inputPhone, code))).willReturn(
+                new AuthFindDto.FindUsernameRes(expectedUsername));
 
-		// when
-		ResultActions resultActions = findUsernameRequest(inputPhone, code);
+        // when
+        ResultActions resultActions = findUsernameRequest(inputPhone, code);
 
-		// then
-		resultActions
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.data.user.username").value(expectedUsername));
-	}
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.user.username").value(expectedUsername));
+    }
 
-	@Test
-	@DisplayName("일반 회원이 아닌 휴대폰 번호로 아이디를 찾을 때 404 응답을 반환한다.")
-	void findUsernameIfUserNotFound() throws Exception {
-		// given
-		String phone = "010-1111-1111";
-		given(authCheckUseCase.findUsername(new PhoneVerificationDto.VerifyCodeReq(phone, code))).willThrow(new UserErrorException(UserErrorCode.NOT_FOUND));
+    @Test
+    @DisplayName("일반 회원이 아닌 휴대폰 번호로 아이디를 찾을 때 404 응답을 반환한다.")
+    void findUsernameIfUserNotFound() throws Exception {
+        // given
+        String phone = "010-1111-1111";
+        given(authCheckUseCase.findUsername(new PhoneVerificationDto.VerifyCodeReq(phone, code))).willThrow(new UserErrorException(UserErrorCode.NOT_FOUND));
 
-		// when
-		ResultActions resultActions = findUsernameRequest(phone, code);
+        // when
+        ResultActions resultActions = findUsernameRequest(phone, code);
 
-		// then
-		resultActions
-				.andExpect(status().isNotFound())
-				.andExpect(jsonPath("$.code").value(UserErrorCode.NOT_FOUND.causedBy().getCode()))
-				.andExpect(jsonPath("$.message").value(UserErrorCode.NOT_FOUND.getExplainError()));
-	}
+        // then
+        resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(UserErrorCode.NOT_FOUND.causedBy().getCode()))
+                .andExpect(jsonPath("$.message").value(UserErrorCode.NOT_FOUND.getExplainError()));
+    }
 
-	@Test
-	@DisplayName("휴대폰 번호와 코드를 입력하지 않았을 때 422 응답을 반환한다.")
-	void findUsernameIfInputIsEmpty() throws Exception {
-		// when
-		ResultActions resultActions = findUsernameRequest("", "");
+    @Test
+    @DisplayName("휴대폰 번호와 코드를 입력하지 않았을 때 422 응답을 반환한다.")
+    void findUsernameIfInputIsEmpty() throws Exception {
+        // when
+        ResultActions resultActions = findUsernameRequest("", "");
 
-		// then
-		resultActions
-				.andExpect(status().is4xxClientError())
-				.andExpect(jsonPath("$.code").value(
-						String.valueOf(StatusCode.UNPROCESSABLE_CONTENT.getCode() * 10 + REQUIRED_PARAMETERS_MISSING_IN_REQUEST_BODY.getCode())))
-				.andExpect(jsonPath("$.message").value(StatusCode.UNPROCESSABLE_CONTENT.name()));
-	}
+        // then
+        resultActions
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.code").value(
+                        String.valueOf(StatusCode.UNPROCESSABLE_CONTENT.getCode() * 10 + REQUIRED_PARAMETERS_MISSING_IN_REQUEST_BODY.getCode())))
+                .andExpect(jsonPath("$.message").value(StatusCode.UNPROCESSABLE_CONTENT.name()));
+    }
 
-	private ResultActions findUsernameRequest(String phone, String code) throws Exception {
-		return mockMvc.perform(get("/v1/find/username")
-				.param("phone", phone)
-				.param("code", code));
-	}
+    private ResultActions findUsernameRequest(String phone, String code) throws Exception {
+        return mockMvc.perform(get("/v1/find/username")
+                .param("phone", phone)
+                .param("code", code));
+    }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthControllerValidationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthControllerValidationTest.java
@@ -5,6 +5,7 @@ import kr.co.pennyway.api.apis.auth.dto.SignUpReq;
 import kr.co.pennyway.api.apis.auth.usecase.AuthUseCase;
 import kr.co.pennyway.api.common.security.jwt.Jwts;
 import kr.co.pennyway.api.common.util.CookieUtil;
+import kr.co.pennyway.api.config.WebConfig;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.test.context.ActiveProfiles;
@@ -28,7 +31,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(controllers = {AuthController.class})
+@WebMvcTest(controllers = {AuthController.class}, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
 @ActiveProfiles("local")
 public class AuthControllerValidationTest {
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryControllerUnitTest.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.ledger.controller;
 
 import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
 import kr.co.pennyway.api.apis.ledger.usecase.SpendingCategoryUseCase;
+import kr.co.pennyway.api.config.WebConfig;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.domains.spending.dto.CategoryInfo;
 import kr.co.pennyway.domain.domains.spending.exception.SpendingErrorCode;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -26,7 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = {SpendingCategoryController.class})
+@WebMvcTest(controllers = {SpendingCategoryController.class}, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
 @ActiveProfiles("test")
 public class SpendingCategoryControllerUnitTest {
     @Autowired

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/SpendingControllerUnitTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
 import kr.co.pennyway.api.apis.ledger.usecase.SpendingUseCase;
+import kr.co.pennyway.api.config.WebConfig;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -11,6 +12,8 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -26,7 +29,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles("test")
-@WebMvcTest(controllers = SpendingController.class)
+@WebMvcTest(controllers = SpendingController.class, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class SpendingControllerUnitTest {
     @Autowired

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/TargetAmountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/TargetAmountControllerUnitTest.java
@@ -2,12 +2,15 @@ package kr.co.pennyway.api.apis.ledger.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.apis.ledger.usecase.TargetAmountUseCase;
+import kr.co.pennyway.api.config.WebConfig;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.domain.domains.target.exception.TargetAmountErrorCode;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,7 +27,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = {TargetAmountController.class})
+@WebMvcTest(controllers = {TargetAmountController.class}, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
 @ActiveProfiles("test")
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class TargetAmountControllerUnitTest {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/question/controller/QuestionControllerTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/question/controller/QuestionControllerTest.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.question.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.apis.question.dto.QuestionReq;
 import kr.co.pennyway.api.apis.question.usecase.QuestionUseCase;
+import kr.co.pennyway.api.config.WebConfig;
 import kr.co.pennyway.domain.domains.question.domain.QuestionCategory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -22,7 +25,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = QuestionController.class)
+@WebMvcTest(controllers = QuestionController.class, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
 @ActiveProfiles("local")
 public class QuestionControllerTest {
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.api.apis.users.dto.DeviceDto;
 import kr.co.pennyway.api.apis.users.dto.UserProfileUpdateDto;
 import kr.co.pennyway.api.apis.users.usecase.UserAccountUseCase;
+import kr.co.pennyway.api.config.WebConfig;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import kr.co.pennyway.common.exception.StatusCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -29,7 +32,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = {UserAccountController.class})
+@WebMvcTest(controllers = {UserAccountController.class}, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
 @ActiveProfiles("local")
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class UserAccountControllerUnitTest {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/converter/IpAddressHeaderConverter.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/converter/IpAddressHeaderConverter.java
@@ -1,0 +1,13 @@
+package kr.co.pennyway.domain.common.converter;
+
+import jakarta.persistence.Converter;
+import kr.co.pennyway.domain.domains.sign.type.IpAddressHeader;
+
+@Converter
+public class IpAddressHeaderConverter extends AbstractLegacyEnumAttributeConverter<IpAddressHeader> {
+    private static final String ENUM_NAME = "IP 주소 헤더";
+
+    public IpAddressHeaderConverter() {
+        super(IpAddressHeader.class, false, ENUM_NAME);
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/sign/SignEventLog.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/sign/SignEventLog.java
@@ -14,14 +14,18 @@ public class SignEventLog {
     private final Long userId;
     private final LocalDateTime signedAt;
     private final String ipAddress;
+    private final String ipAddressHeader;
+    private final String appVersion;
     private final String deviceModel;
     private final String os;
 
     @Builder
-    private SignEventLog(Long userId, LocalDateTime signedAt, String ipAddress, String deviceModel, String os) {
+    public SignEventLog(Long userId, LocalDateTime signedAt, String ipAddress, String ipAddressHeader, String appVersion, String deviceModel, String os) {
         this.userId = userId;
         this.signedAt = signedAt;
         this.ipAddress = ipAddress;
+        this.ipAddressHeader = ipAddressHeader;
+        this.appVersion = appVersion;
         this.deviceModel = deviceModel;
         this.os = os;
     }
@@ -32,6 +36,8 @@ public class SignEventLog {
                 "userId=" + userId +
                 ", signedAt=" + signedAt +
                 ", ipAddress='" + ipAddress + '\'' +
+                ", ipAddressHeader='" + ipAddressHeader + '\'' +
+                ", appVersion='" + appVersion + '\'' +
                 ", deviceModel='" + deviceModel + '\'' +
                 ", os='" + os + '\'' +
                 '}';

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/sign/SignEventLog.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/sign/SignEventLog.java
@@ -1,0 +1,39 @@
+package kr.co.pennyway.domain.common.redis.sign;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RedisHash(value = "signEventLog", timeToLive = 60 * 60 * 24)
+public class SignEventLog {
+    @Id
+    private final Long userId;
+    private final LocalDateTime signedAt;
+    private final String ipAddress;
+    private final String deviceModel;
+    private final String os;
+
+    @Builder
+    private SignEventLog(Long userId, LocalDateTime signedAt, String ipAddress, String deviceModel, String os) {
+        this.userId = userId;
+        this.signedAt = signedAt;
+        this.ipAddress = ipAddress;
+        this.deviceModel = deviceModel;
+        this.os = os;
+    }
+
+    @Override
+    public String toString() {
+        return "SignEventLog{" +
+                "userId=" + userId +
+                ", signedAt=" + signedAt +
+                ", ipAddress='" + ipAddress + '\'' +
+                ", deviceModel='" + deviceModel + '\'' +
+                ", os='" + os + '\'' +
+                '}';
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/sign/SignEventLogRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/sign/SignEventLogRepository.java
@@ -1,0 +1,6 @@
+package kr.co.pennyway.domain.common.redis.sign;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface SignEventLogRepository extends CrudRepository<SignEventLog, Long> {
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/sign/SignEventLogRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/sign/SignEventLogRepository.java
@@ -1,6 +1,6 @@
 package kr.co.pennyway.domain.common.redis.sign;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.ListCrudRepository;
 
-public interface SignEventLogRepository extends CrudRepository<SignEventLog, Long> {
+public interface SignEventLogRepository extends ListCrudRepository<SignEventLog, Long> {
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/sign/SignEventLogService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/sign/SignEventLogService.java
@@ -1,0 +1,23 @@
+package kr.co.pennyway.domain.common.redis.sign;
+
+import kr.co.pennyway.common.annotation.DomainService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@Slf4j
+@DomainService
+@RequiredArgsConstructor
+public class SignEventLogService {
+    private final SignEventLogRepository signEventLogRepository;
+
+    public void create(SignEventLog signEventLog) {
+        signEventLogRepository.save(signEventLog);
+        log.debug("로그 저장 : {}", signEventLog);
+    }
+
+    public List<SignEventLog> findAll() {
+        return signEventLogRepository.findAll();
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/domain/SignInLog.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/domain/SignInLog.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Getter
+@Entity
 @Table(name = "sign_in_log")
 @IdClass(SignInLogId.class)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/domain/SignInLog.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/domain/SignInLog.java
@@ -1,6 +1,8 @@
 package kr.co.pennyway.domain.domains.sign.domain;
 
 import jakarta.persistence.*;
+import kr.co.pennyway.domain.common.converter.IpAddressHeaderConverter;
+import kr.co.pennyway.domain.domains.sign.type.IpAddressHeader;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,15 +23,19 @@ public class SignInLog {
 
     private Long userId;
     private String ipAddress;
+    @Convert(converter = IpAddressHeaderConverter.class)
+    private IpAddressHeader ipAddressHeader;
+    private String appVersion;
     private String deviceModel;
     private String os;
 
     @Builder
-    private SignInLog(LocalDateTime signedAt, Long id, Long userId, String ipAddress, String deviceModel, String os) {
+    public SignInLog(LocalDateTime signedAt, Long userId, String ipAddress, IpAddressHeader ipAddressHeader, String appVersion, String deviceModel, String os) {
         this.signedAt = signedAt;
-        this.id = id;
         this.userId = userId;
         this.ipAddress = ipAddress;
+        this.ipAddressHeader = ipAddressHeader;
+        this.appVersion = appVersion;
         this.deviceModel = deviceModel;
         this.os = os;
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/domain/SignInLog.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/domain/SignInLog.java
@@ -1,0 +1,36 @@
+package kr.co.pennyway.domain.domains.sign.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Table(name = "sign_in_log")
+@IdClass(SignInLogId.class)
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class SignInLog {
+    @Id
+    private LocalDateTime signedAt;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private String ipAddress;
+    private String deviceModel;
+    private String os;
+
+    @Builder
+    private SignInLog(LocalDateTime signedAt, Long id, Long userId, String ipAddress, String deviceModel, String os) {
+        this.signedAt = signedAt;
+        this.id = id;
+        this.userId = userId;
+        this.ipAddress = ipAddress;
+        this.deviceModel = deviceModel;
+        this.os = os;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/domain/SignInLogId.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/domain/SignInLogId.java
@@ -5,11 +5,14 @@ import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-public class SignInLogId {
+public class SignInLogId implements Serializable {
+    @Serial
     @Transient
     private static final long serialVersionUID = 1L;
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/domain/SignInLogId.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/domain/SignInLogId.java
@@ -1,0 +1,32 @@
+package kr.co.pennyway.domain.domains.sign.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Transient;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class SignInLogId {
+    @Transient
+    private static final long serialVersionUID = 1L;
+
+    @Column(name = "signed_at")
+    private LocalDateTime signedAt;
+    @Column(name = "id")
+    private Long id;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SignInLogId that)) return false;
+        return signedAt.equals(that.signedAt) && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return signedAt.hashCode() + id.hashCode();
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/repository/SignInLogRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/repository/SignInLogRepository.java
@@ -1,0 +1,8 @@
+package kr.co.pennyway.domain.domains.sign.repository;
+
+import kr.co.pennyway.domain.domains.sign.domain.SignInLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SignInLogRepository extends JpaRepository<SignInLog, Long> {
+    
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/service/SignInLogService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/service/SignInLogService.java
@@ -1,0 +1,11 @@
+package kr.co.pennyway.domain.domains.sign.service;
+
+import kr.co.pennyway.common.annotation.DomainService;
+import kr.co.pennyway.domain.domains.sign.repository.SignInLogRepository;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class SignInLogService {
+    private final SignInLogRepository signInLogRepository;
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/type/IpAddressHeader.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/sign/type/IpAddressHeader.java
@@ -1,0 +1,19 @@
+package kr.co.pennyway.domain.domains.sign.type;
+
+import kr.co.pennyway.domain.common.converter.LegacyCommonType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum IpAddressHeader implements LegacyCommonType {
+    X_FORWARDED_FOR("0", "X-Forwarded-For"),
+    PROXY_CLIENT_IP("1", "Proxy-Client-IP"),
+    WL_PROXY_CLIENT_IP("2", "WL-Proxy-Client-IP"),
+    HTTP_CLIENT_IP("3", "HTTP_CLIENT_IP"),
+    HTTP_X_FORWARDED_FOR("4", "HTTP_X_FORWARDED_FOR"),
+    REMOTE_ADDR("5", "REMOTE_ADDR");
+
+    private final String code;
+    private final String type;
+}


### PR DESCRIPTION
## 작업 이유
- 사용자가 로그인을 하면 로그인 이력을 caching한다.
- 사용자의 기기 정보는 `User-Agent` 헤더를 통해 전달한다.

<br/>

## 작업 사항
### 📌 Entity
- SignEventLog
   - Redis에 저장하기 위한 Hash Table
   - `userId`를 key로 가지며, ttl은 현재 24시간으로 설정
- SignInLog
   - MySQL에 저장하기 위한 Entity
   - B+ tree 순차 탐색 성능을 높이기 위해 `signedAt + id` 복합키를 갖는다.

<br/>

### 📌 Interceptor

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/a3de1f06-b2ca-415a-98d2-56b124f0419a" width="500px"/>
</div>

- AOP로 처리할 지, Interceptor로 처리할 지 고민했으나 web과 밀접한 기능이므로 Interceptor로 처리하는 것이 옳다고 판단했습니다.
- 일반 로그인, 소셜 로그인, 리프레시 API 에만 동작하며, 아직까진 User-Agent 헤더가 없어도 예외를 반환하지 않습니다.
   - 혹시나 클라이언트에서 동의를 구해야지만 정보를 추출할 수 있는 경우를 대비하여, 확인 후 조치할 예정
   - 하게되면 `preHande()`을 구현하여 처리할 수 있음.

<br/>

### 📌 기타
- `JwtAuthHelper`에 Util의 성격에 가까운 메서드가 포함되어 있어 전부터 고치고 싶었는데, 이번에 함께 수정하게 됐습니다.
- 수정을 하지 않으면 불필요하게 빈을 주입 받아야만 메서드를 사용할 수 있어 같이 수정하게 되었습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 모든 흐름은 오늘 대면으로 전달해드렸기 때문에 PR에 자세히 남기진 않았습니다. 그럼에도 혹시나 이해가 안 가는 부분이 있다면 다시 질문해주세요!
- 예상 외로 수정된 코드 라인 수가 많아서 당황했는데, 예전에 작성한 코드가 자동 포매팅되면서 더 늘어났습니다. 주요 작업은 아래가 끝입니다.
   - Redis와 MySQL에 저장하기 위한 로그 Entity 정의 후, 각각 Repository, Service 구현
   - IpAddr를 가져온 헤더를 파악하기 위한 상수 정의
   - Interceptor 등록
   - 이슈에 언급한 ControllerUnitTest 관련 이슈 때문에 수정한 것들

<br/>

## 발견한 이슈
```java
@WebMvcTest(controllers = {UserAccountController.class}, excludeFilters = {
        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
```
- WebMvcConfigurer에 Service 빈을 주입하는 덕에 Controller Unit Test 시, 빈 의존성 문제가 발생합니다.
   - Controller Unit 테스트 시엔 `@Component` 빈이 생성되지 않음.
- 그래서 모든 Controller Unit Test에서 강제로 `WebConfig`를 무시하도록 설정했는데, 임시 방편인 설정이라 해결책을 찾는 중입니다.

