### PR TITLE
Api: 🐛 태그 생성 & 릴리즈 자동화 파이프라인 후 배포 workflows call

### DIFF
--- a/.github/workflows/create-tag-and-release.yml
+++ b/.github/workflows/create-tag-and-release.yml
@@ -2,11 +2,12 @@ name: Tag and Release
 
 on:
   pull_request:
-    types: [ closed, synchronize, edited ]
+    types: [ closed ]
 
 jobs:
   extract-info:
     # PR이 merge 되었을 때만 실행 (merge가 아닌 close는 제외)
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/create-tag-and-release.yml
+++ b/.github/workflows/create-tag-and-release.yml
@@ -65,11 +65,11 @@ jobs:
     if: ${{ needs.extract-info.outputs.module == 'Api' }}
     uses: ./.github/workflows/deploy-external-api.yml
     with:
-      tags: ${{ needs.extract-info.outputs.version }}
+      tags: ${{ needs.extract-info.outputs.tag }}
 
   call-batch-deploy:
     needs: extract-info
     if: ${{ needs.extract-info.outputs.module == 'Batch' }}
     uses: ./.github/workflows/deploy-batch.yml
     with:
-      tags: ${{ needs.extract-info.outputs.version }}
+      tags: ${{ needs.extract-info.outputs.tag }}

--- a/.github/workflows/create-tag-and-release.yml
+++ b/.github/workflows/create-tag-and-release.yml
@@ -2,12 +2,11 @@ name: Tag and Release
 
 on:
   pull_request:
-    types: [ opened, closed ]
+    types: [ closed, synchronize, edited ]
 
 jobs:
   extract-info:
     # PR이 merge 되었을 때만 실행 (merge가 아닌 close는 제외)
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/create-tag-and-release.yml
+++ b/.github/workflows/create-tag-and-release.yml
@@ -64,6 +64,7 @@ jobs:
     needs: extract-info
     if: ${{ needs.extract-info.outputs.module == 'Api' }}
     uses: ./.github/workflows/deploy-external-api.yml
+    secrets: inherit
     with:
       tags: ${{ needs.extract-info.outputs.tag }}
 
@@ -71,5 +72,6 @@ jobs:
     needs: extract-info
     if: ${{ needs.extract-info.outputs.module == 'Batch' }}
     uses: ./.github/workflows/deploy-batch.yml
+    secrets: inherit
     with:
       tags: ${{ needs.extract-info.outputs.tag }}

--- a/.github/workflows/create-tag-and-release.yml
+++ b/.github/workflows/create-tag-and-release.yml
@@ -13,6 +13,9 @@ jobs:
       contents: write
       pull-requests: write
       repository-projects: write
+    outputs:
+      module: ${{ steps.module_prefix.outputs.module }}
+      tag: ${{ steps.tag_version.outputs.new_tag }}
 
     steps:
       - name: Checkout PR
@@ -57,3 +60,17 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
+
+  call-external-api-deploy:
+    needs: extract-info
+    if: ${{ needs.extract-info.outputs.module == 'Api' }}
+    uses: ./.github/workflows/deploy-external-api.yml
+    with:
+      tags: ${{ needs.extract-info.outputs.version }}
+
+  call-batch-deploy:
+    needs: extract-info
+    if: ${{ needs.extract-info.outputs.module == 'Batch' }}
+    uses: ./.github/workflows/deploy-batch.yml
+    with:
+      tags: ${{ needs.extract-info.outputs.version }}

--- a/.github/workflows/create-tag-and-release.yml
+++ b/.github/workflows/create-tag-and-release.yml
@@ -2,7 +2,7 @@ name: Tag and Release
 
 on:
   pull_request:
-    types: [ closed ]
+    types: [ opened, closed ]
 
 jobs:
   extract-info:

--- a/.github/workflows/deploy-batch.yml
+++ b/.github/workflows/deploy-batch.yml
@@ -1,4 +1,4 @@
-name: Continuous Deployment - External API
+name: Continuous Deployment - Batch
 
 on:
   workflow_call:

--- a/.github/workflows/deploy-batch.yml
+++ b/.github/workflows/deploy-batch.yml
@@ -7,25 +7,6 @@ on:
         description: '배포할 Batch 모듈 태그 정보 (Batch-v*.*.*)'
         required: true
         type: string
-  workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-        type: choice
-        options:
-          - info
-          - warning
-          - debug
-      tags:
-        description: 'Test scenario tags'
-        required: false
-        type: boolean
-      environment:
-        description: 'Environment to run tests against'
-        type: environment
-        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-batch.yml
+++ b/.github/workflows/deploy-batch.yml
@@ -1,9 +1,12 @@
 name: Continuous Deployment - External API
 
 on:
-  push:
-    tags:
-      - Batch-v*.*.*
+  workflow_call:
+    inputs:
+      tags:
+        description: '배포할 Batch 모듈 태그 정보 (Batch-v*.*.*)'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/deploy-batch.yml
+++ b/.github/workflows/deploy-batch.yml
@@ -63,7 +63,8 @@ jobs:
       - name: docker build and push
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build -t pennyway/pennyway-batch ./pennyway-batch
+          docker build -t pennyway/pennyway-batch:${{ steps.get_version.outputs.VERSION }} ./pennyway-batch
+          docker build -t pennyway/pennyway-batch:latest ./pennyway-batch
           docker push pennyway/pennyway-batch:${{ steps.get_version.outputs.VERSION }}
           docker push pennyway/pennyway-batch:latest
 

