### PR TITLE
Api: 🐛 월별 지출내역 조회 쿼리 버그 수정

### DIFF
--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomRepositoryImpl.java
@@ -51,10 +51,11 @@ public class SpendingCustomRepositoryImpl implements SpendingCustomRepository {
         List<OrderSpecifier<?>> orderSpecifiers = QueryDslUtil.getOrderSpecifier(sort);
 
         return queryFactory.selectFrom(spending)
-                .leftJoin(spending.user, user)
                 .leftJoin(spending.spendingCustomCategory, spendingCustomCategory).fetchJoin()
                 .where(spending.spendAt.year().eq(year)
-                        .and(spending.spendAt.month().eq(month)))
+                        .and(spending.spendAt.month().eq(month))
+                        .and(spending.user.id.eq(userId))
+                )
                 .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
                 .fetch();
     }


### PR DESCRIPTION
## 작업 이유
기존 월별 지출내역 조회에 user_id 를 검증하는 `WHERE` 절의 누락으로 인해 로그인된 사용자의 지출내역 뿐만이 아닌 다른 사용자의 데이터까지 조회 해오는 문제 발생.

<br/>

## 작업 사항
`WHERE`절과 필요 없는 `LEFT JOIN`절 제거

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
**쿼리문이 이번엔 적절한지?** 😢

로그인된 사용자의 지출내역 == 조회한 지출내역을 검증하는 테스트의 작성이 필요할까요?
혹시나 찝찝하다면 작성 후 병합 하겠습니다 :)

<br/>

## 발견한 이슈
X
