### PR TITLE
Api: ✏️ 총 지출 총합 값의 정수 범위 초과 케이스를 고려하여 타입 수정

### DIFF
--- a/.github/workflows/open-api-code-review.yml
+++ b/.github/workflows/open-api-code-review.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   pull_request:
-    types: [ opened, synchronize ]
+    types: [ opened ]
 
 jobs:
   test:

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingSearchRes.java
@@ -51,7 +51,7 @@ public class SpendingSearchRes {
             @Schema(description = "일")
             int day,
             @Schema(description = "일별 총 지출 금액")
-            int dailyTotalAmount,
+            long dailyTotalAmount,
             @Schema(description = "개별 지출 내역")
             List<Individual> individuals
     ) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/TargetAmountDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/TargetAmountDto.java
@@ -84,23 +84,23 @@ public class TargetAmountDto {
             @JsonInclude(JsonInclude.Include.NON_DEFAULT)
             int month,
             @Schema(description = "최근 목표 금액 정보. isPresent가 false인 경우 필드가 존재하지 않는다.", requiredMode = Schema.RequiredMode.REQUIRED)
-            @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-            int amount
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Integer amount
     ) {
         public RecentTargetAmountRes {
             if (!isPresent) {
                 assert year == 0;
                 assert month == 0;
-                assert amount == 0;
+                assert amount == null;
             }
         }
 
         public static RecentTargetAmountRes notPresent() {
-            return new RecentTargetAmountRes(false, 0, 0, 0);
+            return new RecentTargetAmountRes(false, 0, 0, null);
         }
 
         public static RecentTargetAmountRes of(int year, int month, int amount) {
-            return (amount == -1) ? new RecentTargetAmountRes(false, 0, 0, 0) : new RecentTargetAmountRes(true, year, month, amount);
+            return (amount == -1) ? new RecentTargetAmountRes(false, 0, 0, null) : new RecentTargetAmountRes(true, year, month, amount);
         }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/TargetAmountDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/TargetAmountDto.java
@@ -78,29 +78,29 @@ public class TargetAmountDto {
             @Schema(description = "최근 목표 금액 존재 여부로써 데이터가 존재하지 않으면 false, 존재하면 true", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
             boolean isPresent,
             @Schema(description = "최근 목표 금액 년도 정보. isPresent가 false인 경우 필드가 존재하지 않는다.", example = "2024", requiredMode = Schema.RequiredMode.REQUIRED)
-            @JsonInclude(JsonInclude.Include.NON_NULL)
-            Integer year,
+            @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+            int year,
             @Schema(description = "최근 목표 금액 월 정보. isPresent가 false인 경우 필드가 존재하지 않는다.", example = "6", requiredMode = Schema.RequiredMode.REQUIRED)
-            @JsonInclude(JsonInclude.Include.NON_NULL)
-            Integer month,
+            @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+            int month,
             @Schema(description = "최근 목표 금액 정보. isPresent가 false인 경우 필드가 존재하지 않는다.", requiredMode = Schema.RequiredMode.REQUIRED)
-            @JsonInclude(JsonInclude.Include.NON_NULL)
-            Integer amount
+            @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+            int amount
     ) {
         public RecentTargetAmountRes {
             if (!isPresent) {
-                assert year == null;
-                assert month == null;
-                assert amount == null;
+                assert year == 0;
+                assert month == 0;
+                assert amount == 0;
             }
         }
 
         public static RecentTargetAmountRes notPresent() {
-            return new RecentTargetAmountRes(false, null, null, null);
+            return new RecentTargetAmountRes(false, 0, 0, 0);
         }
 
-        public static RecentTargetAmountRes of(Integer year, Integer month, Integer amount) {
-            return (amount.equals(-1)) ? new RecentTargetAmountRes(false, null, null, null) : new RecentTargetAmountRes(true, year, month, amount);
+        public static RecentTargetAmountRes of(int year, int month, int amount) {
+            return (amount == -1) ? new RecentTargetAmountRes(false, 0, 0, 0) : new RecentTargetAmountRes(true, year, month, amount);
         }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/TargetAmountDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/TargetAmountDto.java
@@ -17,9 +17,8 @@ public class TargetAmountDto {
     @Schema(title = "목표 금액의 amount 유효성 검사를 위한 요청 파라미터", hidden = true)
     public record AmountParam(
             @Schema(description = "등록하려는 목표 금액 (0이상의 정수)", example = "100000", requiredMode = Schema.RequiredMode.REQUIRED)
-            @NotNull(message = "amount 값은 필수입니다.")
             @Min(value = 0, message = "amount 값은 0 이상이어야 합니다.")
-            Integer amount
+            int amount
     ) {
 
     }
@@ -40,44 +39,28 @@ public class TargetAmountDto {
     @Schema(title = "목표 금액 및 총 지출 금액 조회 응답")
     public record WithTotalSpendingRes(
             @Schema(description = "조회 년도", example = "2024", requiredMode = Schema.RequiredMode.REQUIRED)
-            @NotNull(message = "year 값은 필수입니다.")
-            Integer year,
+            int year,
             @Schema(description = "조회 월", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
-            @NotNull(message = "month 값은 필수입니다.")
-            Integer month,
+            int month,
             @Schema(description = "목표 금액", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotNull(message = "targetAmountDetail 값은 필수입니다.")
             TargetAmountInfo targetAmountDetail,
             @Schema(description = "총 지출 금액", example = "100000", requiredMode = Schema.RequiredMode.REQUIRED)
-            @NotNull(message = "totalSpending 값은 필수입니다.")
-            Integer totalSpending,
+            long totalSpending,
             @Schema(description = "목표 금액과 총 지출 금액의 차액(총 치줄 금액 - 목표 금액). 양수면 초과, 음수면 절약", example = "-50000", requiredMode = Schema.RequiredMode.REQUIRED)
-            @NotNull(message = "diffAmount 값은 필수입니다.")
-            Integer diffAmount
+            long diffAmount
     ) {
     }
 
     @Schema(title = "목표 금액 상세 정보")
     public record TargetAmountInfo(
             @Schema(description = "목표 금액 pk. 실제 저장된 데이터가 아니라면 -1", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-            @NotNull(message = "id 값은 필수입니다.")
-            Long id,
+            long id,
             @Schema(description = "목표 금액. -1이면 설정한 목표 금액이 존재하지 않음을 의미한다.", example = "50000", requiredMode = Schema.RequiredMode.REQUIRED)
-            @NotNull(message = "amount 값은 필수입니다.")
-            Integer amount,
+            int amount,
             @Schema(description = "사용자 확인 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
             boolean isRead
     ) {
-        public TargetAmountInfo {
-            if (id == null) {
-                id = -1L;
-            }
-
-            if (amount == null) {
-                amount = -1;
-            }
-        }
-
         /**
          * {@link TargetAmount} -> {@link TargetAmountInfo} 변환하는 메서드 <br/>
          * 만약, 인자로 들어온 값이 null이라면 모든 값을 -1로 초기화한 더미 데이터를 반환한다.

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/SpendingMapper.java
@@ -84,7 +84,7 @@ public class SpendingMapper {
     /**
      * 하루 지출 내역의 총 금액을 계산하는 메서드
      */
-    private static int calculateDailyTotalAmount(List<Spending> spendings) {
-        return spendings.stream().mapToInt(Spending::getAmount).sum();
+    private static long calculateDailyTotalAmount(List<Spending> spendings) {
+        return spendings.stream().mapToLong(Spending::getAmount).sum();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/TargetAmountMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/TargetAmountMapper.java
@@ -109,6 +109,6 @@ public class TargetAmountMapper {
      * @param valueMapper : Value로 변환할 Function
      */
     private static <T, U> Map<YearMonth, U> toYearMonthMap(List<T> list, Function<T, YearMonth> keyMapper, Function<T, U> valueMapper) {
-        return list.stream().collect(Collectors.toMap(keyMapper, valueMapper, (existing, replacement) -> existing));
+        return list.stream().collect(Collectors.toConcurrentMap(keyMapper, valueMapper, (existing, replacement) -> existing));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/TargetAmountMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/mapper/TargetAmountMapper.java
@@ -22,7 +22,7 @@ public class TargetAmountMapper {
      * @param totalSpending {@link TotalSpendingAmount} : 값이 없을 경우 null
      */
     public static TargetAmountDto.WithTotalSpendingRes toWithTotalSpendingResponse(TargetAmount targetAmount, TotalSpendingAmount totalSpending, LocalDate date) {
-        Integer totalSpendingAmount = (totalSpending != null) ? totalSpending.totalSpending() : 0;
+        long totalSpendingAmount = (totalSpending != null) ? totalSpending.totalSpending() : 0L;
 
         return createWithTotalSpendingRes(targetAmount, totalSpendingAmount, date);
     }
@@ -38,8 +38,8 @@ public class TargetAmountMapper {
         LocalDate startAt = getOldestDate(targetAmounts);
         int monthLength = (endAt.getYear() - startAt.getYear()) * 12 + (endAt.getMonthValue() - startAt.getMonthValue());
 
-        Map<YearMonth, TargetAmount> targetAmountsByDates = toYearMonthMap(targetAmounts, targetAmount -> YearMonth.of(targetAmount.getCreatedAt().getYear(), targetAmount.getCreatedAt().getMonthValue()), Function.identity());
-        Map<YearMonth, Integer> totalSpendingAmounts = toYearMonthMap(totalSpendings, totalSpendingAmount -> YearMonth.of(totalSpendingAmount.year(), totalSpendingAmount.month()), TotalSpendingAmount::totalSpending);
+        Map<YearMonth, TargetAmount> targetAmountsByDates = toYearMonthMap(targetAmounts, ta -> YearMonth.from(ta.getCreatedAt()), Function.identity());
+        Map<YearMonth, Long> totalSpendingAmounts = toYearMonthMap(totalSpendings, TotalSpendingAmount::getYearMonth, TotalSpendingAmount::totalSpending);
 
         return createWithTotalSpendingResponses(targetAmountsByDates, totalSpendingAmounts, startAt, monthLength).stream()
                 .sorted(Comparator.comparing(TargetAmountDto.WithTotalSpendingRes::year).reversed()
@@ -53,42 +53,39 @@ public class TargetAmountMapper {
      * @return {@link TargetAmountDto.RecentTargetAmountRes}
      */
     public static TargetAmountDto.RecentTargetAmountRes toRecentTargetAmountResponse(Optional<TargetAmount> targetAmount) {
-        if (targetAmount.isEmpty()) {
-            return TargetAmountDto.RecentTargetAmountRes.notPresent();
-        }
-
-        Integer year = targetAmount.get().getCreatedAt().getYear();
-        Integer month = targetAmount.get().getCreatedAt().getMonthValue();
-        Integer amount = targetAmount.get().getAmount();
-
-        return TargetAmountDto.RecentTargetAmountRes.of(year, month, amount);
+        return targetAmount.map(ta -> {
+            LocalDate createdAt = ta.getCreatedAt().toLocalDate();
+            return TargetAmountDto.RecentTargetAmountRes.of(createdAt.getYear(), createdAt.getMonthValue(), ta.getAmount());
+        }).orElseGet(TargetAmountDto.RecentTargetAmountRes::notPresent);
     }
 
-    private static List<TargetAmountDto.WithTotalSpendingRes> createWithTotalSpendingResponses(Map<YearMonth, TargetAmount> targetAmounts, Map<YearMonth, Integer> totalSpendings, LocalDate startAt, int monthLength) {
+    private static List<TargetAmountDto.WithTotalSpendingRes> createWithTotalSpendingResponses(Map<YearMonth, TargetAmount> targetAmounts, Map<YearMonth, Long> totalSpendings, LocalDate startAt, int monthLength) {
         List<TargetAmountDto.WithTotalSpendingRes> withTotalSpendingResponses = new ArrayList<>(monthLength + 1);
+        LocalDate date = startAt;
 
         for (int i = 0; i < monthLength + 1; i++) {
-            LocalDate date = startAt.plusMonths(i);
-            YearMonth yearMonth = YearMonth.of(date.getYear(), date.getMonthValue());
+            YearMonth yearMonth = YearMonth.from(date);
 
-            TargetAmount targetAmount = targetAmounts.getOrDefault(yearMonth, null);
-            Integer totalSpending = totalSpendings.getOrDefault(yearMonth, 0);
+            TargetAmount targetAmount = targetAmounts.get(yearMonth);
+            Long totalSpending = totalSpendings.getOrDefault(yearMonth, 0L);
 
             withTotalSpendingResponses.add(createWithTotalSpendingRes(targetAmount, totalSpending, date));
+            date = date.plusMonths(1);
         }
 
         return withTotalSpendingResponses;
     }
 
-    private static TargetAmountDto.WithTotalSpendingRes createWithTotalSpendingRes(TargetAmount targetAmount, Integer totalSpending, LocalDate date) {
+    private static TargetAmountDto.WithTotalSpendingRes createWithTotalSpendingRes(TargetAmount targetAmount, Long totalSpending, LocalDate date) {
         TargetAmountDto.TargetAmountInfo targetAmountInfo = TargetAmountDto.TargetAmountInfo.from(targetAmount);
+        long diffAmount = (targetAmountInfo.amount() == -1) ? 0 : totalSpending - (long) targetAmountInfo.amount();
 
         return TargetAmountDto.WithTotalSpendingRes.builder()
                 .year(date.getYear())
                 .month(date.getMonthValue())
                 .targetAmountDetail(targetAmountInfo)
                 .totalSpending(totalSpending)
-                .diffAmount((targetAmountInfo.amount() == -1) ? 0 : totalSpending - targetAmountInfo.amount())
+                .diffAmount(diffAmount)
                 .build();
     }
 
@@ -112,12 +109,6 @@ public class TargetAmountMapper {
      * @param valueMapper : Value로 변환할 Function
      */
     private static <T, U> Map<YearMonth, U> toYearMonthMap(List<T> list, Function<T, YearMonth> keyMapper, Function<T, U> valueMapper) {
-        return list.stream().collect(
-                Collectors.toMap(
-                        keyMapper,
-                        valueMapper,
-                        (existing, replacement) -> existing
-                )
-        );
+        return list.stream().collect(Collectors.toMap(keyMapper, valueMapper, (existing, replacement) -> existing));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/TargetAmountSaveService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/service/TargetAmountSaveService.java
@@ -36,7 +36,7 @@ public class TargetAmountSaveService {
     }
 
     @Transactional
-    public TargetAmount updateTargetAmount(Long targetAmountId, Integer amount) {
+    public TargetAmount updateTargetAmount(Long targetAmountId, int amount) {
         TargetAmount targetAmount = targetAmountService.readTargetAmount(targetAmountId)
                 .orElseThrow(() -> new TargetAmountErrorException(TargetAmountErrorCode.NOT_FOUND_TARGET_AMOUNT));
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
@@ -39,6 +39,7 @@ public class TargetAmountUseCase {
     public TargetAmountDto.WithTotalSpendingRes getTargetAmountAndTotalSpending(Long userId, LocalDate date) {
         TargetAmount targetAmount = targetAmountSearchService.readTargetAmountThatMonth(userId, date);
         Optional<TotalSpendingAmount> totalSpending = spendingSearchService.readTotalSpendingAmountByUserIdThatMonth(userId, date);
+
         return TargetAmountMapper.toWithTotalSpendingResponse(targetAmount, totalSpending.orElse(null), date);
     }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/usecase/TargetAmountUseCase.java
@@ -57,7 +57,7 @@ public class TargetAmountUseCase {
     }
 
     @Transactional
-    public TargetAmountDto.TargetAmountInfo updateTargetAmount(Long targetAmountId, Integer amount) {
+    public TargetAmountDto.TargetAmountInfo updateTargetAmount(Long targetAmountId, int amount) {
         TargetAmount targetAmount = targetAmountSaveService.updateTargetAmount(targetAmountId, amount);
 
         return TargetAmountDto.TargetAmountInfo.from(targetAmount);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/TargetAmountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/controller/TargetAmountControllerUnitTest.java
@@ -3,11 +3,12 @@ package kr.co.pennyway.api.apis.ledger.controller;
 import kr.co.pennyway.api.apis.ledger.dto.TargetAmountDto;
 import kr.co.pennyway.api.apis.ledger.usecase.TargetAmountUseCase;
 import kr.co.pennyway.api.config.WebConfig;
-import kr.co.pennyway.api.config.fixture.UserFixture;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
-import kr.co.pennyway.domain.domains.target.domain.TargetAmount;
 import kr.co.pennyway.domain.domains.target.exception.TargetAmountErrorCode;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -30,7 +31,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = {TargetAmountController.class}, excludeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
 @ActiveProfiles("test")
-@TestClassOrder(ClassOrderer.OrderAnnotation.class)
 public class TargetAmountControllerUnitTest {
     @Autowired
     private MockMvc mockMvc;
@@ -111,8 +111,8 @@ public class TargetAmountControllerUnitTest {
         @WithSecurityMockUser
         void putTargetAmountWithValidRequest() throws Exception {
             // given
-            Integer amount = 100000;
-            given(targetAmountUseCase.updateTargetAmount(1L, amount)).willReturn(TargetAmountDto.TargetAmountInfo.from(TargetAmount.of(amount, UserFixture.GENERAL_USER.toUser())));
+            int amount = 100000;
+            given(targetAmountUseCase.updateTargetAmount(1L, amount)).willReturn(TargetAmountDto.TargetAmountInfo.from(null));
 
             // when
             ResultActions result = performPutTargetAmount(1L, amount);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/TargetAmountIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/ledger/integration/TargetAmountIntegrationTest.java
@@ -8,6 +8,7 @@ import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
 import kr.co.pennyway.api.config.fixture.SpendingFixture;
 import kr.co.pennyway.api.config.fixture.TargetAmountFixture;
 import kr.co.pennyway.api.config.fixture.UserFixture;
+import kr.co.pennyway.domain.domains.spending.service.SpendingService;
 import kr.co.pennyway.domain.domains.target.domain.TargetAmount;
 import kr.co.pennyway.domain.domains.target.service.TargetAmountService;
 import kr.co.pennyway.domain.domains.user.domain.User;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Slf4j
@@ -46,6 +48,10 @@ public class TargetAmountIntegrationTest extends ExternalApiDBTestConfig {
 
     @Autowired
     private TargetAmountService targetAmountService;
+
+    @Autowired
+    private SpendingService spendingService;
+
     @PersistenceContext
     private EntityManager em;
 
@@ -138,6 +144,26 @@ public class TargetAmountIntegrationTest extends ExternalApiDBTestConfig {
 
             // then
             result.andDo(print()).andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("당월 지출 금액의 총합이 int 범위를 초과해도 200 OK 응답을 반환한다.")
+        @Transactional
+        void getTargetAmountAndTotalSpendingWithIntOverflow() throws Exception {
+            // given
+            User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
+            TargetAmount targetAmount = targetAmountService.createTargetAmount(TargetAmountFixture.GENERAL_TARGET_AMOUNT.toTargetAmount(user));
+            spendingService.createSpending(SpendingFixture.MAX_SPENDING.toSpending(user));
+            spendingService.createSpending(SpendingFixture.MAX_SPENDING.toSpending(user));
+
+            // when
+            ResultActions result = performGetTargetAmountAndTotalSpending(user, LocalDate.now());
+
+            // then
+            result.andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.targetAmount.totalSpending").value("4294967294"))
+                    .andExpect(jsonPath("$.data.targetAmount.diffAmount").value(String.valueOf(4294967294L - (long) targetAmount.getAmount())));
         }
 
         private ResultActions performGetTargetAmountAndTotalSpending(User requestUser, LocalDate date) throws Exception {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/SpendingFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/SpendingFixture.java
@@ -18,7 +18,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public enum SpendingFixture {
     GENERAL_SPENDING(10000, SpendingCategory.FOOD, LocalDateTime.now(), "카페인 수혈", "아메리카노 1잔"),
-    CUSTOM_CATEGORY_SPENDING(10000, SpendingCategory.CUSTOM, LocalDateTime.now(), "커스텀 카페인 수혈", "아메리카노 1잔");
+    CUSTOM_CATEGORY_SPENDING(10000, SpendingCategory.CUSTOM, LocalDateTime.now(), "커스텀 카페인 수혈", "아메리카노 1잔"),
+    MAX_SPENDING(Integer.MAX_VALUE, SpendingCategory.HOBBY, LocalDateTime.now(), "부가티", "이것이 인생");
 
     private final int amount;
     private final SpendingCategory category;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/TotalSpendingAmount.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/TotalSpendingAmount.java
@@ -6,9 +6,9 @@ package kr.co.pennyway.domain.domains.spending.dto;
 public record TotalSpendingAmount(
         Integer year,
         Integer month,
-        Integer totalSpending
+        Long totalSpending
 ) {
-    public TotalSpendingAmount(Integer year, Integer month, Integer totalSpending) {
+    public TotalSpendingAmount(Integer year, Integer month, Long totalSpending) {
         this.year = year;
         this.month = month;
         this.totalSpending = totalSpending;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/TotalSpendingAmount.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/dto/TotalSpendingAmount.java
@@ -1,16 +1,28 @@
 package kr.co.pennyway.domain.domains.spending.dto;
 
+import java.time.YearMonth;
+
 /**
  * 사용자의 해당 년/월 총 지출 금액을 담는 DTO
  */
 public record TotalSpendingAmount(
-        Integer year,
-        Integer month,
-        Long totalSpending
+        int year,
+        int month,
+        long totalSpending
 ) {
-    public TotalSpendingAmount(Integer year, Integer month, Long totalSpending) {
+    public TotalSpendingAmount(int year, int month, long totalSpending) {
         this.year = year;
         this.month = month;
         this.totalSpending = totalSpending;
     }
+
+    /**
+     * YearMonth 객체로 변환하는 메서드
+     *
+     * @return 해당 년/월을 나타내는 YearMonth 객체
+     */
+    public YearMonth getYearMonth() {
+        return YearMonth.of(year, month);
+    }
+
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomRepositoryImpl.java
@@ -32,9 +32,9 @@ public class SpendingCustomRepositoryImpl implements SpendingCustomRepository {
         TotalSpendingAmount result = queryFactory.select(
                         Projections.constructor(
                                 TotalSpendingAmount.class,
-                                spending.spendAt.year(),
-                                spending.spendAt.month(),
-                                spending.amount.sum()
+                                spending.spendAt.year().intValue(),
+                                spending.spendAt.month().intValue(),
+                                spending.amount.sum().longValue()
                         )
                 ).from(user)
                 .leftJoin(spending).on(user.id.eq(spending.user.id))

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
@@ -46,11 +46,6 @@ public class SpendingService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<TotalSpendingAmount> readTotalSpendingAmountByUserId(Long userId, LocalDate date) {
-        return spendingRepository.findTotalSpendingAmountByUserId(userId, date.getYear(), date.getMonthValue());
-    }
-
-    @Transactional(readOnly = true)
     public List<Spending> readSpendings(Long userId, int year, int month) {
         return spendingRepository.findByYearAndMonth(userId, year, month);
     }
@@ -104,6 +99,11 @@ public class SpendingService {
         Sort sort = pageable.getSort();
 
         return SliceUtil.toSlice(spendingRepository.findList(predicate, queryHandler, sort), pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<TotalSpendingAmount> readTotalSpendingAmountByUserId(Long userId, LocalDate date) {
+        return spendingRepository.findTotalSpendingAmountByUserId(userId, date.getYear(), date.getMonthValue());
     }
 
     @Transactional(readOnly = true)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
@@ -116,9 +116,9 @@ public class SpendingService {
         Sort sort = Sort.by(Sort.Order.desc("year(spendAt)"), Sort.Order.desc("month(spendAt)"));
 
         Map<String, Expression<?>> bindings = new LinkedHashMap<>();
-        bindings.put("year", spending.spendAt.year());
-        bindings.put("month", spending.spendAt.month());
-        bindings.put("totalSpending", spending.amount.sum());
+        bindings.put("year", spending.spendAt.year().intValue());
+        bindings.put("month", spending.spendAt.month().intValue());
+        bindings.put("totalSpending", spending.amount.sum().longValue());
 
         return spendingRepository.selectList(predicate, TotalSpendingAmount.class, bindings, queryHandler, sort);
     }


### PR DESCRIPTION
## 작업 이유
- #128 
- 각각의 소비 내역은 int 범위 내에서 지정 가능하지만, 지출 총합 시 int 범위를 초과할 수 있으므로 long 타입으로 수정.

<br/>

## 작업 사항
long 타입 수정하면서, 기존에 무분별하게 원시 타입과 래퍼 타입을 혼용하던 것을 다소 보완했습니다.  

long 타입을 벗어나는 경우는 고려하지 않았습니다.  
현실적으로 long 타입을 벗어날 정도가 되려면
```
2,147,483,647 x χ = 9,223,372,036,854,775,807
χ > 4,294,967,296
```
`χ`개 만큼의 소비 내역이 존재해야 하는데, 이 정도면 악의적인 공격이라고 밖에 볼 수 없으며, 시스템에 큰 지장을 준다고 생각도 안 되기에 별도의 예외 처리를 하지 않았습니다.
<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- Wrapper Type과 Primitive Type을 혼용해서 사용하고 있는데, 타입 캐스팅으로 인한 오버헤드가 심각하게 발생할 만한 부분이 존재하는지?

<br/>

## 발견한 이슈
당월 목표 금액 데이터가 없으면, 총 소비내역도 확인이 불가능한 이슈가 존재함.  
하지만, 해당 API는 어디까지나 "당월" 목표 금액과 총 지출 금액을 조회하려는 용도로 개발되었으며, 정상적인 플로우에서 당월 목표 금액 데이터가 존재하지 않는 경우는 없음.   
따라서 해당 이슈가 ciritcal하지 않다고 판단하여, 별도로 예외처리 하지 않음.