--- a/.github/workflows/deploy-batch.yml
+++ b/.github/workflows/deploy-batch.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Get Version
         id: get_version
         run: |
-          RELEASE_VERSION_WITHOUT_V="$(cut -d'v' -f2 <<< ${GITHUB_REF#refs/*/})"
+          RELEASE_VERSION_WITHOUT_V="$(cut -d'v' -f2 <<< ${{ inputs.tags }})"
           echo "VERSION=$RELEASE_VERSION_WITHOUT_V" >> $GITHUB_OUTPUT
 
       # 3. 자바 환경 설정

--- a/.github/workflows/deploy-external-api.yml
+++ b/.github/workflows/deploy-external-api.yml
@@ -7,25 +7,6 @@ on:
         description: '배포할 Api 모듈 태그 정보 (Api-v*.*.*)'
         required: true
         type: string
-  workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-        type: choice
-        options:
-          - info
-          - warning
-          - debug
-      tags:
-        description: 'Test scenario tags'
-        required: false
-        type: boolean
-      environment:
-        description: 'Environment to run tests against'
-        type: environment
-        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-external-api.yml
+++ b/.github/workflows/deploy-external-api.yml
@@ -71,7 +71,8 @@ jobs:
       - name: docker build and push
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build -t pennyway/pennyway-was ./pennyway-app-external-api
+          docker build -t pennyway/pennyway-was:${{ steps.get_version.outputs.VERSION }} ./pennyway-app-external-api
+          docker build -t pennyway/pennyway-was:latest ./pennyway-app-external-api
           docker push pennyway/pennyway-was:${{ steps.get_version.outputs.VERSION }}
           docker push pennyway/pennyway-was:latest
 

--- a/.github/workflows/deploy-external-api.yml
+++ b/.github/workflows/deploy-external-api.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Get Version
         id: get_version
         run: |
-          RELEASE_VERSION_WITHOUT_V="$(cut -d'v' -f2 <<< ${GITHUB_REF#refs/*/})"
+          RELEASE_VERSION_WITHOUT_V="$(cut -d'v' -f2 <<< ${{ inputs.tags }})"
           echo "VERSION=$RELEASE_VERSION_WITHOUT_V" >> $GITHUB_OUTPUT
 
       # 3. 자바 환경 설정

--- a/.github/workflows/deploy-external-api.yml
+++ b/.github/workflows/deploy-external-api.yml
@@ -1,9 +1,12 @@
 name: Continuous Deployment - External API
 
 on:
-  push:
-    tags:
-      - Api-v*.*.*
+  workflow_call:
+    inputs:
+      tags:
+        description: '배포할 Api 모듈 태그 정보 (Api-v*.*.*)'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       logLevel:


### PR DESCRIPTION
## 작업 이유
- workflows에서 발생한 이벤트가 다른 workflows의 trigger로 동작하지 않음을 발견
- 태그 생성 파이프라인에서 다음 workflows를 호출하도록 수정

<br/>

## 작업 사항
1. 임의의 workflows에서 발생한 이벤트를 다른 workflows가 감지하도록 하는 기행은 불가능함. 반드시 외부에서 발생한 이벤트여야 함. 
2. 그렇다면 tag & release 자동화 이후 실행될 workflows를 명시해주어야 함.
    - 방법1. workflow_run : 태그 생성 CD가 종료되는 이벤트를 감지하여 배포 CD 실행. → 모든 배포 관련 workflows가 실행되어야 해서 기각
    - 방법2. workflow_call : 태그 생성 CD가 다음으로 진행할 배포 CD 선택 → step이 아닌 job 단위에서 실행해야 한다는 단점
    - 방법3. workflow_dispatch : 다른 repository의 workflow를 호출하기 위한 것이므로 기각
    - 방법4. Composite Actions : step 단위에서 사용할 수는 있으나 다루기가 귀찮은 점이 한 두가지가 아님.
3. 테스트

![image](https://github.com/CollaBu/pennyway-was/assets/96044622/518b38d8-471e-4e5e-a7db-27a5fa99bede)

첫 번째 run에서 module과 version 정보를 출력값으로 설정
4개의 run을 만들어서 module명에 맞는 run이 다음 workflows를 호출

![image](https://github.com/CollaBu/pennyway-was/assets/96044622/5270233e-5308-451c-aab5-fbfbf3d65f0f)
![image](https://github.com/CollaBu/pennyway-was/assets/96044622/409567c0-9dd8-4190-8a8a-0293c49ec63a)

위에서 전달한 값을 inputs.tag로 받아서 배포 파이프라인 실행

![image](https://github.com/CollaBu/pennyway-was/assets/96044622/fbb03d7b-3586-439f-8851-4e33c52990ed)

<br/>

테스트를 위해 제거했던 PR merged 조건문 추가

![image](https://github.com/CollaBu/pennyway-was/assets/96044622/b8de3243-dbed-4a5f-b5aa-cbb8a48d8880)
![image](https://github.com/CollaBu/pennyway-was/assets/96044622/0e24e1f3-91bf-4d88-96a4-a29c4f7d5a3a)

전 단계가 수행되지 않으면, 이후 workflows는 별도로 체크 안 해줘도 실행 안 됨을 확인.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
![image](https://github.com/CollaBu/pennyway-was/assets/96044622/5b976bb2-8f5b-411d-83f3-7087b90f3bde)

- 아직 플로우가 이해가 잘 안 되실 듯하여 정리해두었습니다.

<br/>

## 발견한 이슈
- 제발 돼라. 제발 제발

