### PR TITLE
Api: 🐛 목표 금액 DELETE 유즈 케이스 잘못된 필터링 제거

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/TargetAmountDeleteService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/TargetAmountDeleteService.java
@@ -16,7 +16,6 @@ public class TargetAmountDeleteService {
     @Transactional
     public void execute(Long targetAmountId) {
         TargetAmount targetAmount = targetAmountService.readTargetAmount(targetAmountId)
-                .filter(TargetAmount::isAllocatedAmount)
                 .orElseThrow(() -> new TargetAmountErrorException(TargetAmountErrorCode.NOT_FOUND_TARGET_AMOUNT));
 
         if (!targetAmount.isThatMonth()) {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/TargetAmountIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/TargetAmountIntegrationTest.java
@@ -27,6 +27,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -270,18 +271,21 @@ public class TargetAmountIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @DisplayName("당월 목표 금액 pk에 대한 접근 권한이 있지만, amount가 이미 -1인 경우 404 Not Found 에러 응답을 반환한다.")
-        @Transactional
+        @DisplayName("당월 목표 금액 pk에 대한 접근 권한이 있으며, amount == -1이어도 isRead가 true로 변경된다.")
         void deleteTargetAmountNotFound() throws Exception {
             // given
             User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
             TargetAmount targetAmount = targetAmountService.createTargetAmount(TargetAmount.of(-1, user));
+            Long targetAmountId = targetAmount.getId();
 
             // when
             ResultActions result = performDeleteTargetAmount(targetAmount.getId(), user);
 
             // then
-            result.andDo(print()).andExpect(status().isNotFound());
+            result.andDo(print()).andExpect(status().isOk());
+            TargetAmount deletedTargetAmount = targetAmountService.readTargetAmount(targetAmountId).orElseThrow();
+            assertEquals(-1, deletedTargetAmount.getAmount());
+            assertTrue(deletedTargetAmount.isRead());
         }
 
         @Test


### PR DESCRIPTION
## 작업 이유
- iOS 팀에서 추천할 최근 목표 금액이 없을 시, DELETE 요청을 수행하면 404 NOT FOUND 예외 발생

<br/>

## 작업 사항
```java
TargetAmount targetAmount = targetAmountService.readTargetAmount(targetAmountId)
                .filter(TargetAmount::isAllocatedAmount)
                .orElseThrow(() -> new TargetAmountErrorException(TargetAmountErrorCode.NOT_FOUND_TARGET_AMOUNT));
```
기존에는 "amount == -1", 즉 목표 금액이 설정되어 있지 않는 데이터를 필터링해도 무방했습니다.  
하지만 목표 금액에 `is_read`라는 필드가 추가되면서, 목표 금액이 할당되어 있지 않을 때에서 is_read를 false로 바꾸기 위해 DELETE 요청을 보내는 Usecase가 추가되었습니다.  

따라서 filter를 제거하여 요청을 성공적으로 처리하도록 수정했습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음

<br/>

## 발견한 이슈
- 없음
