### PR TITLE
✨ 지출 내역 삭제 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
@@ -81,5 +81,15 @@ public interface SpendingApi {
 
     @Operation(summary = "지출 내역 삭제", method = "DELETE", description = "지출 내역의 ID값으로 해당 지출 내역을 삭제 합니다.")
     @Parameter(name = "spendingId", description = "지출 내역 ID", example = "1", required = true, in = ParameterIn.PATH)
+    @ApiResponse(responseCode = "403", description = "지출 카테고리에 대한 권한이 없습니다.", content = @Content(examples = {
+            @ExampleObject(name = "지출 카테고리 권한 오류", description = "지출 카테고리에 대한 권한이 없습니다.",
+                    value = """
+                            {
+                            "code": "4030",
+                            "message": "ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN"
+                            }
+                            """
+            )
+    }))
     ResponseEntity<?> deleteSpending(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingApi.java
@@ -77,4 +77,9 @@ public interface SpendingApi {
             }))
     })
     ResponseEntity<?> getSpendingDetail(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user);
+
+
+    @Operation(summary = "지출 내역 삭제", method = "DELETE", description = "지출 내역의 ID값으로 해당 지출 내역을 삭제 합니다.")
+    @Parameter(name = "spendingId", description = "지출 내역 ID", example = "1", required = true, in = ParameterIn.PATH)
+    ResponseEntity<?> deleteSpending(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -48,6 +48,15 @@ public class SpendingController implements SpendingApi {
         return ResponseEntity.ok(SuccessResponse.from("spending", spendingUseCase.getSpedingDetail(user.getUserId(), spendingId)));
     }
 
+    @Override
+    @DeleteMapping("/{spendingId}")
+    @PreAuthorize("isAuthenticated() and @spendingManager.hasPermission(#user.getUserId(), #spendingId)")
+    public ResponseEntity<?> deleteSpending(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user) {
+        spendingUseCase.deleteSpending(user.getUserId(), spendingId);
+
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+
     /**
      * categoryId가 -1이면 서비스에서 정의한 카테고리를 사용하므로 저장하려는 지출 내역의 icon은 OTHER가 될 수 없고, <br/>
      * categoryId가 -1이 아니면 사용자가 정의한 카테고리를 사용하므로 저장하려는 지출 내역의 icon은 OTHER임을 확인한다.

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingController.java
@@ -52,7 +52,7 @@ public class SpendingController implements SpendingApi {
     @DeleteMapping("/{spendingId}")
     @PreAuthorize("isAuthenticated() and @spendingManager.hasPermission(#user.getUserId(), #spendingId)")
     public ResponseEntity<?> deleteSpending(@PathVariable Long spendingId, @AuthenticationPrincipal SecurityUserDetails user) {
-        spendingUseCase.deleteSpending(user.getUserId(), spendingId);
+        spendingUseCase.deleteSpending(spendingId);
 
         return ResponseEntity.ok(SuccessResponse.noContent());
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
@@ -54,4 +54,12 @@ public class SpendingUseCase {
 
         return SpendingMapper.toSpendingSearchResIndividual(spending);
     }
+
+    @Transactional
+    public void deleteSpending(Long userId, Long spendingId) {
+        Spending spending = spendingService.readSpending(spendingId)
+                .orElseThrow(() -> new SpendingErrorException(SpendingErrorCode.NOT_FOUND_SPENDING));
+
+        spendingService.deleteSpending(spending);
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingUseCase.java
@@ -56,7 +56,7 @@ public class SpendingUseCase {
     }
 
     @Transactional
-    public void deleteSpending(Long userId, Long spendingId) {
+    public void deleteSpending(Long spendingId) {
         Spending spending = spendingService.readSpending(spendingId)
                 .orElseThrow(() -> new SpendingErrorException(SpendingErrorCode.NOT_FOUND_SPENDING));
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingControllerIntegrationTest.java
@@ -26,7 +26,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -171,15 +170,8 @@ public class SpendingControllerIntegrationTest extends ExternalApiDBTestConfig {
         void deleteSpendingSuccess() throws Exception {
             // given
             User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
-            Spending spending = spendingService.createSpending(Spending.builder()
-                    .amount(10000)
-                    .category(SpendingCategory.FOOD)
-                    .spendAt(LocalDateTime.now())
-                    .accountName("소비처")
-                    .memo("메모")
-                    .user(user)
-                    .spendingCustomCategory(null)
-                    .build());
+            Spending spending = SpendingFixture.toSpending(user);
+            spendingService.createSpending(spending);
 
             // when
             ResultActions resultActions = performDeleteSpendingSuccess(user, spending.getId());
@@ -188,6 +180,7 @@ public class SpendingControllerIntegrationTest extends ExternalApiDBTestConfig {
             resultActions
                     .andDo(print())
                     .andExpect(status().isOk());
+            Assertions.assertTrue(spendingService.readSpending(spending.getId()).isEmpty());
         }
 
         @Test
@@ -196,15 +189,8 @@ public class SpendingControllerIntegrationTest extends ExternalApiDBTestConfig {
         void deleteSpendingForbidden() throws Exception {
             // given
             User user1 = userService.createUser(UserFixture.GENERAL_USER.toUser());
-            Spending spending = spendingService.createSpending(Spending.builder()
-                    .amount(10000)
-                    .category(SpendingCategory.FOOD)
-                    .spendAt(LocalDateTime.now())
-                    .accountName("소비처")
-                    .memo("메모")
-                    .user(user1)
-                    .spendingCustomCategory(null)
-                    .build());
+            Spending spending = SpendingFixture.toSpending(user1);
+            spendingService.createSpending(spending);
             User user2 = userService.createUser(UserFixture.GENERAL_USER.toUser());
 
             // when

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingControllerIntegrationTest.java
@@ -170,7 +170,7 @@ public class SpendingControllerIntegrationTest extends ExternalApiDBTestConfig {
         void deleteSpendingSuccess() throws Exception {
             // given
             User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
-            Spending spending = SpendingFixture.toSpending(user);
+            Spending spending = SpendingFixture.GENERAL_SPENDING.toSpending(user);
             spendingService.createSpending(spending);
 
             // when
@@ -184,12 +184,12 @@ public class SpendingControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @DisplayName("권한이 없는 사용자의 지출 내역 삭제")
+        @DisplayName("사용자가 spendingId에 해당하는 지출 내역의 소유자가 아닌 경우, 403 Forbidden을 반환한다.")
         @Transactional
         void deleteSpendingForbidden() throws Exception {
             // given
             User user1 = userService.createUser(UserFixture.GENERAL_USER.toUser());
-            Spending spending = SpendingFixture.toSpending(user1);
+            Spending spending = SpendingFixture.GENERAL_SPENDING.toSpending(user1);
             spendingService.createSpending(spending);
             User user2 = userService.createUser(UserFixture.GENERAL_USER.toUser());
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/SpendingFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/SpendingFixture.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.api.config.fixture;
 
+import kr.co.pennyway.api.apis.ledger.dto.SpendingReq;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import kr.co.pennyway.domain.domains.user.domain.User;
@@ -14,18 +15,27 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-public class SpendingFixture {
-    private static final String SPENDING_TABLE = "spending";
+public enum SpendingFixture {
+    GENERAL_SPENDING(10000, SpendingCategory.FOOD, LocalDateTime.now(), "카페인 수혈", "아메리카노 1잔", UserFixture.GENERAL_USER.toUser());
 
-    public static Spending toSpending(User user) {
-        return Spending.builder()
-                .amount(10000)
-                .category(SpendingCategory.FOOD)
-                .spendAt(LocalDateTime.now())
-                .accountName("카페인 수혈")
-                .memo("아메리카노 1잔")
-                .user(user)
-                .build();
+    private final int amount;
+    private final SpendingCategory category;
+    private final LocalDateTime spendAt;
+    private final String accountName;
+    private final String memo;
+    private final User user;
+
+    SpendingFixture(int amount, SpendingCategory category, LocalDateTime spendAt, String accountName, String memo, User user) {
+        this.amount = amount;
+        this.category = category;
+        this.spendAt = spendAt;
+        this.accountName = accountName;
+        this.memo = memo;
+        this.user = user;
+    }
+
+    public static SpendingReq toSpendingReq(User user) {
+        return new SpendingReq(10000, -1L, SpendingCategory.FOOD, LocalDate.now(), "카페인 수혈", "아메리카노 1잔");
     }
 
     public static void bulkInsertSpending(User user, int capacity, NamedParameterJdbcTemplate jdbcTemplate) {
@@ -34,7 +44,7 @@ public class SpendingFixture {
         String sql = String.format("""
                 INSERT INTO `%s` (amount, category, spend_at, account_name, memo, user_id, spending_custom_category_id, created_at, updated_at, deleted_at)
                 VALUES (:amount, 1+FLOOR(RAND()*11), :spendAt, :accountName, :memo, :user.id, null, NOW(), NOW(), null)
-                """, SPENDING_TABLE);
+                """, "spending");
         SqlParameterSource[] params = spendings.stream()
                 .map(BeanPropertySqlParameterSource::new)
                 .toArray(SqlParameterSource[]::new);
@@ -74,5 +84,16 @@ public class SpendingFixture {
     private static String getRandomAccountName() {
         List<String> accountNames = List.of("현금", "카드", "통장", "월급통장", "적금", "보험", "투자", "기타");
         return accountNames.get(ThreadLocalRandom.current().nextInt(0, accountNames.size()));
+    }
+
+    public Spending toSpending(User user) {
+        return Spending.builder()
+                .amount(amount)
+                .category(category)
+                .spendAt(spendAt)
+                .accountName(accountName)
+                .memo(memo)
+                .user(user)
+                .build();
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/SpendingFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/SpendingFixture.java
@@ -17,6 +17,17 @@ import java.util.concurrent.ThreadLocalRandom;
 public class SpendingFixture {
     private static final String SPENDING_TABLE = "spending";
 
+    public static Spending toSpending(User user) {
+        return Spending.builder()
+                .amount(10000)
+                .category(SpendingCategory.FOOD)
+                .spendAt(LocalDateTime.now())
+                .accountName("카페인 수혈")
+                .memo("아메리카노 1잔")
+                .user(user)
+                .build();
+    }
+
     public static void bulkInsertSpending(User user, int capacity, NamedParameterJdbcTemplate jdbcTemplate) {
         Collection<Spending> spendings = getRandomSpendings(user, capacity);
 
@@ -56,7 +67,7 @@ public class SpendingFixture {
         int year = ThreadLocalRandom.current().nextInt(startAt.getYear(), endAt.getYear() + 1);
         int month = (year == endAt.getYear()) ? ThreadLocalRandom.current().nextInt(1, endAt.getMonthValue() + 1) : ThreadLocalRandom.current().nextInt(1, 13);
         int day = ThreadLocalRandom.current().nextInt(1, 29);
-        
+
         return LocalDateTime.of(year, month, day, 0, 0, 0);
     }
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
@@ -47,8 +47,8 @@ public class SpendingService {
     @Transactional(readOnly = true)
     public List<Spending> readSpendings(Predicate predicate, QueryHandler queryHandler, Sort sort) {
         return spendingRepository.findList(predicate, queryHandler, sort);
-    }  
-  
+    }
+
     @Transactional(readOnly = true)
     public List<TotalSpendingAmount> readTotalSpendingsAmountByUserId(Long userId) {
         Predicate predicate = user.id.eq(userId);
@@ -69,5 +69,10 @@ public class SpendingService {
     @Transactional(readOnly = true)
     public boolean isExistsSpending(Long userId, Long spendingId) {
         return spendingRepository.existsByIdAndUser_Id(spendingId, userId);
+    }
+
+    @Transactional
+    public void deleteSpending(Spending spending) {
+        spendingRepository.delete(spending);
     }
 }


### PR DESCRIPTION
## 작업 이유
사용자는 지출 내역을 삭제할 수 있다.

<br/>

## 작업 사항
### API Spec
- url : `DELETE /v2/{지출내역 ID}`
- pre-condition : 사용자는 로그인 한 상태이고, 삭제하고자 하는 지출 내역의 작성자여야 한다.

결과
![image](https://github.com/CollaBu/pennyway-was/assets/79460319/1a754332-9c95-45d6-aadd-3d9825b4dd92)
통합테스트 결과
![image](https://github.com/CollaBu/pennyway-was/assets/79460319/3c1a25f5-b766-48d5-a3a1-d811f4c7fba4)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
> 로직 자체는 다 합쳐서 10줄이내입니다.


<br/>

## 발견한 이슈
### `@PreAuthorize` 사용시 잘못된 에러응답 발생
![image](https://github.com/CollaBu/pennyway-was/assets/79460319/d14ee023-c8cd-4594-87bc-b866c98588eb)
> **Scenario**
- 사용자는 없는 지출 내역 삭제를 시도
- `@PreAuthorize`의 `hasPermission`메서드가 해당 사용자 id + 지출 내역 id를 포함한 지출내역 레코드가 `isExist` 하는지 확인
- `false` 일시 403`FORBIDDEN` 예외 발생

위 시나리오에서, 없는 지출내역의 삭제 요청이 들어왔을때도 똑같이 `isExist` 구문이 `false`가 나오므로 권한 예외가 발생합니다. 즉, 틀린 예외가 발생합니다.

- 개선 방안
`hasPermission` 메서드의 권한 인증 로직을 변경한다.
> **FROM** `spendingId` + `userId`로 존재하는 레코드가 있는지? 

> **TO** `spendingId로 존재하는 레코드가 있는지?` + 있다면, `spendingId` + `userId`로 존재하는 레코드가 있는지?` 로 변경하기

잠재 위험 -> 레코드의 존재여부를 검사하는 로직이 권한검사에서 한번, `UseCase`단에서 한번 존재하며, 관심사가 잘못됨.

사실상 클라이언트단에서 다른 사용자의 지출내역 삭제 요청이 들어올 일은 없긴하지만, 비정상적인 요청에도 고려해야한다는 점에서 고민이 됩니다. 좋은 의견있으면 공유해주시면 감사하겠습니다!
