### PR TITLE
Api: ✨ 사용자 정의 카테고리 삭제 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingCategoryApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingCategoryApi.java
@@ -46,7 +46,7 @@ public interface SpendingCategoryApi {
                             """
             )
     }))
-    ResponseEntity<?> deleteSpendingCategory(@PathVariable Long categoryId, @AuthenticationPrincipal SecurityUserDetails user);
+    ResponseEntity<?> deleteSpendingCategory(@PathVariable Long categoryId);
 }
 
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingCategoryApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/api/SpendingCategoryApi.java
@@ -12,6 +12,7 @@ import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "지출 카테고리 API")
 public interface SpendingCategoryApi {
@@ -32,4 +33,20 @@ public interface SpendingCategoryApi {
     @Operation(summary = "사용자 정의 지출 카테고리 조회", method = "GET", description = "사용자가 생성한 지출 카테고리 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "지출 카테고리 조회 성공", content = @Content(mediaType = "application/json", schemaProperties = @SchemaProperty(name = "spendingCategories", array = @ArraySchema(schema = @Schema(implementation = SpendingCategoryDto.Res.class)))))
     ResponseEntity<?> getSpendingCategories(@AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "사용자 정의 카테고리 삭제", method = "DELETE", description = "사용자가 생성한 지출 카테고리를 삭제합니다.")
+    @Parameter(name = "categoryId", description = "카테고리 ID", example = "1", required = true, in = ParameterIn.PATH)
+    @ApiResponse(responseCode = "403", description = "지출 카테고리에 대한 권한이 없습니다.", content = @Content(examples = {
+            @ExampleObject(name = "지출 카테고리 권한 오류", description = "지출 카테고리에 대한 권한이 없습니다.",
+                    value = """ 
+                            {
+                            "code": "4030",
+                            "message": "ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN"
+                            }
+                            """
+            )
+    }))
+    ResponseEntity<?> deleteSpendingCategory(@PathVariable Long categoryId, @AuthenticationPrincipal SecurityUserDetails user);
 }
+
+

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
@@ -44,8 +44,8 @@ public class SpendingCategoryController implements SpendingCategoryApi {
 
     @Override
     @DeleteMapping("/{categoryId}")
-    @PreAuthorize("isAuthenticated() and @spendingCategoryManager.hasPermission(#user.getUserId(), #categoryId)")
-    public ResponseEntity<?> deleteSpendingCategory(@PathVariable Long categoryId, @AuthenticationPrincipal SecurityUserDetails user) {
+    @PreAuthorize("isAuthenticated() and @spendingCategoryManager.hasPermission(principal.userId, #categoryId)")
+    public ResponseEntity<?> deleteSpendingCategory(@PathVariable Long categoryId) {
         spendingCategoryUseCase.deleteSpendingCategory(categoryId);
 
         return ResponseEntity.ok(SuccessResponse.noContent());

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
@@ -54,6 +54,7 @@ public class SpendingCategoryController implements SpendingCategoryApi {
         spendingCategoryUseCase.deleteSpendingCategory(categoryId);
 
         return ResponseEntity.ok(SuccessResponse.noContent());
+    }
 
     @GetMapping("/{categoryId}/spendings/count")
     @PreAuthorize("isAuthenticated() and @spendingCategoryManager.hasPermission(#user.getUserId(), #categoryId, #type)")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
@@ -14,10 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -43,5 +40,13 @@ public class SpendingCategoryController implements SpendingCategoryApi {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getSpendingCategories(@AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from("spendingCategories", spendingCategoryUseCase.getSpendingCategories(user.getUserId())));
+    }
+
+    @DeleteMapping("/{categoryId}")
+    @PreAuthorize("isAuthenticated() and @spendingCategoryManager.hasPermission(#user.getUserId(), #categoryId)")
+    public ResponseEntity<?> deleteSpendingCategory(@PathVariable Long categoryId, @AuthenticationPrincipal SecurityUserDetails user) {
+        spendingCategoryUseCase.deleteSpendingCategory(categoryId);
+
+        return ResponseEntity.ok(SuccessResponse.noContent());
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/controller/SpendingCategoryController.java
@@ -42,6 +42,7 @@ public class SpendingCategoryController implements SpendingCategoryApi {
         return ResponseEntity.ok(SuccessResponse.from("spendingCategories", spendingCategoryUseCase.getSpendingCategories(user.getUserId())));
     }
 
+    @Override
     @DeleteMapping("/{categoryId}")
     @PreAuthorize("isAuthenticated() and @spendingCategoryManager.hasPermission(#user.getUserId(), #categoryId)")
     public ResponseEntity<?> deleteSpendingCategory(@PathVariable Long categoryId, @AuthenticationPrincipal SecurityUserDetails user) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/SpendingCategoryDeleteService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/SpendingCategoryDeleteService.java
@@ -1,0 +1,22 @@
+package kr.co.pennyway.api.apis.ledger.service;
+
+import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
+import kr.co.pennyway.domain.domains.spending.service.SpendingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SpendingCategoryDeleteService {
+    private final SpendingCustomCategoryService spendingCustomCategoryService;
+    private final SpendingService spendingService;
+
+    @Transactional
+    public void execute(Long categoryId) {
+        spendingService.deleteSpendingsByCategoryIdInQuery(categoryId);
+        spendingCustomCategoryService.deleteSpendingCustomCategory(categoryId);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingCategoryUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingCategoryUseCase.java
@@ -3,8 +3,8 @@ package kr.co.pennyway.api.apis.ledger.usecase;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
 import kr.co.pennyway.api.apis.ledger.dto.SpendingSearchRes;
 import kr.co.pennyway.api.apis.ledger.mapper.SpendingCategoryMapper;
-import kr.co.pennyway.api.apis.ledger.service.SpendingCategoryDeleteService;
 import kr.co.pennyway.api.apis.ledger.mapper.SpendingMapper;
+import kr.co.pennyway.api.apis.ledger.service.SpendingCategoryDeleteService;
 import kr.co.pennyway.api.apis.ledger.service.SpendingCategorySaveService;
 import kr.co.pennyway.api.apis.ledger.service.SpendingCategorySearchService;
 import kr.co.pennyway.api.apis.ledger.service.SpendingSearchService;
@@ -48,7 +48,8 @@ public class SpendingCategoryUseCase {
     @Transactional
     public void deleteSpendingCategory(Long categoryId) {
         spendingCategoryDeleteService.execute(categoryId);
-    
+    }
+
     @Transactional(readOnly = true)
     public int getSpendingTotalCountByCategory(Long userId, Long categoryId, SpendingCategoryType type) {
         return spendingSearchService.readSpendingTotalCountByCategoryId(userId, categoryId, type);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingCategoryUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/SpendingCategoryUseCase.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.ledger.usecase;
 
 import kr.co.pennyway.api.apis.ledger.dto.SpendingCategoryDto;
 import kr.co.pennyway.api.apis.ledger.mapper.SpendingCategoryMapper;
+import kr.co.pennyway.api.apis.ledger.service.SpendingCategoryDeleteService;
 import kr.co.pennyway.api.apis.ledger.service.SpendingCategorySaveService;
 import kr.co.pennyway.api.apis.ledger.service.SpendingCategorySearchService;
 import kr.co.pennyway.common.annotation.UseCase;
@@ -19,6 +20,7 @@ import java.util.List;
 public class SpendingCategoryUseCase {
     private final SpendingCategorySaveService spendingCategorySaveService;
     private final SpendingCategorySearchService spendingCategorySearchService;
+    private final SpendingCategoryDeleteService spendingCategoryDeleteService;
 
     @Transactional
     public SpendingCategoryDto.Res createSpendingCategory(Long userId, String categoryName, SpendingCategory icon) {
@@ -32,5 +34,10 @@ public class SpendingCategoryUseCase {
         List<SpendingCustomCategory> categories = spendingCategorySearchService.readSpendingCustomCategories(userId);
 
         return SpendingCategoryMapper.toResponses(categories);
+    }
+
+    @Transactional
+    public void deleteSpendingCategory(Long categoryId) {
+        spendingCategoryDeleteService.execute(categoryId);
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingCategoryIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/SpendingCategoryIntegrationTest.java
@@ -1,0 +1,74 @@
+package kr.co.pennyway.api.apis.ledger.integration;
+
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
+import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
+import kr.co.pennyway.api.config.fixture.SpendingCustomCategoryFixture;
+import kr.co.pennyway.api.config.fixture.SpendingFixture;
+import kr.co.pennyway.api.config.fixture.UserFixture;
+import kr.co.pennyway.domain.domains.spending.domain.Spending;
+import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
+import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
+import kr.co.pennyway.domain.domains.spending.service.SpendingService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+@ExternalApiIntegrationTest
+@AutoConfigureMockMvc
+public class SpendingCategoryIntegrationTest extends ExternalApiDBTestConfig {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private SpendingService spendingService;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private SpendingCustomCategoryService spendingCustomCategoryService;
+
+    @Test
+    @DisplayName("사용자 정의 지출 카테고리를 삭제하고, 삭제된 카테고리를 가지는 지출 내역 또한 삭제된다.")
+    @Transactional
+    void deleteSpendingCustomCategory() throws Exception {
+        // given
+        User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
+        SpendingCustomCategory spendingCustomCategory = spendingCustomCategoryService.createSpendingCustomCategory(SpendingCustomCategoryFixture.GENERAL_SPENDING_CUSTOM_CATEGORY.toCustomSpendingCategory(user));
+        Spending spending = spendingService.createSpending(SpendingFixture.CUSTOM_CATEGORY_SPENDING.toCustomCategorySpending(user, spendingCustomCategory));
+
+        // when
+        ResultActions resultActions = performDeleteSpendingCategory(spendingCustomCategory.getId(), user);
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        Assertions.assertTrue(spendingCustomCategoryService.readSpendingCustomCategory(spendingCustomCategory.getId()).isEmpty());
+        Assertions.assertTrue(spendingService.readSpending(spending.getId()).isEmpty());
+    }
+
+    private ResultActions performDeleteSpendingCategory(Long categoryId, User requestUser) throws Exception {
+        UserDetails userDetails = SecurityUserDetails.from(requestUser);
+
+        return mockMvc.perform(MockMvcRequestBuilders.delete("/v2/spending-categories/{categoryId}", categoryId)
+                .with(user(userDetails)));
+    }
+
+
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingRepository.java
@@ -17,7 +17,7 @@ public interface SpendingRepository extends ExtendedRepository<Spending, Long>, 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Spending s SET s.deletedAt = NOW() WHERE s.spendingCustomCategory.id = :categoryId AND s.deletedAt IS NULL")
     void deleteAllByCategoryIdAndDeletedAtNullInQuery(Long categoryId);
-}
+
     @Transactional(readOnly = true)
     int countByUser_IdAndSpendingCustomCategory_Id(Long userId, Long categoryId);
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingRepository.java
@@ -2,9 +2,16 @@ package kr.co.pennyway.domain.domains.spending.repository;
 
 import kr.co.pennyway.domain.common.repository.ExtendedRepository;
 import kr.co.pennyway.domain.domains.spending.domain.Spending;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface SpendingRepository extends ExtendedRepository<Spending, Long>, SpendingCustomRepository {
     @Transactional(readOnly = true)
     boolean existsByIdAndUser_Id(Long id, Long userId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Spending s SET s.deletedAt = NOW() WHERE s.spendingCustomCategory.id = :categoryId AND s.deletedAt IS NULL")
+    void deleteAllByCategoryIdAndDeletedAtNullInQuery(Long categoryId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
@@ -35,4 +35,9 @@ public class SpendingCustomCategoryService {
     public boolean isExistsSpendingCustomCategory(Long userId, Long categoryId) {
         return spendingCustomCategoryRepository.existsByIdAndUser_Id(categoryId, userId);
     }
+
+    @Transactional
+    public void deleteSpendingCustomCategory(Long categoryId) {
+        spendingCustomCategoryRepository.deleteById(categoryId);
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
@@ -66,6 +66,11 @@ public class SpendingService {
         return spendingRepository.selectList(predicate, TotalSpendingAmount.class, bindings, queryHandler, sort);
     }
 
+    @Transactional
+    public void deleteSpendingsByCategoryIdInQuery(Long categoryId) {
+        spendingRepository.deleteAllByCategoryIdAndDeletedAtNullInQuery(categoryId);
+    }
+
     @Transactional(readOnly = true)
     public boolean isExistsSpending(Long userId, Long spendingId) {
         return spendingRepository.existsByIdAndUser_Id(spendingId, userId);


### PR DESCRIPTION
## 작업 이유
- 사용자는 사용자 지정 카테고리를 삭제할 수 있다.

<br/>

## 작업 사항
### API Spec
- url : `DELETE /v2/spending-categories/{categoryId}`
- pre-condition : 사용자는 로그인 한 상태이고, 삭제하고자 하는 사용자 정의 카테고리의 작성자여야 한다.

결과 응답
```json
{
  "code" : "2000",
  "data" : { }
}
```

### 테스트 결과
![image](https://github.com/CollaBu/pennyway-was/assets/79460319/752e3792-6b74-42b8-86e6-f6bd1e93bdd1)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
`@OnDelete`등과 같은 방법을 통해 DDL을 통한 연쇄 삭제를 사용할 것인지 아니면 비즈니스 로직에서 직접 연쇄 삭제를 구현해야 할지 고민하다가 일단은 조금더 명시적인 방법인 후자를 택했습니다.

어떤 방법이 더 좋을지 의견주시면 의논 후 반영토록 하겠습니다.

<br/>

## 발견한 이슈
단위 테스트를 작성해보려 했으나... **삭제 행위**에 있어서 단위테스트가 의미가 없다고 판단했습니다.
삭제 동작 같은 경우에는 **실제로 DB에서 데이터가 제거가 되었는지?** 가 중심적인 관심사인데, 단위 테스트를 진행하면 Mock 객체의 동작(여기서는 DAO계층의 동작) 결과를 개발자가 전부 직접 제공해주어야 하기 때문입니다.

혹시나 이런 상황에서 의미있는 단위테스트를 작성할 수 있는 방법이 있으면 알려주시면 감사하겠습니다 :)
