### PR TITLE
Batch: ✨ 매월 목표 금액 설정 공지 푸시 알림 배치

### DIFF
--- a/pennyway-batch/src/main/java/kr/co/pennyway/batch/common/dto/AnnounceNotificationDto.java
+++ b/pennyway-batch/src/main/java/kr/co/pennyway/batch/common/dto/AnnounceNotificationDto.java
@@ -22,20 +22,14 @@ public record DailySpendingNotification(
         Objects.requireNonNull(deviceTokens, "deviceTokens must not be null");
     }
 
-    /**
-     * {@link DeviceTokenOwner}를 DailySpendingNotification DTO로 변환하는 정적 팩토리 메서드
-     * <p>
-     * DeviceToken은 List로 변환되어 멤버 변수로 관리하게 된다.
-     */
-    public static DailySpendingNotification from(DeviceTokenOwner owner) {
-        Announcement announcement = Announcement.DAILY_SPENDING;
+    public static DailySpendingNotification from(DeviceTokenOwner owner, Announcement announcement) {
         Set<String> deviceTokens = new HashSet<>();
         deviceTokens.add(owner.deviceToken());
 
         return DailySpendingNotification.builder()
                 .userId(owner.userId())
                 .title(announcement.createFormattedTitle(owner.name()))
-                .content(announcement.getContent())
+                .content(announcement.createFormattedContent(owner.name()))
                 .deviceTokens(deviceTokens)
                 .build();
     }

--- a/pennyway-batch/src/main/java/kr/co/pennyway/batch/common/dto/AnnounceNotificationDto.java
+++ b/pennyway-batch/src/main/java/kr/co/pennyway/batch/common/dto/AnnounceNotificationDto.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.batch.common.dto;
 import kr.co.pennyway.domain.domains.notification.type.Announcement;
 import lombok.Builder;
 
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -28,10 +29,18 @@ public record AnnounceNotificationDto(
 
         return AnnounceNotificationDto.builder()
                 .userId(owner.userId())
-                .title(announcement.createFormattedTitle(owner.name()))
+                .title(createFormattedTitle(owner, announcement))
                 .content(announcement.createFormattedContent(owner.name()))
                 .deviceTokens(deviceTokens)
                 .build();
+    }
+
+    private static String createFormattedTitle(DeviceTokenOwner owner, Announcement announcement) {
+        if (announcement.equals(Announcement.MONTHLY_TARGET_AMOUNT)) {
+            return announcement.createFormattedTitle(String.valueOf(LocalDateTime.now().getMonthValue()));
+        }
+
+        return announcement.createFormattedTitle(owner.name());
     }
 
     public void addDeviceToken(String deviceToken) {

--- a/pennyway-batch/src/main/java/kr/co/pennyway/batch/common/dto/AnnounceNotificationDto.java
+++ b/pennyway-batch/src/main/java/kr/co/pennyway/batch/common/dto/AnnounceNotificationDto.java
@@ -9,24 +9,24 @@ import java.util.Objects;
 import java.util.Set;
 
 @Builder
-public record DailySpendingNotification(
+public record AnnounceNotificationDto(
         Long userId,
         String title,
         String content,
         Set<String> deviceTokens
 ) {
-    public DailySpendingNotification {
+    public AnnounceNotificationDto {
         Objects.requireNonNull(userId, "userId must not be null");
         Objects.requireNonNull(title, "title must not be null");
         Objects.requireNonNull(content, "content must not be null");
         Objects.requireNonNull(deviceTokens, "deviceTokens must not be null");
     }
 
-    public static DailySpendingNotification from(DeviceTokenOwner owner, Announcement announcement) {
+    public static AnnounceNotificationDto from(DeviceTokenOwner owner, Announcement announcement) {
         Set<String> deviceTokens = new HashSet<>();
         deviceTokens.add(owner.deviceToken());
 
-        return DailySpendingNotification.builder()
+        return AnnounceNotificationDto.builder()
                 .userId(owner.userId())
                 .title(announcement.createFormattedTitle(owner.name()))
                 .content(announcement.createFormattedContent(owner.name()))

--- a/pennyway-batch/src/main/java/kr/co/pennyway/batch/job/MonthlyTargetAmountNotifyConfig.java
+++ b/pennyway-batch/src/main/java/kr/co/pennyway/batch/job/MonthlyTargetAmountNotifyConfig.java
@@ -2,7 +2,7 @@ package kr.co.pennyway.batch.job;
 
 import kr.co.pennyway.batch.common.dto.DeviceTokenOwner;
 import kr.co.pennyway.batch.reader.ActiveDeviceTokenReader;
-import kr.co.pennyway.batch.writer.DailySpendingNotifyWriter;
+import kr.co.pennyway.batch.writer.MonthlyTotalAmountNotifyWriter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -16,17 +16,17 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 @RequiredArgsConstructor
-public class DailySpendingNotifyConfig {
+public class MonthlyTargetAmountNotifyConfig {
     private final JobRepository jobRepository;
     private final ActiveDeviceTokenReader reader;
-    private final DailySpendingNotifyWriter writer;
+    private final MonthlyTotalAmountNotifyWriter writer;
 
     @Bean
-    public Job dailyNotificationJob(PlatformTransactionManager transactionManager) {
-        return new JobBuilder("dailyNotificationJob", jobRepository)
-                .start(dailyNotificationStep(transactionManager))
+    public Job monthlyNotificationJob(PlatformTransactionManager transactionManager) {
+        return new JobBuilder("monthlyNotificationJob", jobRepository)
+                .start(monthlyNotificationStep(transactionManager))
                 .on("FAILED")
-                .stopAndRestart(dailyNotificationStep(transactionManager))
+                .stopAndRestart(monthlyNotificationStep(transactionManager))
                 .on("*")
                 .end()
                 .end()
@@ -35,8 +35,8 @@ public class DailySpendingNotifyConfig {
 
     @Bean
     @JobScope
-    public Step dailyNotificationStep(PlatformTransactionManager transactionManager) {
-        return new StepBuilder("sendSpendingNotifyStep", jobRepository)
+    public Step monthlyNotificationStep(PlatformTransactionManager transactionManager) {
+        return new StepBuilder("sendMonthlyNotifyStep", jobRepository)
                 .<DeviceTokenOwner, DeviceTokenOwner>chunk(1000, transactionManager)
                 .reader(reader.querydslNoOffsetPagingItemReader())
                 .writer(writer)

--- a/pennyway-batch/src/main/java/kr/co/pennyway/batch/scheduler/SpendingNotifyScheduler.java
+++ b/pennyway-batch/src/main/java/kr/co/pennyway/batch/scheduler/SpendingNotifyScheduler.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class SpendingNotifyScheduler {
     private final JobLauncher jobLauncher;
     private final Job dailyNotificationJob;
+    private final Job monthlyNotificationJob;
 
     @Scheduled(cron = "0 0 20 * * ?")
     public void runDailyNotificationJob() {
@@ -31,6 +32,20 @@ public class SpendingNotifyScheduler {
         } catch (JobExecutionAlreadyRunningException | JobRestartException
                  | JobInstanceAlreadyCompleteException | JobParametersInvalidException e) {
             log.error("Failed to run dailyNotificationJob", e);
+        }
+    }
+
+    @Scheduled(cron = "0 0 10 1 * ?")
+    public void runMonthlyNotificationJob() {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+
+        try {
+            jobLauncher.run(monthlyNotificationJob, jobParameters);
+        } catch (JobExecutionAlreadyRunningException | JobRestartException
+                 | JobInstanceAlreadyCompleteException | JobParametersInvalidException e) {
+            log.error("Failed to run monthlyNotificationJob", e);
         }
     }
 }

--- a/pennyway-batch/src/main/java/kr/co/pennyway/batch/writer/DailySpendingNotifyWriter.java
+++ b/pennyway-batch/src/main/java/kr/co/pennyway/batch/writer/DailySpendingNotifyWriter.java
@@ -23,7 +23,7 @@ import java.util.Map;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class NotificationWriter implements ItemWriter<DeviceTokenOwner> {
+public class DailySpendingNotifyWriter implements ItemWriter<DeviceTokenOwner> {
     private final NotificationRepository notificationRepository;
     private final ApplicationEventPublisher publisher;
 

--- a/pennyway-batch/src/main/java/kr/co/pennyway/batch/writer/DailySpendingNotifyWriter.java
+++ b/pennyway-batch/src/main/java/kr/co/pennyway/batch/writer/DailySpendingNotifyWriter.java
@@ -1,6 +1,6 @@
 package kr.co.pennyway.batch.writer;
 
-import kr.co.pennyway.batch.common.dto.DailySpendingNotification;
+import kr.co.pennyway.batch.common.dto.AnnounceNotificationDto;
 import kr.co.pennyway.batch.common.dto.DeviceTokenOwner;
 import kr.co.pennyway.domain.domains.notification.repository.NotificationRepository;
 import kr.co.pennyway.domain.domains.notification.type.Announcement;
@@ -33,17 +33,17 @@ public class DailySpendingNotifyWriter implements ItemWriter<DeviceTokenOwner> {
     public void write(@NonNull Chunk<? extends DeviceTokenOwner> owners) throws Exception {
         log.info("Writer 실행: {}", owners.size());
 
-        Map<Long, DailySpendingNotification> notificationMap = new HashMap<>();
+        Map<Long, AnnounceNotificationDto> notificationMap = new HashMap<>();
 
         for (DeviceTokenOwner owner : owners) {
-            notificationMap.computeIfAbsent(owner.userId(), k -> DailySpendingNotification.from(owner)).addDeviceToken(owner.deviceToken());
+            notificationMap.computeIfAbsent(owner.userId(), k -> AnnounceNotificationDto.from(owner, Announcement.DAILY_SPENDING)).addDeviceToken(owner.deviceToken());
         }
 
         List<Long> userIds = new ArrayList<>(notificationMap.keySet());
 
         notificationRepository.saveDailySpendingAnnounceInBulk(userIds, Announcement.DAILY_SPENDING);
 
-        for (DailySpendingNotification notification : notificationMap.values()) {
+        for (AnnounceNotificationDto notification : notificationMap.values()) {
             publisher.publishEvent(NotificationEvent.of(notification.title(), notification.content(), notification.deviceTokensForList(), ""));
         }
     }

--- a/pennyway-batch/src/main/java/kr/co/pennyway/batch/writer/MonthlyTotalAmountNotifyWriter.java
+++ b/pennyway-batch/src/main/java/kr/co/pennyway/batch/writer/MonthlyTotalAmountNotifyWriter.java
@@ -1,0 +1,50 @@
+package kr.co.pennyway.batch.writer;
+
+import kr.co.pennyway.batch.common.dto.AnnounceNotificationDto;
+import kr.co.pennyway.batch.common.dto.DeviceTokenOwner;
+import kr.co.pennyway.domain.domains.notification.repository.NotificationRepository;
+import kr.co.pennyway.domain.domains.notification.type.Announcement;
+import kr.co.pennyway.infra.common.event.NotificationEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MonthlyTotalAmountNotifyWriter implements ItemWriter<DeviceTokenOwner> {
+    private final NotificationRepository notificationRepository;
+    private final ApplicationEventPublisher publisher;
+
+    @Override
+    @StepScope
+    @Transactional
+    public void write(@NonNull Chunk<? extends DeviceTokenOwner> owners) throws Exception {
+        log.info("Writer 실행: {}", owners.size());
+
+        Map<Long, AnnounceNotificationDto> notificationMap = new HashMap<>();
+
+        for (DeviceTokenOwner owner : owners) {
+            notificationMap.computeIfAbsent(owner.userId(), k -> AnnounceNotificationDto.from(owner, Announcement.MONTHLY_TARGET_AMOUNT)).addDeviceToken(owner.deviceToken());
+        }
+
+        List<Long> userIds = new ArrayList<>(notificationMap.keySet());
+
+        notificationRepository.saveDailySpendingAnnounceInBulk(userIds, Announcement.MONTHLY_TARGET_AMOUNT);
+
+        for (AnnounceNotificationDto notification : notificationMap.values()) {
+            publisher.publishEvent(NotificationEvent.of(notification.title(), notification.content(), notification.deviceTokensForList(), ""));
+        }
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/domain/Notification.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/domain/Notification.java
@@ -72,10 +72,19 @@ public class Notification extends DateAuditable {
      * @apiNote 이 메서드는 {@link NoticeType#ANNOUNCEMENT} 타입에 대해서만 동작한다. 다른 타입의 알림을 포맷팅해야 하는 경우 해당 메서드를 확장해야 한다.
      */
     public String createFormattedTitle() {
-        if (type.equals(NoticeType.ANNOUNCEMENT)) {
-            return announcement.createFormattedTitle(receiverName);
+        if (!type.equals(NoticeType.ANNOUNCEMENT)) {
+            return ""; // TODO: 알림 종류가 신규로 추가될 때, 해당 로직을 구현해야 함.
         }
-        return ""; // TODO: 알림 종류가 신규로 추가될 때, 해당 로직을 구현해야 함.
+
+        return formatAnnouncementTitle();
+    }
+
+    private String formatAnnouncementTitle() {
+        if (announcement.equals(Announcement.MONTHLY_TARGET_AMOUNT)) {
+            return announcement.createFormattedTitle(String.valueOf(getCreatedAt().getMonthValue()));
+        }
+
+        return announcement.createFormattedTitle(receiverName);
     }
 
     /**
@@ -86,10 +95,11 @@ public class Notification extends DateAuditable {
      * @apiNote 이 메서드는 {@link NoticeType#ANNOUNCEMENT} 타입에 대해서만 동작한다. 다른 타입의 알림을 포맷팅해야 하는 경우 해당 메서드를 확장해야 한다.
      */
     public String createFormattedContent() {
-        if (type.equals(NoticeType.ANNOUNCEMENT)) {
-            return announcement.createFormattedContent(receiverName);
+        if (!type.equals(NoticeType.ANNOUNCEMENT)) {
+            return ""; // TODO: 알림 종류가 신규로 추가될 때, 해당 로직을 구현해야 함.
         }
-        return ""; // TODO: 알림 종류가 신규로 추가될 때, 해당 로직을 구현해야 함.
+
+        return announcement.createFormattedContent(receiverName);
     }
 
     public static class Builder {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/type/Announcement.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/type/Announcement.java
@@ -10,7 +10,7 @@ public enum Announcement implements LegacyCommonType {
 
     // 정기 지출 알림
     DAILY_SPENDING("1", "%s님, 3분 카레보다 빨리 끝나요!", "많은 친구들이 소비 기록에 참여하고 있어요👀"),
-    MONTHLY_TARGET_AMOUNT("2", "%월의 첫 시작! 두구두구..🥁", "%s님의 이번 달 목표 소비 금액은?");
+    MONTHLY_TARGET_AMOUNT("2", "%s월의 첫 시작! 두구두구..🥁", "%s님의 이번 달 목표 소비 금액은?");
 
     private final String code;
     private final String title;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/type/Announcement.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/type/Announcement.java
@@ -10,7 +10,7 @@ public enum Announcement implements LegacyCommonType {
 
     // 정기 지출 알림
     DAILY_SPENDING("1", "%s님, 3분 카레보다 빨리 끝나요!", "많은 친구들이 소비 기록에 참여하고 있어요👀"),
-    MONTHLY_TARGET_AMOUNT("2", "6월의 첫 시작! 두구두구..🥁", "%s님의 이번 달 목표 소비 금액은?");
+    MONTHLY_TARGET_AMOUNT("2", "%월의 첫 시작! 두구두구..🥁", "%s님의 이번 달 목표 소비 금액은?");
 
     private final String code;
     private final String title;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/type/Announcement.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/type/Announcement.java
@@ -62,5 +62,9 @@ public enum Announcement implements LegacyCommonType {
         if (!StringUtils.hasText(name)) {
             throw new IllegalArgumentException("name must not be empty");
         }
+
+        if (this == NOT_ANNOUNCE) {
+            throw new IllegalArgumentException("NOT_ANNOUNCE type is not allowed");
+        }
     }
 }


### PR DESCRIPTION
## 작업 이유
- 매월 1일이 되면, 지출 관리 푸시 알림을 허용한 사용자의 활성화된 device_token 전체에 푸시 알림을 보낼 수 있어야 한다.
- 사용자가 여러 device_token을 가지고 있더라도, 사용자에게 저장되는 푸시 알림은 하나여야 한다.

<br/>

## 작업 사항

<div align="center">
   <img src="https://github.com/user-attachments/assets/326e21c2-94de-44c9-9ed1-35ed2f3c10d2" width="300px"/>
</div>

- 다른 건 이전 배치 작업이랑 똑같은데, 한 가지...문제가...이 공지 알림은 제목에 날짜가 들어간당...ㅎㅎ
   - 생성할 땐, 시스템 상의 현재 날짜의 달을 삽입
   - 조회할 땐, 데이터의 created_at 정보의 달을 삽입
- 파싱할 때, announcement enum class를 호출하는 측에서 분기 처리해야 함 
   - AnnounceNotificationDto의 정적 팩토리 메서드 내에서 title 만들 때, 번거롭게 또 분기처리....

![image](https://github.com/user-attachments/assets/43a29623-3f41-414d-bb40-b26c86eb030d)

![image](https://github.com/user-attachments/assets/8ec94a42-63bd-4f34-b321-55afce2fff32)

저장 & 조회 모두 잘 되는 것을 확인 함.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- `MONTHLY_TARGET_AMOUNT` 상수의 제목 파싱하는 방법이 너무 더럽고, 휴먼 에러를 야기할 수 있다고 생각.
   - 하지만 반면으로 "공지" 알림이라는 게 빈번한 수정이 발생할 사안은 아닌 듯 해서 냅둬도 괜찮을 지도.
   - 분기처리를 Announcement 호출자 측으로 위임해버리는 바람에, title, content 수정 시 버그가 많아질 것 같아서 대비책을 구상해둘 필요가 있을 것 같음..

<br/>

## 발견한 이슈
- 없음.

