### PR TITLE
Api: ✨ 최근 목표 금액 조회 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/TargetAmountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/TargetAmountApi.java
@@ -68,6 +68,11 @@ public interface TargetAmountApi {
             schemaProperties = @SchemaProperty(name = "targetAmounts", array = @ArraySchema(schema = @Schema(implementation = TargetAmountDto.WithTotalSpendingRes.class)))))
     ResponseEntity<?> getTargetAmountsAndTotalSpendings(@Validated TargetAmountDto.DateParam param, @AuthenticationPrincipal SecurityUserDetails user);
 
+    @Operation(summary = "당월 이전 사용자가 입력한 목표 금액 중 최신 데이터 단일 조회", method = "GET",
+            description = "당월에 목표 금액이 존재한다면 당월 목표 금액이 반환되겠지만, 일반적으로 해당 API는 당월 목표 금액 조회 시 isRead가 false인 경우이므로 amount도 -1이라는 전제를 두어 별도의 예외처리를 수행하지는 않는다. isPresent 필드를 통해 데이터 존재 여부를 확인할 수 있다.")
+    @ApiResponse(responseCode = "200", description = "목표 금액 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "targetAmount", schema = @Schema(implementation = TargetAmountDto.RecentTargetAmountRes.class))))
+    ResponseEntity<?> getRecentTargetAmount(@AuthenticationPrincipal SecurityUserDetails user);
+
     @Operation(summary = "당월 목표 금액 수정", method = "PATCH")
     @Parameters({
             @Parameter(name = "targetAmountId", description = "수정하려는 목표 금액 ID", required = true, example = "1", in = ParameterIn.PATH),

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/TargetAmountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/TargetAmountController.java
@@ -53,6 +53,13 @@ public class TargetAmountController implements TargetAmountApi {
     }
 
     @Override
+    @GetMapping("/recent")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getRecentTargetAmount(@AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(SuccessResponse.from(TARGET_AMOUNT, targetAmountUseCase.getRecentTargetAmount(user.getUserId())));
+    }
+
+    @Override
     @PatchMapping("/{target_amount_id}")
     @PreAuthorize("isAuthenticated() and @targetAmountManager.hasPermission(principal.userId, #targetAmountId)")
     public ResponseEntity<?> patchTargetAmount(@Validated TargetAmountDto.AmountParam param, @PathVariable("target_amount_id") Long targetAmountId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/TargetAmountDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/TargetAmountDto.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.ledger.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -86,6 +87,25 @@ public class TargetAmountDto {
                 return new TargetAmountInfo(-1L, -1, false);
             }
             return new TargetAmountInfo(targetAmount.getId(), targetAmount.getAmount(), targetAmount.isRead());
+        }
+    }
+
+    @Schema(title = "가장 최근에 입력한 목표 금액 정보")
+    public record RecentTargetAmountRes(
+            @Schema(description = "최근 목표 금액 존재 여부로써 데이터가 존재하지 않으면 false, 존재하면 true", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+            boolean isPresent,
+            @Schema(description = "최근 목표 금액 정보. isPresent가 false인 경우 필드가 존재하지 않는다.", requiredMode = Schema.RequiredMode.REQUIRED)
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Integer amount
+    ) {
+        public RecentTargetAmountRes {
+            if (!isPresent) {
+                amount = null;
+            }
+        }
+
+        public static RecentTargetAmountRes valueOf(Integer amount) {
+            return (amount.equals(-1)) ? new RecentTargetAmountRes(false, null) : new RecentTargetAmountRes(true, amount);
         }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/TargetAmountMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/TargetAmountMapper.java
@@ -49,6 +49,15 @@ public class TargetAmountMapper {
                 .toList();
     }
 
+    /**
+     * 최근 목표 금액을 응답 형태로 변환한다.
+     *
+     * @return TargetAmountDto.RecentTargetAmountRes
+     */
+    public static TargetAmountDto.RecentTargetAmountRes toRecentTargetAmountResponse(Integer amount) {
+        return TargetAmountDto.RecentTargetAmountRes.valueOf(amount);
+    }
+
     private static List<TargetAmountDto.WithTotalSpendingRes> createWithTotalSpendingResponses(Map<YearMonth, TargetAmount> targetAmounts, Map<YearMonth, Integer> totalSpendings, LocalDate startAt, int monthLength) {
         List<TargetAmountDto.WithTotalSpendingRes> withTotalSpendingResponses = new ArrayList<>(monthLength + 1);
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/RecentTargetAmountSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/RecentTargetAmountSearchService.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.api.apis.ledger.service;
+
+import kr.co.pennyway.domain.domains.target.domain.TargetAmount;
+import kr.co.pennyway.domain.domains.target.service.TargetAmountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RecentTargetAmountSearchService {
+    private final TargetAmountService targetAmountService;
+
+    @Transactional(readOnly = true)
+    public Integer readRecentTargetAmount(Long userId) {
+        return targetAmountService.readRecentTargetAmount(userId)
+                .map(TargetAmount::getAmount)
+                .orElse(-1);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.ledger.usecase;
 
 import kr.co.pennyway.api.apis.ledger.dto.TargetAmountDto;
 import kr.co.pennyway.api.apis.ledger.mapper.TargetAmountMapper;
+import kr.co.pennyway.api.apis.ledger.service.RecentTargetAmountSearchService;
 import kr.co.pennyway.api.apis.ledger.service.TargetAmountSaveService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.common.redisson.DistributedLockPrefix;
@@ -32,6 +33,7 @@ public class TargetAmountUseCase {
     private final SpendingService spendingService;
 
     private final TargetAmountSaveService targetAmountSaveService;
+    private final RecentTargetAmountSearchService recentTargetAmountSearchService;
 
     @Transactional
     public TargetAmountDto.TargetAmountInfo createTargetAmount(Long userId, int year, int month) {
@@ -62,7 +64,7 @@ public class TargetAmountUseCase {
 
     @Transactional(readOnly = true)
     public TargetAmountDto.RecentTargetAmountRes getRecentTargetAmount(Long userId) {
-        return null;
+        return TargetAmountMapper.toRecentTargetAmountResponse(recentTargetAmountSearchService.readRecentTargetAmount(userId));
     }
 
     @Transactional

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
@@ -60,6 +60,11 @@ public class TargetAmountUseCase {
         return TargetAmountMapper.toWithTotalSpendingResponses(targetAmounts, totalSpendings, user.getCreatedAt().toLocalDate(), date);
     }
 
+    @Transactional(readOnly = true)
+    public TargetAmountDto.RecentTargetAmountRes getRecentTargetAmount(Long userId) {
+        return null;
+    }
+
     @Transactional
     public TargetAmountDto.TargetAmountInfo updateTargetAmount(Long targetAmountId, Integer amount) {
         TargetAmount targetAmount = targetAmountService.readTargetAmount(targetAmountId)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/repository/TargetAmountCustomRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/repository/TargetAmountCustomRepository.java
@@ -1,7 +1,12 @@
 package kr.co.pennyway.domain.domains.target.repository;
 
+import kr.co.pennyway.domain.domains.target.domain.TargetAmount;
+
 import java.time.LocalDate;
+import java.util.Optional;
 
 public interface TargetAmountCustomRepository {
+    Optional<TargetAmount> findRecentOneByUserId(Long userId);
+
     boolean existsByUserIdThatMonth(Long userId, LocalDate date);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/repository/TargetAmountCustomRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/repository/TargetAmountCustomRepositoryImpl.java
@@ -5,11 +5,13 @@ import kr.co.pennyway.domain.domains.target.domain.QTargetAmount;
 import kr.co.pennyway.domain.domains.target.domain.TargetAmount;
 import kr.co.pennyway.domain.domains.user.domain.QUser;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.Optional;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class TargetAmountCustomRepositoryImpl implements TargetAmountCustomRepository {
@@ -31,8 +33,9 @@ public class TargetAmountCustomRepositoryImpl implements TargetAmountCustomRepos
                         .and(targetAmount.amount.gt(-1)))
                 .orderBy(targetAmount.createdAt.desc())
                 .fetchFirst();
+        log.info("최근 목표 금액 : {}", result);
 
-        return Optional.of(result);
+        return Optional.ofNullable(result);
     }
 
     @Override

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/repository/TargetAmountCustomRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/repository/TargetAmountCustomRepositoryImpl.java
@@ -33,7 +33,6 @@ public class TargetAmountCustomRepositoryImpl implements TargetAmountCustomRepos
                         .and(targetAmount.amount.gt(-1)))
                 .orderBy(targetAmount.createdAt.desc())
                 .fetchFirst();
-        log.info("최근 목표 금액 : {}", result);
 
         return Optional.ofNullable(result);
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/repository/TargetAmountCustomRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/repository/TargetAmountCustomRepositoryImpl.java
@@ -2,11 +2,13 @@ package kr.co.pennyway.domain.domains.target.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.pennyway.domain.domains.target.domain.QTargetAmount;
+import kr.co.pennyway.domain.domains.target.domain.TargetAmount;
 import kr.co.pennyway.domain.domains.user.domain.QUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -15,6 +17,23 @@ public class TargetAmountCustomRepositoryImpl implements TargetAmountCustomRepos
 
     private final QUser user = QUser.user;
     private final QTargetAmount targetAmount = QTargetAmount.targetAmount;
+
+    /**
+     * 사용자의 가장 최근 목표 금액을 조회한다.
+     *
+     * @return 최근 목표 금액이 존재하지 않을 경우 Optional.empty()를 반환하며, 당월 목표 금액 정보일 수도 있다.
+     */
+    @Override
+    public Optional<TargetAmount> findRecentOneByUserId(Long userId) {
+        TargetAmount result = queryFactory.selectFrom(targetAmount)
+                .innerJoin(user).on(targetAmount.user.id.eq(user.id))
+                .where(user.id.eq(userId)
+                        .and(targetAmount.amount.gt(-1)))
+                .orderBy(targetAmount.createdAt.desc())
+                .fetchFirst();
+
+        return Optional.of(result);
+    }
 
     @Override
     public boolean existsByUserIdThatMonth(Long userId, LocalDate date) {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/service/TargetAmountService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/target/service/TargetAmountService.java
@@ -38,6 +38,11 @@ public class TargetAmountService {
     }
 
     @Transactional(readOnly = true)
+    public Optional<TargetAmount> readRecentTargetAmount(Long userId) {
+        return targetAmountRepository.findRecentOneByUserId(userId);
+    }
+
+    @Transactional(readOnly = true)
     public boolean isExistsTargetAmountThatMonth(Long userId, LocalDate date) {
         return targetAmountRepository.existsByUserIdThatMonth(userId, date);
     }

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/target/repository/RecentTargetAmountSearchTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/target/repository/RecentTargetAmountSearchTest.java
@@ -1,0 +1,94 @@
+package kr.co.pennyway.domain.domains.target.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.co.pennyway.domain.config.ContainerMySqlTestConfig;
+import kr.co.pennyway.domain.config.JpaConfig;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+@DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=create"})
+@ContextConfiguration(classes = JpaConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public class RecentTargetAmountSearchTest extends ContainerMySqlTestConfig {
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private TargetAmountRepository targetAmountRepository;
+    @Autowired
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    @MockBean
+    private JPAQueryFactory jpaQueryFactory;
+
+    @Test
+    @DisplayName("사용자의 가장 최근 목표 금액을 조회할 수 있다.")
+    @Transactional
+    public void 가장_최근_사용자_목표_금액_조회() {
+        // given
+        User user = userRepository.save(User.builder().username("jayang").name("Yang").phone("010-0000-0000").build());
+        bulkInsertTargetAmount(user);
+
+        // when - then
+        targetAmountRepository.findTopByUser_IdOrderByCreatedAtDesc(user.getId())
+                .ifPresentOrElse(
+                        targetAmount -> assertEquals(targetAmount.getAmount(), 30000),
+                        () -> Assertions.fail("최근 목표 금액이 존재하지 않습니다.")
+                );
+    }
+
+    private void bulkInsertTargetAmount(User user) {
+        Collection<MockTargetAmount> targetAmounts = getMockTargetAmounts();
+
+        String sql = String.format("""
+                INSERT INTO `%s` (amount, is_read, user_id, created_at, updated_at)
+                VALUES (:amount, true, :userId, :createdAt, :updatedAt)
+                """, "target_amount");
+        SqlParameterSource[] params = targetAmounts.stream()
+                .map(mockTargetAmount -> new MapSqlParameterSource()
+                        .addValue("amount", mockTargetAmount.amount)
+                        .addValue("userId", user.getId())
+                        .addValue("createdAt", mockTargetAmount.createdAt)
+                        .addValue("updatedAt", mockTargetAmount.updatedAt))
+                .toArray(SqlParameterSource[]::new);
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+
+    private Collection<MockTargetAmount> getMockTargetAmounts() {
+        return List.of(
+                MockTargetAmount.of(10000, true, LocalDateTime.of(2021, 1, 1, 0, 0, 0), LocalDateTime.of(2021, 1, 1, 0, 0, 0)),
+                MockTargetAmount.of(-1, false, LocalDateTime.of(2022, 3, 1, 0, 0, 0), LocalDateTime.of(2022, 3, 1, 0, 0, 0)),
+                MockTargetAmount.of(20000, true, LocalDateTime.of(2022, 5, 1, 0, 0, 0), LocalDateTime.of(2022, 5, 1, 0, 0, 0)),
+                MockTargetAmount.of(30000, true, LocalDateTime.of(2023, 7, 1, 0, 0, 0), LocalDateTime.of(2023, 7, 1, 0, 0, 0)),
+                MockTargetAmount.of(-1, false, LocalDateTime.of(2024, 1, 1, 0, 0, 0), LocalDateTime.of(2024, 1, 1, 0, 0, 0)),
+                MockTargetAmount.of(-1, true, LocalDateTime.of(2024, 2, 1, 0, 0, 0), LocalDateTime.of(2024, 2, 1, 0, 0, 0))
+        );
+    }
+
+    private record MockTargetAmount(int amount, boolean isRead, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        public static MockTargetAmount of(int amount, boolean isRead, LocalDateTime createdAt, LocalDateTime updatedAt) {
+            return new MockTargetAmount(amount, isRead, createdAt, updatedAt);
+        }
+    }
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/target/repository/RecentTargetAmountSearchTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/target/repository/RecentTargetAmountSearchTest.java
@@ -51,7 +51,7 @@ public class RecentTargetAmountSearchTest extends ContainerMySqlTestConfig {
         bulkInsertTargetAmount(user);
 
         // when - then
-        targetAmountRepository.findTopByUser_IdOrderByCreatedAtDesc(user.getId())
+        targetAmountRepository.findRecentOneByUserId(user.getId())
                 .ifPresentOrElse(
                         targetAmount -> assertEquals(targetAmount.getAmount(), 30000),
                         () -> Assertions.fail("최근 목표 금액이 존재하지 않습니다.")

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/target/repository/RecentTargetAmountSearchTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/target/repository/RecentTargetAmountSearchTest.java
@@ -1,8 +1,8 @@
 package kr.co.pennyway.domain.domains.target.repository;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.pennyway.domain.config.ContainerMySqlTestConfig;
 import kr.co.pennyway.domain.config.JpaConfig;
+import kr.co.pennyway.domain.config.TestJpaConfig;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ContextConfiguration(classes = JpaConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
+@Import(TestJpaConfig.class)
 public class RecentTargetAmountSearchTest extends ContainerMySqlTestConfig {
     @Autowired
     private UserRepository userRepository;
@@ -38,9 +39,6 @@ public class RecentTargetAmountSearchTest extends ContainerMySqlTestConfig {
     private TargetAmountRepository targetAmountRepository;
     @Autowired
     private NamedParameterJdbcTemplate jdbcTemplate;
-
-    @MockBean
-    private JPAQueryFactory jpaQueryFactory;
 
     @Test
     @DisplayName("사용자의 가장 최근 목표 금액을 조회할 수 있다.")


### PR DESCRIPTION
## 작업 이유

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/f0207dba-b899-4fab-8c3e-6464b1065f5a" width="350px"/>
</div>

- 사용자의 가장 최근 목표 금액을 조회하는 API 필요

<br/>

## 작업 사항

<div align="center">
   <img src="https://github.com/CollaBu/pennyway-was/assets/96044622/d3d6640c-096b-47e9-b1df-3a578b2fb327" width="700px"/>
</div>

- 시스템에 기록된 사용자의 가장 최근 목표 금액을 조회한다.
   - `amount`는 -1이 아니어야 한다.
- 당월 목표 금액 정보가 반환될 수도 있다.
   - 당월 목표 금액이 있는 상태에서 해당 API를 호출하는 건 있어서는 안 되는 경우라고 별도로 처리하지 않음.
- 응답 데이터에서 isPresent 필드를 사용해 amount 필드 여부를 확인할 수 있도록 함.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- isPresent 필드를 제거하고, 없으면 amount = -1을 넘길까 고민 중

<br/>

## 발견한 이슈
- 없음

