### PR TITLE
Ignore: ✨ 사용자가 수신한 푸시 알림 리스트 최신순 조회

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
@@ -1,0 +1,63 @@
+package kr.co.pennyway.api.apis.notification.api;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.apis.notification.dto.NotificationDto;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "[알림 API]")
+public interface NotificationApi {
+    @Operation(summary = "수신한 알림 목록 무한 스크롤 조회")
+    @Parameters({
+            @Parameter(
+                    in = ParameterIn.QUERY,
+                    description = "조회하려는 페이지 (0..N) (기본 값 : 0)",
+                    name = "page",
+                    example = "0",
+                    schema = @Schema(
+                            type = "integer",
+                            defaultValue = "0"
+                    )
+            ),
+            @Parameter(
+                    in = ParameterIn.QUERY,
+                    description = "페이지 내 데이터 수 (기본 값 : 30)",
+                    name = "size",
+                    example = "30",
+                    schema = @Schema(
+                            type = "integer",
+                            defaultValue = "30"
+                    )
+            ),
+            @Parameter(
+                    in = ParameterIn.QUERY,
+                    description = "정렬 기준 (기본 값 : notification.createdAt,DESC)",
+                    name = "sort",
+                    example = "notification.createdAt,DESC",
+                    array = @ArraySchema(
+                            schema = @Schema(
+                                    type = "string"
+                            )
+                    )
+            ), @Parameter(name = "pageable", hidden = true)})
+    @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "notifications", schema = @Schema(implementation = NotificationDto.SliceRes.class))))
+    ResponseEntity<?> getNotifications(
+            @PageableDefault(page = 0, size = 30) @SortDefault(sort = "notification.createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal SecurityUserDetails user
+    );
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
@@ -1,0 +1,14 @@
+package kr.co.pennyway.api.apis.notification.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/notifications")
+public class NotificationController {
+    private final NotificationUseCase notificationUseCase;
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
@@ -1,7 +1,16 @@
 package kr.co.pennyway.api.apis.notification.controller;
 
+import kr.co.pennyway.api.apis.notification.usecase.NotificationUseCase;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +20,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v2/notifications")
 public class NotificationController {
     private final NotificationUseCase notificationUseCase;
+
+    @GetMapping("")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getNotifications(
+            @PageableDefault(page = 0, size = 20) @SortDefault(sort = "notification.createdAt") Pageable pageable,
+            @AuthenticationPrincipal SecurityUserDetails user
+    ) {
+        return ResponseEntity.ok(notificationUseCase.getNotifications(user.getUserId(), pageable));
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
@@ -6,6 +6,7 @@ import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,7 @@ public class NotificationController {
     @GetMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getNotifications(
-            @PageableDefault(page = 0, size = 30) @SortDefault(sort = "notification.createdAt") Pageable pageable,
+            @PageableDefault(page = 0, size = 30) @SortDefault(sort = "notification.createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal SecurityUserDetails user
     ) {
         return ResponseEntity.ok(SuccessResponse.from(NOTIFICATIONS, notificationUseCase.getNotifications(user.getUserId(), pageable)));

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
@@ -27,7 +27,7 @@ public class NotificationController {
     @GetMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getNotifications(
-            @PageableDefault(page = 0, size = 20) @SortDefault(sort = "notification.createdAt") Pageable pageable,
+            @PageableDefault(page = 0, size = 30) @SortDefault(sort = "notification.createdAt") Pageable pageable,
             @AuthenticationPrincipal SecurityUserDetails user
     ) {
         return ResponseEntity.ok(SuccessResponse.from(NOTIFICATIONS, notificationUseCase.getNotifications(user.getUserId(), pageable)));

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.notification.controller;
 
 import kr.co.pennyway.api.apis.notification.usecase.NotificationUseCase;
+import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/v2/notifications")
 public class NotificationController {
+    private static final String NOTIFICATIONS = "notifications";
+
     private final NotificationUseCase notificationUseCase;
 
     @GetMapping("")
@@ -27,6 +30,6 @@ public class NotificationController {
             @PageableDefault(page = 0, size = 20) @SortDefault(sort = "notification.createdAt") Pageable pageable,
             @AuthenticationPrincipal SecurityUserDetails user
     ) {
-        return ResponseEntity.ok(notificationUseCase.getNotifications(user.getUserId(), pageable));
+        return ResponseEntity.ok(SuccessResponse.from(NOTIFICATIONS, notificationUseCase.getNotifications(user.getUserId(), pageable)));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.api.apis.notification.controller;
 
+import kr.co.pennyway.api.apis.notification.api.NotificationApi;
 import kr.co.pennyway.api.apis.notification.usecase.NotificationUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
@@ -20,11 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v2/notifications")
-public class NotificationController {
+public class NotificationController implements NotificationApi {
     private static final String NOTIFICATIONS = "notifications";
 
     private final NotificationUseCase notificationUseCase;
 
+    @Override
     @GetMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getNotifications(

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/dto/NotificationDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/dto/NotificationDto.java
@@ -1,0 +1,63 @@
+package kr.co.pennyway.api.apis.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class NotificationDto {
+    @Schema(title = "푸시 알림 슬라이스 응답")
+    public record SliceRes(
+            @Schema(description = "푸시 알림 리스트")
+            List<Info> content,
+            @Schema(description = "현재 페이지 번호")
+            int currentPageNumber,
+            @Schema(description = "페이지 크기")
+            int pageSize,
+            @Schema(description = "전체 요소 개수")
+            int numberOfElements,
+            @Schema(description = "다음 페이지 존재 여부")
+            boolean hasNext
+    ) {
+        public static SliceRes from(List<Info> notifications, Pageable pageable, int numberOfElements, boolean hasNext) {
+            return new SliceRes(notifications, pageable.getPageNumber(), pageable.getPageSize(), numberOfElements, hasNext);
+        }
+    }
+
+    @Schema(title = "푸시 알림 상세 정보", description = "푸시 알림 pk, 읽음 여부, 제목, 내용, 타입 그리고 딥 링크 정보를 담고 있다.")
+    public record Info(
+            @Schema(description = "푸시 알림 pk", example = "1")
+            Long id,
+            @Schema(description = "푸시 알림 읽음 여부", example = "true")
+            boolean isRead,
+            @Schema(description = "푸시 알림 제목", example = "페니웨이 공지")
+            String title,
+            @Schema(description = "푸시 알림 내용", example = "안녕하세요. 페니웨이입니다.")
+            String content,
+            @Schema(description = "푸시 알림 타입. ex) ANNOUNCEMENT", example = "FEED_LIKE_FROM_TO")
+            String type,
+            @Schema(description = "푸시 알림 행위자. ex) 다른 사용자 <type이 ANNOUNCEMENT면 존재하지 않음>", example = "pennyway")
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            String from,
+            @Schema(description = "푸시 알림 행위자 pk <type이 ANNOUNCEMENT면 존재하지 않음>", example = "1")
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Long fromId,
+            @Schema(description = "푸시 알림 행위자가 액션을 취한 대상 ex) 피드, 채팅 <type이 ANNOUNCEMENT면 존재하지 않음>", example = "feed")
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            String to,
+            @Schema(description = "푸시 알림 행위자가 액션을 취한 대상 pk <type이 ANNOUNCEMENT면 존재하지 않음>", example = "3")
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Long toId,
+            @Schema(description = "푸시 알림 생성 시간", example = "yyyy-MM-dd HH:mm:ss")
+            @JsonSerialize(using = LocalDateTimeSerializer.class)
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt
+    ) {
+
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/dto/NotificationDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/dto/NotificationDto.java
@@ -54,7 +54,7 @@ public class NotificationDto {
             @Schema(description = "푸시 알림 행위자가 액션을 취한 대상 pk. ex) 피드 pk, 댓글 pk <type이 ANNOUNCEMENT면 존재하지 않음>", example = "3")
             @JsonInclude(JsonInclude.Include.NON_NULL)
             Long toId,
-            @Schema(description = "푸시 알림 생성 시간", example = "yyyy-MM-dd HH:mm:ss")
+            @Schema(description = "푸시 알림 생성 시간", example = "2024-07-17 12:00:00")
             @JsonSerialize(using = LocalDateTimeSerializer.class)
             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime createdAt
@@ -70,7 +70,8 @@ public class NotificationDto {
 
             if (!notification.getType().equals(NoticeType.ANNOUNCEMENT)) {
                 builder.from(notification.getSenderName())
-                        .fromId(notification.getSender().getId()).toId(notification.getToId());
+                        .fromId(notification.getSender().getId())
+                        .toId(notification.getToId());
             }
 
             return builder.build();

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/dto/NotificationDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/dto/NotificationDto.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.pennyway.domain.domains.notification.domain.Notification;
+import kr.co.pennyway.domain.domains.notification.type.NoticeType;
 import lombok.Builder;
 import org.springframework.data.domain.Pageable;
 
@@ -49,10 +51,7 @@ public class NotificationDto {
             @Schema(description = "푸시 알림 행위자 pk <type이 ANNOUNCEMENT면 존재하지 않음>", example = "1")
             @JsonInclude(JsonInclude.Include.NON_NULL)
             Long fromId,
-            @Schema(description = "푸시 알림 행위자가 액션을 취한 대상 ex) 피드, 채팅 <type이 ANNOUNCEMENT면 존재하지 않음>", example = "feed")
-            @JsonInclude(JsonInclude.Include.NON_NULL)
-            String to,
-            @Schema(description = "푸시 알림 행위자가 액션을 취한 대상 pk <type이 ANNOUNCEMENT면 존재하지 않음>", example = "3")
+            @Schema(description = "푸시 알림 행위자가 액션을 취한 대상 pk. ex) 피드 pk, 댓글 pk <type이 ANNOUNCEMENT면 존재하지 않음>", example = "3")
             @JsonInclude(JsonInclude.Include.NON_NULL)
             Long toId,
             @Schema(description = "푸시 알림 생성 시간", example = "yyyy-MM-dd HH:mm:ss")
@@ -60,6 +59,21 @@ public class NotificationDto {
             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime createdAt
     ) {
+        public static NotificationDto.Info from(Notification notification) {
+            NotificationDto.Info.InfoBuilder builder = NotificationDto.Info.builder()
+                    .id(notification.getId())
+                    .isRead(notification.getReadAt() != null)
+                    .title(notification.createFormattedTitle())
+                    .content(notification.createFormattedContent())
+                    .type(notification.getType().name())
+                    .createdAt(notification.getCreatedAt());
 
+            if (!notification.getType().equals(NoticeType.ANNOUNCEMENT)) {
+                builder.from(notification.getSenderName())
+                        .fromId(notification.getSender().getId()).toId(notification.getToId());
+            }
+
+            return builder.build();
+        }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/dto/NotificationDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/dto/NotificationDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
@@ -29,6 +30,7 @@ public class NotificationDto {
         }
     }
 
+    @Builder
     @Schema(title = "푸시 알림 상세 정보", description = "푸시 알림 pk, 읽음 여부, 제목, 내용, 타입 그리고 딥 링크 정보를 담고 있다.")
     public record Info(
             @Schema(description = "푸시 알림 pk", example = "1")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/mapper/NotificationMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/mapper/NotificationMapper.java
@@ -15,25 +15,10 @@ public class NotificationMapper {
      */
     public static NotificationDto.SliceRes toSliceRes(Slice<Notification> notifications, Pageable pageable) {
         return NotificationDto.SliceRes.from(
-                notifications.getContent().stream().map(NotificationMapper::toRes).toList(),
+                notifications.getContent().stream().map(NotificationDto.Info::from).toList(),
                 pageable,
                 notifications.getNumberOfElements(),
                 notifications.hasNext()
         );
-    }
-
-    /**
-     * Notification 정보를 추출하여 응답 형태로 변환한다.
-     */
-    private static NotificationDto.Info toRes(Notification notification) {
-        String title = notification.createFormattedTitle();
-        String content = notification.createFormattedContent();
-
-        return NotificationDto.Info.builder()
-                .id(notification.getId())
-                .title(title)
-                .content(content)
-                .createdAt(notification.getCreatedAt())
-                .build();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/mapper/NotificationMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/mapper/NotificationMapper.java
@@ -3,7 +3,6 @@ package kr.co.pennyway.api.apis.notification.mapper;
 import kr.co.pennyway.api.apis.notification.dto.NotificationDto;
 import kr.co.pennyway.common.annotation.Mapper;
 import kr.co.pennyway.domain.domains.notification.domain.Notification;
-import kr.co.pennyway.domain.domains.notification.type.NoticeType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -27,20 +26,8 @@ public class NotificationMapper {
      * Notification 정보를 추출하여 응답 형태로 변환한다.
      */
     private static NotificationDto.Info toRes(Notification notification) {
-        String title = "", content = "";
-
-        // 1. notification의 타입을 확인
-        NoticeType type = notification.getType();
-
-//        // 2. type이 Announcement라면, Announcement도 확인한다.
-//        if (type.equals(NoticeType.ANNOUNCEMENT)) { // TODO: 공지사항 중에 title, content 모두, 한쪽, 혹은 아예 이름이 들어가지 않는 경우가 있을 수 있음.
-//            Announcement announcement = notification.getAnnouncement();
-//            title = announcement.createFormattedTitle("헬로"); // TODO: 사용자 이름을 받아서 처리
-//            content = announcement.createFormattedContent("헬로"); // TODO: 사용자 이름을 받아서 처리
-//        } else { // TODO: 공지사항이 아닌 경우도, 알림 종류에 따라 title, content의 형태가 어떻게 될 지 알 수가 없음.
-//            title = type.createFormattedTitle("헬로"); // TODO: 사용자 이름을 받아서 처리
-//            content = type.createFormattedContent("헬로"); // TODO: 사용자 이름을 받아서 처리
-//        }
+        String title = notification.createFormattedTitle();
+        String content = notification.createFormattedContent();
 
         return NotificationDto.Info.builder()
                 .id(notification.getId())

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/mapper/NotificationMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/mapper/NotificationMapper.java
@@ -1,0 +1,52 @@
+package kr.co.pennyway.api.apis.notification.mapper;
+
+import kr.co.pennyway.api.apis.notification.dto.NotificationDto;
+import kr.co.pennyway.common.annotation.Mapper;
+import kr.co.pennyway.domain.domains.notification.domain.Notification;
+import kr.co.pennyway.domain.domains.notification.type.NoticeType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+@Slf4j
+@Mapper
+public class NotificationMapper {
+    /**
+     * Slice<Notification> 타입을 무한 스크롤 응답 형태로 변환한다.
+     */
+    public static NotificationDto.SliceRes toSliceRes(Slice<Notification> notifications, Pageable pageable) {
+        return NotificationDto.SliceRes.from(
+                notifications.getContent().stream().map(NotificationMapper::toRes).toList(),
+                pageable,
+                notifications.getNumberOfElements(),
+                notifications.hasNext()
+        );
+    }
+
+    /**
+     * Notification 정보를 추출하여 응답 형태로 변환한다.
+     */
+    private static NotificationDto.Info toRes(Notification notification) {
+        String title = "", content = "";
+
+        // 1. notification의 타입을 확인
+        NoticeType type = notification.getType();
+
+//        // 2. type이 Announcement라면, Announcement도 확인한다.
+//        if (type.equals(NoticeType.ANNOUNCEMENT)) { // TODO: 공지사항 중에 title, content 모두, 한쪽, 혹은 아예 이름이 들어가지 않는 경우가 있을 수 있음.
+//            Announcement announcement = notification.getAnnouncement();
+//            title = announcement.createFormattedTitle("헬로"); // TODO: 사용자 이름을 받아서 처리
+//            content = announcement.createFormattedContent("헬로"); // TODO: 사용자 이름을 받아서 처리
+//        } else { // TODO: 공지사항이 아닌 경우도, 알림 종류에 따라 title, content의 형태가 어떻게 될 지 알 수가 없음.
+//            title = type.createFormattedTitle("헬로"); // TODO: 사용자 이름을 받아서 처리
+//            content = type.createFormattedContent("헬로"); // TODO: 사용자 이름을 받아서 처리
+//        }
+
+        return NotificationDto.Info.builder()
+                .id(notification.getId())
+                .title(title)
+                .content(content)
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/service/NotificationSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/service/NotificationSearchService.java
@@ -1,0 +1,22 @@
+package kr.co.pennyway.api.apis.notification.service;
+
+import kr.co.pennyway.domain.domains.notification.domain.Notification;
+import kr.co.pennyway.domain.domains.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationSearchService {
+    private final NotificationService notificationService;
+
+    @Transactional(readOnly = true)
+    public Slice<Notification> getNotifications(Long userId, Pageable pageable) {
+        return notificationService.readNotificationsSlice(userId, pageable);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
@@ -1,17 +1,23 @@
 package kr.co.pennyway.api.apis.notification.usecase;
 
 import kr.co.pennyway.api.apis.notification.dto.NotificationDto;
+import kr.co.pennyway.api.apis.notification.service.NotificationSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.domains.notification.domain.Notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class NotificationUseCase {
+    private final NotificationSearchService notificationSearchService;
 
     public NotificationDto.SliceRes getNotifications(Long userId, Pageable pageable) {
-        return null;
+        Slice<Notification> notifications = notificationSearchService.getNotifications(userId, pageable);
+
+        return NotificationMapper.toSliceRes(notifications, pageable);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.notification.usecase;
 
 import kr.co.pennyway.api.apis.notification.dto.NotificationDto;
+import kr.co.pennyway.api.apis.notification.mapper.NotificationMapper;
 import kr.co.pennyway.api.apis.notification.service.NotificationSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.notification.domain.Notification;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
@@ -1,0 +1,11 @@
+package kr.co.pennyway.api.apis.notification.usecase;
+
+import kr.co.pennyway.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class NotificationUseCase {
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
@@ -1,11 +1,17 @@
 package kr.co.pennyway.api.apis.notification.usecase;
 
+import kr.co.pennyway.api.apis.notification.dto.NotificationDto;
 import kr.co.pennyway.common.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class NotificationUseCase {
+
+    public NotificationDto.SliceRes getNotifications(Long userId, Pageable pageable) {
+        return null;
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/SwaggerConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/SwaggerConfig.java
@@ -65,11 +65,21 @@ public class SwaggerConfig {
 
     @Bean
     public GroupedOpenApi userApi() {
-        String[] targets = {"kr.co.pennyway.api.apis.users"};
+        String[] targets = {"kr.co.pennyway.api.apis.users", "kr.co.pennyway.api.apis.notification"};
 
         return GroupedOpenApi.builder()
                 .packagesToScan(targets)
                 .group("사용자 기본 기능")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi storageApi() {
+        String[] targets = {"kr.co.pennyway.api.apis.storage"};
+
+        return GroupedOpenApi.builder()
+                .packagesToScan(targets)
+                .group("정적 파일 저장")
                 .build();
     }
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
@@ -7,9 +7,9 @@ import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.domain.Pageable;
@@ -20,9 +20,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = {NotificationController.class}, excludeFilters = {
@@ -31,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class GetNotificationsControllerUnitTest {
     @Autowired
     private MockMvc mockMvc;
-    @Mock
+    @MockBean
     private NotificationUseCase notificationUseCase;
 
     @BeforeEach
@@ -51,13 +54,15 @@ public class GetNotificationsControllerUnitTest {
         // when
         int page = 0, currentPageNumber = 0, pageSize = 20, numberOfElements = 1;
         Pageable pa = Pageable.ofSize(pageSize).withPage(currentPageNumber);
-        given(notificationUseCase.getNotifications(1L, any())).willReturn(NotificationFixture.createSliceRes(pa, currentPageNumber, numberOfElements));
+        given(notificationUseCase.getNotifications(eq(1L), any())).willReturn(NotificationFixture.createSliceRes(pa, currentPageNumber, numberOfElements));
 
         // when
         ResultActions result = performGetNotifications(page);
 
         // then
-        result.andExpect(status().isOk());
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.notifications.currentPageNumber").value(page));
     }
 
     private ResultActions performGetNotifications(int page) throws Exception {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.notification.controller;
 
 import kr.co.pennyway.api.apis.notification.usecase.NotificationUseCase;
 import kr.co.pennyway.api.config.WebConfig;
+import kr.co.pennyway.api.config.fixture.NotificationFixture;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -50,7 +51,7 @@ public class GetNotificationsControllerUnitTest {
         // when
         int page = 0, currentPageNumber = 0, pageSize = 20, numberOfElements = 1;
         Pageable pa = Pageable.ofSize(pageSize).withPage(currentPageNumber);
-        given(notificationUseCase.getNotifications(1L, any())).willReturn(NotificationFixture.getSliceRes(pa, currentPageNumber, numberOfElements));
+        given(notificationUseCase.getNotifications(1L, any())).willReturn(NotificationFixture.createSliceRes(pa, currentPageNumber, numberOfElements));
 
         // when
         ResultActions result = performGetNotifications(page);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
@@ -4,7 +4,9 @@ import kr.co.pennyway.api.apis.notification.dto.NotificationDto;
 import kr.co.pennyway.api.apis.notification.usecase.NotificationUseCase;
 import kr.co.pennyway.api.config.WebConfig;
 import kr.co.pennyway.api.config.fixture.NotificationFixture;
+import kr.co.pennyway.api.config.fixture.UserFixture;
 import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
+import kr.co.pennyway.domain.domains.notification.domain.Notification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -55,7 +59,11 @@ public class GetNotificationsControllerUnitTest {
         // when
         int page = 0, currentPageNumber = 0, pageSize = 20, numberOfElements = 1;
         Pageable pa = Pageable.ofSize(pageSize).withPage(currentPageNumber);
-        given(notificationUseCase.getNotifications(eq(1L), any())).willReturn(NotificationFixture.createSliceRes(pa, currentPageNumber, numberOfElements));
+
+        Notification notification = NotificationFixture.ANNOUNCEMENT_DAILY_SPENDING.toEntity(UserFixture.GENERAL_USER.toUser());
+        NotificationDto.Info info = NotificationDto.Info.from(notification);
+
+        given(notificationUseCase.getNotifications(eq(1L), any())).willReturn(NotificationDto.SliceRes.from(List.of(info), pa, numberOfElements, false));
 
         // when
         ResultActions result = performGetNotifications(page);
@@ -73,7 +81,11 @@ public class GetNotificationsControllerUnitTest {
         // when
         int page = 0, currentPageNumber = 0, pageSize = 20, numberOfElements = 1;
         Pageable pa = Pageable.ofSize(pageSize).withPage(currentPageNumber);
-        NotificationDto.SliceRes sliceRes = NotificationFixture.createSliceRes(pa, currentPageNumber, numberOfElements);
+
+        Notification notification = NotificationFixture.ANNOUNCEMENT_DAILY_SPENDING.toEntity(UserFixture.GENERAL_USER.toUser());
+        NotificationDto.Info info = NotificationDto.Info.from(notification);
+        NotificationDto.SliceRes sliceRes = NotificationDto.SliceRes.from(List.of(info), pa, numberOfElements, false);
+
         given(notificationUseCase.getNotifications(eq(1L), any())).willReturn(sliceRes);
 
         // when

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
@@ -1,7 +1,11 @@
 package kr.co.pennyway.api.apis.notification.controller;
 
+import kr.co.pennyway.api.apis.notification.usecase.NotificationUseCase;
 import kr.co.pennyway.api.config.WebConfig;
+import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -9,11 +13,17 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = {NotificationController.class}, excludeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
@@ -32,5 +42,24 @@ public class GetNotificationsControllerUnitTest {
                 .defaultRequest(put("/**").with(csrf()))
                 .defaultRequest(delete("/**").with(csrf()))
                 .build();
+    }
+
+    @Test
+    @WithSecurityMockUser
+    @DisplayName("쿼리 파라미터로 page 외의 파라미터는 기본값을 갖는다.")
+    void getNotificationsWithDefaultParameters() throws Exception {
+        // when
+        given(notificationUseCase.getNotifications(1L, any())).willReturn(List.of(NotificationRes.from(NotificationFixture.DAILY_SPENDING.toEntity())));
+
+        // when
+        ResultActions result = performGetNotifications(1);
+
+        // then
+        result.andExpect(status().isOk());
+    }
+
+    private ResultActions performGetNotifications(int page) throws Exception {
+        return mockMvc.perform(get("/v2/notifications")
+                .param("page", String.valueOf(page)));
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
@@ -11,13 +11,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -49,10 +48,12 @@ public class GetNotificationsControllerUnitTest {
     @DisplayName("쿼리 파라미터로 page 외의 파라미터는 기본값을 갖는다.")
     void getNotificationsWithDefaultParameters() throws Exception {
         // when
-        given(notificationUseCase.getNotifications(1L, any())).willReturn(List.of(NotificationRes.from(NotificationFixture.DAILY_SPENDING.toEntity())));
+        int page = 0, currentPageNumber = 0, pageSize = 20, numberOfElements = 1;
+        Pageable pa = Pageable.ofSize(pageSize).withPage(currentPageNumber);
+        given(notificationUseCase.getNotifications(1L, any())).willReturn(NotificationFixture.getSliceRes(pa, currentPageNumber, numberOfElements));
 
         // when
-        ResultActions result = performGetNotifications(1);
+        ResultActions result = performGetNotifications(page);
 
         // then
         result.andExpect(status().isOk());

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
@@ -1,0 +1,36 @@
+package kr.co.pennyway.api.apis.notification.controller;
+
+import kr.co.pennyway.api.config.WebConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@WebMvcTest(controllers = {NotificationController.class}, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
+@ActiveProfiles("test")
+public class GetNotificationsControllerUnitTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Mock
+    private NotificationUseCase notificationUseCase;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .defaultRequest(post("/**").with(csrf()))
+                .defaultRequest(put("/**").with(csrf()))
+                .defaultRequest(delete("/**").with(csrf()))
+                .build();
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/NotificationFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/NotificationFixture.java
@@ -1,0 +1,51 @@
+package kr.co.pennyway.api.config.fixture;
+
+import kr.co.pennyway.api.apis.notification.dto.NotificationDto;
+import kr.co.pennyway.domain.domains.notification.domain.Notification;
+import kr.co.pennyway.domain.domains.notification.type.Announcement;
+import kr.co.pennyway.domain.domains.notification.type.NoticeType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public enum NotificationFixture {
+    ANNOUNCEMENT_DAILY_SPENDING(null, NoticeType.ANNOUNCEMENT, Announcement.DAILY_SPENDING);
+
+    private final LocalDateTime readAt;
+    private final NoticeType type;
+    private final Announcement announcement;
+
+    public static NotificationDto.SliceRes createSliceRes(Pageable pa, int currentPageNumber, int numberOfElements) {
+        return new NotificationDto.SliceRes(
+                List.of(createInfo(1L, "title", "content", ANNOUNCEMENT_DAILY_SPENDING)),
+                currentPageNumber,
+                pa.getPageSize(),
+                numberOfElements,
+                false
+        );
+    }
+
+    public static NotificationDto.Info createInfo(Long id, String title, String content, NotificationFixture fixture) {
+        return new NotificationDto.Info(
+                id,
+                (fixture.readAt != null),
+                title,
+                content,
+                fixture.type.name(),
+                null,
+                null,
+                null,
+                null,
+                LocalDateTime.now()
+        );
+    }
+
+    public Notification toEntity() {
+        return new Notification.Builder(this.type, this.announcement)
+                .readAt(this.readAt)
+                .build();
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/NotificationFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/NotificationFixture.java
@@ -1,14 +1,12 @@
 package kr.co.pennyway.api.config.fixture;
 
-import kr.co.pennyway.api.apis.notification.dto.NotificationDto;
 import kr.co.pennyway.domain.domains.notification.domain.Notification;
 import kr.co.pennyway.domain.domains.notification.type.Announcement;
 import kr.co.pennyway.domain.domains.notification.type.NoticeType;
+import kr.co.pennyway.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @RequiredArgsConstructor
 public enum NotificationFixture {
@@ -18,34 +16,8 @@ public enum NotificationFixture {
     private final NoticeType type;
     private final Announcement announcement;
 
-    public static NotificationDto.SliceRes createSliceRes(Pageable pa, int currentPageNumber, int numberOfElements) {
-        return new NotificationDto.SliceRes(
-                List.of(createInfo(1L, "title", "content", ANNOUNCEMENT_DAILY_SPENDING)),
-                currentPageNumber,
-                pa.getPageSize(),
-                numberOfElements,
-                false
-        );
-    }
-
-    public static NotificationDto.Info createInfo(Long id, String title, String content, NotificationFixture fixture) {
-        return new NotificationDto.Info(
-                id,
-                (fixture.readAt != null),
-                title,
-                content,
-                fixture.type.name(),
-                null,
-                null,
-                null,
-                null,
-                LocalDateTime.now()
-        );
-    }
-
-    public Notification toEntity() {
-        return new Notification.Builder(this.type, this.announcement)
-                .readAt(this.readAt)
+    public Notification toEntity(User receiver) {
+        return new Notification.Builder(this.type, this.announcement, receiver)
                 .build();
     }
 }

--- a/pennyway-batch/src/main/java/kr/co/pennyway/batch/writer/NotificationWriter.java
+++ b/pennyway-batch/src/main/java/kr/co/pennyway/batch/writer/NotificationWriter.java
@@ -14,7 +14,6 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,7 +30,6 @@ public class NotificationWriter implements ItemWriter<DeviceTokenOwner> {
     @Transactional
     public void write(@NonNull Chunk<? extends DeviceTokenOwner> owners) throws Exception {
         log.info("Writer 실행: {}", owners.size());
-        LocalDateTime publishedAt = LocalDateTime.now();
 
         Map<Long, DailySpendingNotification> notificationMap = new HashMap<>();
 
@@ -41,7 +39,7 @@ public class NotificationWriter implements ItemWriter<DeviceTokenOwner> {
 
         List<Long> userIds = new ArrayList<>(notificationMap.keySet());
 
-        notificationRepository.saveDailySpendingAnnounceInBulk(userIds, publishedAt, Announcement.DAILY_SPENDING);
+        notificationRepository.saveDailySpendingAnnounceInBulk(userIds, Announcement.DAILY_SPENDING);
 
         for (DailySpendingNotification notification : notificationMap.values()) {
             publisher.publishEvent(NotificationEvent.of(notification.title(), notification.content(), notification.deviceTokensForList(), ""));

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/domain/Notification.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/domain/Notification.java
@@ -30,19 +30,25 @@ public class Notification extends DateAuditable {
     private Announcement announcement; // 공지 종류
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "receiver")
-    private User receiver;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender")
     private User sender;
+    private String senderName;
 
-    private Notification(LocalDateTime readAt, NoticeType type, Announcement announcement, User receiver, User sender) {
-        this.readAt = readAt;
+    private Long toId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver")
+    private User receiver;
+    private String receiverName;
+
+    private Notification(NoticeType type, Announcement announcement, User sender, String senderName, Long toId, User receiver, String receiverName) {
         this.type = Objects.requireNonNull(type);
         this.announcement = Objects.requireNonNull(announcement);
-        this.receiver = receiver;
-        this.sender = sender;
+        this.sender = (!type.equals(NoticeType.ANNOUNCEMENT)) ? Objects.requireNonNull(sender) : sender;
+        this.senderName = (!type.equals(NoticeType.ANNOUNCEMENT)) ? Objects.requireNonNull(senderName) : senderName;
+        this.toId = toId;
+        this.receiver = Objects.requireNonNull(receiver);
+        this.receiverName = Objects.requireNonNull(receiverName);
     }
 
     @Override
@@ -52,39 +58,43 @@ public class Notification extends DateAuditable {
                 ", readAt=" + readAt +
                 ", type=" + type +
                 ", announcement=" + announcement +
+                ", senderName='" + senderName + '\'' +
+                ", toId=" + toId +
+                ", receiverName='" + receiverName + '\'' +
                 '}';
     }
 
     public static class Builder {
-        private LocalDateTime readAt;
-        private NoticeType type;
-        private Announcement announcement;
+        private final NoticeType type;
+        private final Announcement announcement;
+        private final User receiver;
+        private final String receiverName;
 
-        private User receiver = null;
-        private User sender = null;
+        private User sender;
+        private String senderName;
 
-        public Builder(NoticeType type, Announcement announcement) {
+        private Long toId;
+
+        public Builder(NoticeType type, Announcement announcement, User receiver) {
             this.type = type;
             this.announcement = announcement;
-        }
-
-        public Builder readAt(LocalDateTime readAt) {
-            this.readAt = readAt;
-            return this;
-        }
-
-        public Builder receiver(User receiver) {
             this.receiver = receiver;
-            return this;
+            this.receiverName = receiver.getName();
         }
 
         public Builder sender(User sender) {
             this.sender = sender;
+            this.senderName = sender.getName();
+            return this;
+        }
+
+        public Builder toId(Long toId) {
+            this.toId = toId;
             return this;
         }
 
         public Notification build() {
-            return new Notification(readAt, type, announcement, receiver, sender);
+            return new Notification(type, announcement, sender, senderName, toId, receiver, receiverName);
         }
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/domain/Notification.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/domain/Notification.java
@@ -64,6 +64,20 @@ public class Notification extends DateAuditable {
                 '}';
     }
 
+    public String createFormattedTitle() {
+        if (type.equals(NoticeType.ANNOUNCEMENT)) {
+            return announcement.createFormattedTitle(receiverName);
+        }
+        return ""; // TODO: 알림 종류가 신규로 추가될 때, 해당 로직을 구현해야 함.
+    }
+
+    public String createFormattedContent() {
+        if (type.equals(NoticeType.ANNOUNCEMENT)) {
+            return announcement.createFormattedContent(receiverName);
+        }
+        return ""; // TODO: 알림 종류가 신규로 추가될 때, 해당 로직을 구현해야 함.
+    }
+
     public static class Builder {
         private final NoticeType type;
         private final Announcement announcement;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/repository/NotificationCustomRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/repository/NotificationCustomRepository.java
@@ -2,18 +2,17 @@ package kr.co.pennyway.domain.domains.notification.repository;
 
 import kr.co.pennyway.domain.domains.notification.type.Announcement;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface NotificationCustomRepository {
     /**
      * 사용자들에게 정기 지출 등록 알림을 저장한다. (발송이 아님)
-     * 만약 이미 publishedAt의 년-월-일에 해당하는 알림이 존재하고, 그 알림의 announcement까지 같다면 저장하지 않는다.
+     * 만약 이미 전송하려는 데이터가 년-월-일에 해당하는 생성일을 가지고 있고, 그 알림의 announcement 타입까지 같다면 저장하지 않는다.
      *
      * <pre>
      * {@code
-     * INSERT INTO notification(id, type, read_at, created_at, updated_at, receiver, announcement)
-     * SELECT NULL, '0', NULL, NOW(), NOW(), u.id, '1'
+     * INSERT INTO notification(type, announcement, created_at, updated_at, receiver, receiver_name)
+     * SELECT ?, ?, NOW(), NOW(), u.id, u.name
      * FROM user u
      * WHERE u.id IN (?)
      * AND NOT EXISTS (
@@ -29,8 +28,7 @@ public interface NotificationCustomRepository {
      * </pre>
      *
      * @param userIds      : 등록할 사용자 아이디 목록
-     * @param publishedAt  : 알림 발송 시간, 공지 알림 중복 저장 방지를 위해 조건식에 사용
-     * @param announcement : 알림 타입 {@link Announcement}
+     * @param announcement : 공지 타입 {@link Announcement}
      */
-    void saveDailySpendingAnnounceInBulk(List<Long> userIds, LocalDateTime publishedAt, Announcement announcement);
+    void saveDailySpendingAnnounceInBulk(List<Long> userIds, Announcement announcement);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/repository/NotificationCustomRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/repository/NotificationCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.domain.domains.notification.repository;
 
 import kr.co.pennyway.domain.domains.notification.type.Announcement;
+import kr.co.pennyway.domain.domains.notification.type.NoticeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
@@ -9,7 +10,6 @@ import org.springframework.stereotype.Repository;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,31 +19,31 @@ import java.util.List;
 public class NotificationCustomRepositoryImpl implements NotificationCustomRepository {
     private final JdbcTemplate jdbcTemplate;
 
-    private int batchSize = 500;
+    private final int BATCH_SIZE = 500;
 
     @Override
-    public void saveDailySpendingAnnounceInBulk(List<Long> userIds, LocalDateTime publishedAt, Announcement announcement) {
+    public void saveDailySpendingAnnounceInBulk(List<Long> userIds, Announcement announcement) {
         int batchCount = 0;
         List<Long> subItems = new ArrayList<>();
 
         for (int i = 0; i < userIds.size(); ++i) {
             subItems.add(userIds.get(i));
 
-            if ((i + 1) % batchSize == 0) {
-                batchCount = batchInsert(batchCount, subItems, publishedAt, announcement);
+            if ((i + 1) % BATCH_SIZE == 0) {
+                batchCount = batchInsert(batchCount, subItems, NoticeType.ANNOUNCEMENT, announcement);
             }
         }
 
         if (!subItems.isEmpty()) {
-            batchInsert(batchCount, subItems, publishedAt, announcement);
+            batchInsert(batchCount, subItems, NoticeType.ANNOUNCEMENT, announcement);
         }
 
         log.info("Notification saved. announcement: {}, count: {}", announcement, userIds.size());
     }
 
-    private int batchInsert(int batchCount, List<Long> userIds, LocalDateTime publishedAt, Announcement announcement) {
-        String sql = "INSERT INTO notification(id, type, read_at, created_at, updated_at, receiver, announcement) " +
-                "SELECT NULL, '0', NULL, NOW(), NOW(), u.id, ? " +
+    private int batchInsert(int batchCount, List<Long> userIds, NoticeType noticeType, Announcement announcement) {
+        String sql = "INSERT INTO notification(id, read_at, type, announcement, created_at, updated_at, receiver, receiver_name) " +
+                "SELECT NULL, NULL, ?, ?, NOW(), NOW(), u.id, u.name " +
                 "FROM user u " +
                 "WHERE u.id IN (?) " +
                 "AND NOT EXISTS ( " +
@@ -59,9 +59,10 @@ public class NotificationCustomRepositoryImpl implements NotificationCustomRepos
         jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {
-                ps.setString(1, announcement.getCode());
-                ps.setLong(2, userIds.get(i));
-                ps.setString(3, announcement.getCode());
+                ps.setString(1, noticeType.getCode());
+                ps.setString(2, announcement.getCode());
+                ps.setLong(3, userIds.get(i));
+                ps.setString(4, announcement.getCode());
             }
 
             @Override

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/repository/NotificationRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/repository/NotificationRepository.java
@@ -1,7 +1,7 @@
 package kr.co.pennyway.domain.domains.notification.repository;
 
+import kr.co.pennyway.domain.common.repository.ExtendedRepository;
 import kr.co.pennyway.domain.domains.notification.domain.Notification;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationCustomRepository {
+public interface NotificationRepository extends ExtendedRepository<Notification, Long>, NotificationCustomRepository {
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/service/NotificationService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/service/NotificationService.java
@@ -1,0 +1,37 @@
+package kr.co.pennyway.domain.domains.notification.service;
+
+import com.querydsl.core.types.Predicate;
+import kr.co.pennyway.common.annotation.DomainService;
+import kr.co.pennyway.domain.common.repository.QueryHandler;
+import kr.co.pennyway.domain.common.util.SliceUtil;
+import kr.co.pennyway.domain.domains.notification.domain.Notification;
+import kr.co.pennyway.domain.domains.notification.domain.QNotification;
+import kr.co.pennyway.domain.domains.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@DomainService
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+
+    private final QNotification notification = QNotification.notification;
+
+    @Transactional(readOnly = true)
+    public Slice<Notification> readNotificationsSlice(Long userId, Pageable pageable) {
+        Predicate predicate = notification.receiver.id.eq(userId);
+
+        QueryHandler queryHandler = query -> query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1);
+
+        Sort sort = pageable.getSort();
+
+        return SliceUtil.toSlice(notificationRepository.findList(predicate, queryHandler, sort), pageable);
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/type/Announcement.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/type/Announcement.java
@@ -24,11 +24,21 @@ public enum Announcement implements LegacyCommonType {
 
     public String createFormattedTitle(String name) {
         validateName(name);
+
+        if (this.title.indexOf("%") == -1) {
+            return this.title;
+        }
+
         return String.format(title, name);
     }
 
     public String createFormattedContent(String name) {
         validateName(name);
+
+        if (this.content.indexOf("%") == -1) {
+            return this.content;
+        }
+
         return String.format(content, name);
     }
 

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/notification/repository/ReadNotificationsSliceUnitTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/notification/repository/ReadNotificationsSliceUnitTest.java
@@ -1,0 +1,121 @@
+package kr.co.pennyway.domain.domains.notification.repository;
+
+import kr.co.pennyway.domain.config.ContainerMySqlTestConfig;
+import kr.co.pennyway.domain.config.JpaConfig;
+import kr.co.pennyway.domain.config.TestJpaConfig;
+import kr.co.pennyway.domain.domains.notification.domain.Notification;
+import kr.co.pennyway.domain.domains.notification.service.NotificationService;
+import kr.co.pennyway.domain.domains.notification.type.Announcement;
+import kr.co.pennyway.domain.domains.notification.type.NoticeType;
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.repository.UserRepository;
+import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
+import kr.co.pennyway.domain.domains.user.type.Role;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+import static org.springframework.test.util.AssertionErrors.assertTrue;
+
+@Slf4j
+@DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=create"})
+@ContextConfiguration(classes = {JpaConfig.class, NotificationService.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestJpaConfig.class)
+@ActiveProfiles("test")
+public class ReadNotificationsSliceUnitTest extends ContainerMySqlTestConfig {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Autowired
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Test
+    @Transactional
+    @DisplayName("특정 사용자의 알림 목록을 슬라이스로 조회하며, 결과는 최신순으로 정렬되어야 한다.")
+    public void readNotificationsSliceSorted() {
+        // given
+        User user = userRepository.save(createUser("jayang"));
+        Pageable pa = PageRequest.of(0, 5, Sort.by(Sort.Order.desc("notification.createdAt")));
+
+        List<Notification> notifications = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Notification notification = new Notification.Builder(NoticeType.ANNOUNCEMENT, Announcement.DAILY_SPENDING, user).build();
+            notifications.add(notification);
+        }
+        bulkInsertNotifications(notifications);
+
+        // when
+        Slice<Notification> result = notificationService.readNotificationsSlice(user.getId(), pa);
+
+        // then
+        assertEquals("Slice 데이터 개수는 5개여야 한다.", 5, result.getNumberOfElements());
+        assertTrue("hasNext()는 true여야 한다.", result.hasNext());
+        for (int i = 0; i < result.getNumberOfElements() - 1; i++) {
+            Notification current = result.getContent().get(i);
+            Notification next = result.getContent().get(i + 1);
+            log.debug("current: {}, next: {}", current.getCreatedAt(), next.getCreatedAt());
+            log.debug("notification: {}", current);
+            assert current.getCreatedAt().isAfter(next.getCreatedAt());
+        }
+    }
+
+    private User createUser(String name) {
+        return User.builder()
+                .username("test")
+                .name(name)
+                .password("test")
+                .phone("010-1234-5678")
+                .role(Role.USER)
+                .profileVisibility(ProfileVisibility.PUBLIC)
+                .notifySetting(NotifySetting.of(true, true, true))
+                .build();
+    }
+
+    private void bulkInsertNotifications(List<Notification> notifications) {
+        String sql = String.format("""
+                INSERT INTO `%s` (type, announcement, created_at, updated_at, receiver, receiver_name)
+                VALUES (:type, :announcement, :createdAt, :updatedAt, :receiver, :receiverName);
+                """, "notification");
+
+        LocalDateTime date = LocalDateTime.now();
+        SqlParameterSource[] params = new SqlParameterSource[notifications.size()];
+
+        for (int i = 0; i < notifications.size(); i++) {
+            Notification notification = notifications.get(i);
+            params[i] = new MapSqlParameterSource()
+                    .addValue("type", notification.getType().getCode())
+                    .addValue("announcement", notification.getAnnouncement().getCode())
+                    .addValue("createdAt", date)
+                    .addValue("updatedAt", date)
+                    .addValue("receiver", notification.getReceiver().getId())
+                    .addValue("receiverName", notification.getReceiverName());
+            date = date.minusDays(1);
+        }
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/notification/repository/SaveDailySpendingAnnounceInBulkTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/notification/repository/SaveDailySpendingAnnounceInBulkTest.java
@@ -22,7 +22,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.springframework.test.util.AssertionErrors.assertEquals;
@@ -51,7 +50,6 @@ public class SaveDailySpendingAnnounceInBulkTest extends ContainerMySqlTestConfi
         // when
         notificationRepository.saveDailySpendingAnnounceInBulk(
                 List.of(user1.getId(), user2.getId(), user3.getId()),
-                LocalDateTime.now(),
                 Announcement.DAILY_SPENDING
         );
 
@@ -70,20 +68,19 @@ public class SaveDailySpendingAnnounceInBulkTest extends ContainerMySqlTestConfi
         User user1 = userRepository.save(createUser("jayang"));
         User user2 = userRepository.save(createUser("mock"));
 
-        Notification notification = new Notification.Builder(NoticeType.ANNOUNCEMENT, Announcement.DAILY_SPENDING)
-                .receiver(user1)
+        Notification notification = new Notification.Builder(NoticeType.ANNOUNCEMENT, Announcement.DAILY_SPENDING, user1)
                 .build();
         notificationRepository.save(notification);
 
         // when
         notificationRepository.saveDailySpendingAnnounceInBulk(
                 List.of(user1.getId(), user2.getId()),
-                LocalDateTime.now(),
                 Announcement.DAILY_SPENDING
         );
 
         // then
         List<Notification> notifications = notificationRepository.findAll();
+        log.debug("notifications: {}", notifications);
         assertEquals("알림이 중복 저장되지 않아야 한다.", 2, notifications.size());
     }
 


### PR DESCRIPTION
## 작업 이유
- 사용자가 수신한 푸시 알림 리스트를 무한 스크롤로 조회 가능한 API 구현

<br/>

## 작업 사항
### 1️⃣ Notification Entity 수정
```sql
CREATE TABLE `pennyway`.`notification` (
	`id` bigint NOT NULL AUTO_INCREMENT,
	`type` char NOT NULL,
    `announcement` char NOT NULL,
	`read_at` datetime DEFAULT NULL,
	`created_at` datetime NOT NULL,
	`updated_at` datetime NOT NULL,
	`sender` bigint DEFAULT NULL,
	`receiver` bigint NOT NULL,
	PRIMARY KEY (`id`),
	UNIQUE INDEX `id_UNIQUE` (`id` ASC) VISIBLE,
	FOREIGN KEY (`sender`) REFERENCES `pennyway`.`user` (`id`)
	ON DELETE CASCADE ON UPDATE CASCADE,
	FOREIGN KEY (`receiver`) REFERENCES `pennyway`.`user` (`id`)
	ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;
```
- 기존 iOS 측에서 딥 링크를 위한 데이터를 확인할 수 없던 문제가 존재함.
- 따라서 송신자 `sender`, 수신자 `receiver`, 대상 pk `toId` 필드를 추가함.
- 송신자의 이름을 join 없이 유추하기 위해 비정규화하여 `receiver_name` 필드를 추가
   - 해당 방식은 송신자의 이름이 바뀌었을 시, 문제가 발생할 우려가 존재하므로 개선될 필요가 있음.
   - 현재는 사용하지 않기 때문에 해당 문제를 이슈로 등록하고 추후 처리.
- notification은 사용자가 자기 자신의 데이터를 불러오는 경우밖에 없으므로 `receiver_name`은 따로 저장하지 않음. 

<br/>

### 2️⃣ 푸시 알림 제목, 내용 포맷팅
```java
public class Notification extends DateAuditable {
    ...

    public String createFormattedTitle() {
        if (type.equals(NoticeType.ANNOUNCEMENT)) {
            return announcement.createFormattedTitle(receiverName);
        }
        return ""; // TODO: 알림 종류가 신규로 추가될 때, 해당 로직을 구현해야 함.
    }

    public String createFormattedContent() {
        if (type.equals(NoticeType.ANNOUNCEMENT)) {
            return announcement.createFormattedContent(receiverName);
        }
        return ""; // TODO: 알림 종류가 신규로 추가될 때, 해당 로직을 구현해야 함.
    }
}
```
- 이유가 없다면, `Notification` Entity 내의 함수를 호출하여 포맷팅된 문자열을 얻을 수 있음.
- 현재는 공지 알림인 경우밖에 존재하지 않으므로, notice type class 내의 포매팅 메서드는 구현하지 않음.

<br/>

```java
public enum Announcement implements LegacyCommonType {
    ...

    public String createFormattedTitle(String name) {
        validateName(name);

        if (this.title.indexOf("%") == -1) {
            return this.title;
        }

        return String.format(title, name);
    }

    public String createFormattedContent(String name) {
        validateName(name);

        if (this.content.indexOf("%") == -1) {
            return this.content;
        }

        return String.format(content, name);
    }
}
```
- `Announcement`는 제목과 내용에 수신자의 이름을 삽입하여 문자열을 반환하는 함수를 지님.
- `.contains()`가 아닌 `.indexOf()`를 사용한 이유는 성능 개선 목적을 위함.
   - *contains*()의 시간복잡도는 O(N*M)
   - *indexOf*()의 시간복잡도는 O(N)
   - title 혹은 content에 수신자의 이름을 삽입할 필요가 있는지 확인만 하면 되므로, indexOf 메서드를 사용함.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 전에 언급하긴 했지만, Notification Entity가 변경된 이유에 대해 이해하였는지?
- 포맷팅을 하는 방법이 적절하게 수행되고 있다고 생각하는지?

<br/>

## 발견한 이슈
- receiver name만 고려하고 비정규화를 했는데, 어차피 나중엔 사용자 프로필 데이터도 수신해야 함. 이를 개선할 수 있는 방법으로 join을 할 지, 매번 쿼리를 따로 호출할 지, 사용자 정보를 모두 캐싱해두고 빠르게 조회하는 전략을 수행할 지 고민이 필요함. 혹시나 좋은 아이디어 있다면 추천해주세용.
