### PR TITLE
Api: 🎇 Api-v1.0.0 릴리즈

### DIFF
--- a/.github/workflows/create-tag-and-release.yml
+++ b/.github/workflows/create-tag-and-release.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch
+          release_branches: main,dev.*
           custom_release_rules: release:major, feat:minor:Features, refactor:minor:Refactoring, fix:patch:Bug Fixes, hotfix:patch:Hotfixes, docs:patch:Documentation, style:patch:Styles, perf:patch:Performance Improvements, test:patch:Tests, ci:patch:Continuous Integration, chore:patch:Chores, revert:patch:Reverts
           tag_prefix: '${{ steps.module_prefix.outputs.module }}-v'
 


### PR DESCRIPTION
내용은 사실 버그 픽스지만 ㅎㅎ  

![image](https://github.com/CollaBu/pennyway-was/assets/96044622/43c21844-e5ee-4765-9813-76f2242f29b0)

태그 자동 생성 시 main 브랜치가 아닌 브랜치는 pre-release 처리되어서 브랜치 명이 태그의 접미사로 붙는 기능이 있었는데  
개인 저장소에서 위와 같이 설정했을 때 정상적으로 태그가 발행되는 것을 확인하긴 했습니다.  

제발 잘 되길 빌어주세요.  

![image](https://github.com/CollaBu/pennyway-was/assets/96044622/097e3cf3-2d70-455c-9a69-eccf4d2a713d)

로컬 테스트 로그 화면.