### PR TITLE
Api: 🐛 N+1 문제 개선 테스트의 간헐적 실패문제 수정

### DIFF
--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingControllerIntegrationTest.java
@@ -133,7 +133,7 @@ public class SpendingControllerIntegrationTest extends ExternalApiDBTestConfig {
         void getSpendingListAtYearAndMonthSuccess() throws Exception {
             // given
             User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
-            SpendingFixture.bulkInsertSpending(user, 150, false, jdbcTemplate);
+            SpendingFixture.bulkInsertSpending(user, 150, 0L, jdbcTemplate);
 
             // when
             long before = System.currentTimeMillis();

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/TargetAmountIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/TargetAmountIntegrationTest.java
@@ -114,7 +114,7 @@ public class TargetAmountIntegrationTest extends ExternalApiDBTestConfig {
         void getTargetAmountAndTotalSpending() throws Exception {
             // given
             User user = createUserWithCreatedAt(LocalDateTime.now().minusYears(2), jdbcTemplate);
-            SpendingFixture.bulkInsertSpending(user, 300, false, jdbcTemplate);
+            SpendingFixture.bulkInsertSpending(user, 300, 0L, jdbcTemplate);
             TargetAmountFixture.bulkInsertTargetAmount(user, jdbcTemplate);
 
             // when
@@ -156,7 +156,7 @@ public class TargetAmountIntegrationTest extends ExternalApiDBTestConfig {
         void getTargetAmountsAndTotalSpendings() throws Exception {
             // given
             User user = createUserWithCreatedAt(LocalDateTime.now().minusYears(2).plusMonths(2), jdbcTemplate);
-            SpendingFixture.bulkInsertSpending(user, 300, false, jdbcTemplate);
+            SpendingFixture.bulkInsertSpending(user, 300, 0L, jdbcTemplate);
             TargetAmountFixture.bulkInsertTargetAmount(user, jdbcTemplate);
 
             // when

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/SpendingCustomCategoryFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/SpendingCustomCategoryFixture.java
@@ -3,13 +3,6 @@ package kr.co.pennyway.api.config.fixture;
 import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
 import kr.co.pennyway.domain.domains.spending.type.SpendingCategory;
 import kr.co.pennyway.domain.domains.user.domain.User;
-import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.jdbc.core.namedparam.SqlParameterSource;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 public enum SpendingCustomCategoryFixture {
     GENERAL_SPENDING_CUSTOM_CATEGORY("일반카테고리", SpendingCategory.FOOD);
@@ -20,28 +13,6 @@ public enum SpendingCustomCategoryFixture {
     SpendingCustomCategoryFixture(String name, SpendingCategory icon) {
         this.name = name;
         this.icon = icon;
-    }
-
-    public static void bulkInsertCustomCategory(User user, int capacity, NamedParameterJdbcTemplate jdbcTemplate) {
-        Collection<SpendingCustomCategory> customCategories = getCustomCategories(user, capacity);
-
-        String sql = String.format("""
-                INSERT INTO `%s` (name, icon, user_id, created_at, updated_at, deleted_at)
-                VALUES (:name, 1, :user.id, NOW(), NOW(), null)
-                """, "spending_custom_category");
-        SqlParameterSource[] params = customCategories.stream()
-                .map(BeanPropertySqlParameterSource::new)
-                .toArray(SqlParameterSource[]::new);
-        jdbcTemplate.batchUpdate(sql, params);
-    }
-
-    private static List<SpendingCustomCategory> getCustomCategories(User user, int capacity) {
-        List<SpendingCustomCategory> customCategories = new ArrayList<>(capacity);
-
-        for (int i = 0; i < capacity; i++) {
-            customCategories.add(SpendingCustomCategoryFixture.GENERAL_SPENDING_CUSTOM_CATEGORY.toCustomSpendingCategory(user));
-        }
-        return customCategories;
     }
 
     public SpendingCustomCategory toCustomSpendingCategory(User user) {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/SpendingFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/SpendingFixture.java
@@ -39,15 +39,22 @@ public enum SpendingFixture {
         return new SpendingReq(10000, -1L, SpendingCategory.FOOD, LocalDate.now(), "카페인 수혈", "아메리카노 1잔");
     }
 
-    public static void bulkInsertSpending(User user, int capacity, boolean isCustom, NamedParameterJdbcTemplate jdbcTemplate) {
+    /**
+     * Spending 객체들을 벌크연산으로 삽입한다.
+     *
+     * @param user             {@link User} Spending 객체의 사용자
+     * @param capacity         {@link Integer} 생성할 Spending 객체의 개수
+     * @param customCategoryId {@link Long} Spending 객체의 customCategoryId. 기본 카테고리를 가질시 0이 된다.
+     * @param jdbcTemplate     {@link NamedParameterJdbcTemplate} Spending 객체를 생성할 때 사용할 jdbcTemplate
+     */
+    public static void bulkInsertSpending(User user, int capacity, Long customCategoryId, NamedParameterJdbcTemplate jdbcTemplate) {
         Collection<Spending> spendings = getRandomSpendings(user, capacity);
         String sql;
-        if (isCustom) {
-            SpendingCustomCategoryFixture.bulkInsertCustomCategory(user, capacity, jdbcTemplate);
+        if (!customCategoryId.equals(0L)) {
             sql = String.format("""
                     INSERT INTO `%s` (amount, category, spend_at, account_name, memo, user_id, spending_custom_category_id, created_at, updated_at, deleted_at)
-                    VALUES (:amount, 1+FLOOR(RAND()*11), :spendAt, :accountName, :memo, :user.id, 1 + FLOOR(RAND() * %d), NOW(), NOW(), null)
-                    """, "spending", capacity);
+                    VALUES (:amount, 1+FLOOR(RAND()*11), :spendAt, :accountName, :memo, :user.id, %d, NOW(), NOW(), null)
+                    """, "spending", customCategoryId);
         } else {
             sql = String.format("""
                     INSERT INTO `%s` (amount, category, spend_at, account_name, memo, user_id, spending_custom_category_id, created_at, updated_at, deleted_at)


### PR DESCRIPTION
## 작업 이유
CI 환경에서 `SpendingSearchServiceTest.java`의 간헐적 테스트 실패가 확인되어 이슈 체크 및 수정의 필요성 대두.

<br/>

## 작업 사항
### 에러 발생 원인
![image](https://github.com/CollaBu/pennyway-was/assets/79460319/43a2e5c3-d4a0-4042-8577-e5ffd7ee3adf)
원인은 일단 **외래키 제약조건**의 위반이었습니다.

`Spending` 객체가 `SpendingCustomCategory` 테이블에 존재하지 않는 id를 spending_custom_category필드의 값으로 가지게 되면서 위반되었던 것이었습니다.

### 문제 되는 부분
> 코드를 다 때려 넣어서 설명하다가 너무 복잡해서 간단하게 줄였습니다.

- `SpendingSearchServiceTest.java`에서 테스트를 위해 커스텀 카테고리를 가지는 `Spending` 객체들을 bulkInsert하는 과정이 존재하는데, 이를 수행하기 위해서는 먼저 커스텀 카테고리들을 DB에 생성해 주어야 함.
- 이 때문에 `SpendingCustomCategoryFixture` 에서 커스텀 카테고리를 capacity 개 만큼 DB에 bulkInsert 함.
- 그 후, capacity 만큼의 `Spending`들을 DB에 저장함. 이때 CustomCategory 필드에 들어갈 id(외래키) 값은 {1~capacity}사이에서 **랜덤으로** 뽑았음. `1 + FLOOR(RAND() * %d)`

 1\~capacity 사이의 값들에서 랜덤으로 뽑는 과정이 무엇인가 잘못 된 것 같은데, 제가 직접 찍어본 결과 잘못될 수가 없습니다...
분명히 capacity 개의 커스텀 카테고리들이 저장되고, `Spending` 객체들을 생성할때는 1\~capacity 사이의 id를 사용하는데 여기서 없는 id를 참조할 일이 없는데 말이죠.. (아마 이건 저번에 언급한 병렬실행과 무엇인가 관련이 있는 것 같습니다..)

결국 그래서 저는 기존 코드의 문제점을 찾지 못했습니다....만!
일단은 전에 @psychology50 님이 한번 언급해주셨던 것 처럼 랜덤이 필요없는 곳에 굳이 랜덤을 넣은것이 화근이라고 생각해 
 fetch테스트의 목적성을 유지함과 동시에 랜덤으로 customCategoryId를 넣어주는 부분을 변경해 **외래키 제약조건이 위반될 여지를 완전히 제거**했습니다.

그에따라 `bulkInsertSpending`메소드 사용하는 방법이 변경되었고, 이는 javaDoc으로 명시해 두었습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
`SpendingFixture.java`에서 bulkInsertSpending 메소드만 봐주시면 됩니다.

일단 이것도 가장 크게 의심되는 부분을 제거한 것일 뿐이지, 로컬에서는 실패하는일 없이 계속 성공해서 병합 후 지켜 보아야 할 듯 합니다.... :cry:

#119 PR은 본 PR merge이후에 merge하겠습니다~~

<br/>

## 발견한 이슈
X

