### PR TITLE
Api: ✏️ 문의하기 API content 글자 수 제한 및 사용자 이름 정규식 수정

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -64,7 +64,7 @@ public class SignUpReq {
             String username,
             @Schema(description = "이름", example = "페니웨이")
             @NotBlank(message = "이름을 입력해주세요")
-            @Pattern(regexp = "^[가-힣a-z]{2,8}$", message = "2~8자의 한글, 영문 소문자만 사용 가능합니다.")
+            @Pattern(regexp = "^[가-힣a-z0-9]{2,8}$", message = "2~8자의 한글, 영문 소문자, 숫자만 사용 가능합니다.")
             String name,
             @Schema(description = "비밀번호", example = "pennyway1234")
             @NotBlank(message = "비밀번호를 입력해주세요")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/question/dto/QuestionReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/question/dto/QuestionReq.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import kr.co.pennyway.domain.domains.question.domain.Question;
 import kr.co.pennyway.domain.domains.question.domain.QuestionCategory;
 
@@ -13,7 +14,7 @@ public record QuestionReq(
         @Email(message = "이메일 형식이 올바르지 않습니다.")
         String email,
         @Schema(description = "문의 내용", example = "문의 내용입니다.")
-        @NotBlank(message = "문의 내용을 입력해주세요")
+        @Size(min = 1, max = 5000, message = "문의 내용은 1자 이상 5000자 이하로 입력해주세요")
         String content,
         @Schema(description = "문의 카테고리", example = "UTILIZATION")
         @NotNull(message = "문의 카테고리를 입력해주세요")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileUpdateDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileUpdateDto.java
@@ -11,7 +11,7 @@ public class UserProfileUpdateDto {
     public record NameReq(
             @Schema(description = "이름", example = "페니웨이")
             @NotBlank(message = "이름을 입력해주세요")
-            @Pattern(regexp = "^[가-힣a-z]{2,8}$", message = "2~8자의 한글, 영문 소문자만 사용 가능합니다.")
+            @Pattern(regexp = "^[가-힣a-z0-9]{2,8}$", message = "2~8자의 한글, 영문 소문자, 숫자만 사용 가능합니다.")
             String name
     ) {
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthControllerValidationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthControllerValidationTest.java
@@ -101,11 +101,11 @@ public class AuthControllerValidationTest {
                 .andDo(print());
     }
 
-    @DisplayName("[3] 이름은 2~8자의 한글, 영문 소문자만 사용 가능합니다.")
+    @DisplayName("[3] 2~8자의 한글, 영문 소문자, 숫자만 사용 가능합니다.")
     @Test
     void nameValidError() throws Exception {
         // given
-        SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이1", "pennyway1234",
+        SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이12345", "pennyway1234",
                 "010-1234-5678", "123456");
 
         // when
@@ -118,7 +118,7 @@ public class AuthControllerValidationTest {
         // then
         resultActions
                 .andExpect(status().isUnprocessableEntity())
-                .andExpect(jsonPath("$.fieldErrors.name").value("2~8자의 한글, 영문 소문자만 사용 가능합니다."))
+                .andExpect(jsonPath("$.fieldErrors.name").value("2~8자의 한글, 영문 소문자, 숫자만 사용 가능합니다."))
                 .andDo(print());
     }
 
@@ -213,7 +213,7 @@ public class AuthControllerValidationTest {
     @Test
     void signUp() throws Exception {
         // given
-        SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이", "pennyway1234",
+        SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이123", "pennyway1234",
                 "010-1234-5678", "123456");
         ResponseCookie expectedCookie = ResponseCookie.from("refreshToken", "refreshToken")
                 .maxAge(Duration.ofDays(7).toSeconds()).httpOnly(true).path("/").build();

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/question/controller/QuestionControllerTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/question/controller/QuestionControllerTest.java
@@ -65,7 +65,7 @@ public class QuestionControllerTest {
         resultActions
                 .andExpect(status().isUnprocessableEntity())
                 .andExpect(jsonPath("$.fieldErrors.email").value("이메일을 입력해주세요"))
-                .andExpect(jsonPath("$.fieldErrors.content").value("문의 내용을 입력해주세요"))
+                .andExpect(jsonPath("$.fieldErrors.content").value("문의 내용은 1자 이상 5000자 이하로 입력해주세요"))
                 .andDo(print());
     }
 
@@ -125,6 +125,28 @@ public class QuestionControllerTest {
         // then
         resultActions
                 .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("[5] 이메일, 내용을 필수로 입력해야 합니다.")
+    void sendLargeQuestion() throws Exception {
+
+        // given
+        String content = "a".repeat(5001);
+        QuestionReq request = new QuestionReq("team.collabu@gmail.com", content, QuestionCategory.ETC);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/v1/questions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.fieldErrors.content").value("문의 내용은 1자 이상 5000자 이하로 입력해주세요"))
                 .andDo(print());
     }
 }


### PR DESCRIPTION
## 작업 이유
문의하기 API에 글자수 상한 제한이 없어 추가 및 사용자 이름 정규표현식 수정

<br/>

## 작업 사항
`QuestionReq` dto 수정
글자수 상한 에러 발생 테스트 작성
`SignUpReq`, `UserProfileUpdateDto` 수정

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
`@Size` 어노테이션의 사용이 적절한지?

<br/>

## 발견한 이슈
X

