### PR TITLE
Api: ✏️ 문의하기 응답속도 개선을 위한 이벤트 핸들러 비동기 처리

### DIFF
--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/MailEventHandling.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/MailEventHandling.java
@@ -4,6 +4,7 @@ import kr.co.pennyway.infra.client.google.mail.GoogleMailSender;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -21,8 +22,9 @@ public class MailEventHandling {
      * @param event {@link MailEvent}
      */
     @TransactionalEventListener
+    @Async
     public void handleMailEvent(MailEvent event) {
-        log.info("handleMailEvent: {}", event);
+        log.info("문의 메일 전송 이벤트 발생: {}", event);
         googleMailSender.sendMail(event.email(), event.content(), event.category());
     }
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MailConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MailConfig.java
@@ -5,10 +5,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import java.util.Properties;
 
 @Configuration
+@EnableAsync
 public class MailConfig {
     @Value("${app.mail.host}")
     private String host;


### PR DESCRIPTION
## 작업 이유
- 문의하기 메일 API 응답속도 문제를 인식 후, 개선하기 위함

<br/>





## 작업 사항
### 개선 전
![image](https://github.com/CollaBu/pennyway-was/assets/79460319/aeccc71d-3c57-41ba-b114-808236b010c3)
![image](https://github.com/CollaBu/pennyway-was/assets/79460319/8029e721-e869-49a6-955c-003dcfd3ca44)


### 개선 후
![image](https://github.com/CollaBu/pennyway-was/assets/79460319/5f0fe132-e155-4ee1-9b30-297f388d172e)
![image](https://github.com/CollaBu/pennyway-was/assets/79460319/eb55a598-6fbe-4b48-a1df-46bcec7f1d36)

### 개선 내용

문의하기 메일 발송 로직을 비동기 처리토록 하기 위해 `@EnableAsync` 어노테이션을 Configuration에 달아주고, `@Async` 어노테이션을 이벤트 핸들러에 달아줌으로써 비동기 처리가 가능케 했습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
`@EnableAsync`를 사용시 고려되는 부작용이있는지?

<br/>

## 발견한 이슈
문의하기 발송 로직은`@TransactionalEventListener`를 사용해 메일을 보내는 작업은 이벤트 핸들러가 작업을 수행합니다. 단순히 이를 사용하기만 해도 비동기 처리가 된다고 생각 했었는데, 아니었습니다. 😅 
위 사진에 나와있듯이, 이벤트를 발행하는 곳과 이벤트를 감지해 특정한 동작을 수행하는 곳이 같은 스레드였습니다.