### PR TITLE
Api: ✏️ 사용자 삭제 로직 추가

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserDeleteService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserDeleteService.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.api.apis.users.service;
 
+import kr.co.pennyway.domain.domains.device.service.DeviceTokenService;
 import kr.co.pennyway.domain.domains.oauth.service.OauthService;
 import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
 import kr.co.pennyway.domain.domains.spending.service.SpendingService;
@@ -24,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserDeleteService {
     private final UserService userService;
     private final OauthService oauthService;
+    private final DeviceTokenService deviceTokenService;
 
     private final SpendingService spendingService;
     private final SpendingCustomCategoryService spendingCustomCategoryService;
@@ -43,6 +45,7 @@ public class UserDeleteService {
         // TODO: [2024-05-03] 하나라도 채팅방의 방장으로 참여하는 경우 삭제 불가능 처리
 
         oauthService.deleteOauthsByUserIdInQuery(userId);
+        deviceTokenService.deleteDevicesByUserIdInQuery(userId);
 
         spendingService.deleteSpendingsByUserIdInQuery(userId);
         spendingCustomCategoryService.deleteSpendingCustomCategoriesByUserIdInQuery(userId);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserDeleteService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserDeleteService.java
@@ -1,6 +1,8 @@
 package kr.co.pennyway.api.apis.users.service;
 
 import kr.co.pennyway.domain.domains.oauth.service.OauthService;
+import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
+import kr.co.pennyway.domain.domains.spending.service.SpendingService;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
 import kr.co.pennyway.domain.domains.user.service.UserService;
@@ -23,13 +25,28 @@ public class UserDeleteService {
     private final UserService userService;
     private final OauthService oauthService;
 
+    private final SpendingService spendingService;
+    private final SpendingCustomCategoryService spendingCustomCategoryService;
+
+    /**
+     * 사용자와 관련한 모든 데이터를 삭제(soft delete)하는 메서드
+     * <p>
+     * hard delete가 수행되어야 할 데이터는 삭제하지 않으며, 사용자 데이터 유지 기간이 만료될 때 DBA가 수행한다.
+     *
+     * @param userId
+     * @todo [2024-05-03] 채팅 기능이 추가되는 경우 채팅방장 탈퇴를 제한해야 하며, 추가로 삭제될 엔티티 삭제 로직을 추가해야 한다.
+     */
     @Transactional
     public void execute(Long userId) {
         if (!userService.isExistUser(userId)) throw new UserErrorException(UserErrorCode.NOT_FOUND);
 
         // TODO: [2024-05-03] 하나라도 채팅방의 방장으로 참여하는 경우 삭제 불가능 처리
-        
-        oauthService.deleteOauthsByUserId(userId);
+
+        oauthService.deleteOauthsByUserIdInQuery(userId);
+
+        spendingService.deleteSpendingsByUserIdInQuery(userId);
+        spendingCustomCategoryService.deleteSpendingCustomCategoriesByUserIdInQuery(userId);
+
         userService.deleteUser(userId);
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/TestJpaConfig.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/TestJpaConfig.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.api.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestJpaConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    @ConditionalOnMissingBean
+    public JPAQueryFactory testJpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceTokenRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceTokenRepository.java
@@ -2,6 +2,9 @@ package kr.co.pennyway.domain.domains.device.repository;
 
 import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +13,9 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
     Optional<DeviceToken> findByUser_IdAndToken(Long userId, String token);
 
     List<DeviceToken> findAllByUser_Id(Long userId);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("UPDATE DeviceToken d SET d.activated = false WHERE d.user.id = :userId")
+    void deleteAllByUserIdInQuery(Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceTokenRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/repository/DeviceTokenRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+    @Query("SELECT d FROM DeviceToken d WHERE d.user.id = :userId AND d.token = :token")
     Optional<DeviceToken> findByUser_IdAndToken(Long userId, String token);
 
     List<DeviceToken> findAllByUser_Id(Long userId);

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceTokenService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceTokenService.java
@@ -40,4 +40,9 @@ public class DeviceTokenService {
     public void deleteDevice(DeviceToken deviceToken) {
         deviceTokenRepository.delete(deviceToken);
     }
+
+    @Transactional
+    public void deleteDevicesByUserIdInQuery(Long userId) {
+        deviceTokenRepository.deleteAllByUserIdInQuery(userId);
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceTokenService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceTokenService.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -24,16 +23,6 @@ public class DeviceTokenService {
     @Transactional
     public Optional<DeviceToken> readDeviceByUserIdAndToken(Long userId, String token) {
         return deviceTokenRepository.findByUser_IdAndToken(userId, token);
-    }
-
-    @Transactional(readOnly = true)
-    public List<DeviceToken> readDevicesByUserId(Long userId) {
-        return deviceTokenRepository.findAllByUser_Id(userId);
-    }
-
-    @Transactional
-    public void deleteDevice(Long deviceId) {
-        deviceTokenRepository.deleteById(deviceId);
     }
 
     @Transactional

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -54,7 +54,7 @@ public class OauthService {
     }
 
     @Transactional
-    public void deleteOauthsByUserId(Long userId) {
+    public void deleteOauthsByUserIdInQuery(Long userId) {
         oauthRepository.deleteAllByUser_IdAndDeletedAtNullInQuery(userId);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomCategoryRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomCategoryRepository.java
@@ -17,6 +17,6 @@ public interface SpendingCustomCategoryRepository extends JpaRepository<Spending
 
     @Modifying(clearAutomatically = true)
     @Transactional
-    @Query("UPDATE SpendingCustomCategory s SET s.deletedAt = NOW() WHERE s.user.id = :userId AND s.deletedAt IS NULL")
+    @Query("UPDATE SpendingCustomCategory s SET s.deletedAt = NOW() WHERE s.user.id = :userId")
     void deleteAllByUserIdInQuery(Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomCategoryRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingCustomCategoryRepository.java
@@ -2,6 +2,8 @@ package kr.co.pennyway.domain.domains.spending.repository;
 
 import kr.co.pennyway.domain.domains.spending.domain.SpendingCustomCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -12,4 +14,9 @@ public interface SpendingCustomCategoryRepository extends JpaRepository<Spending
 
     @Transactional(readOnly = true)
     List<SpendingCustomCategory> findAllByUser_Id(Long userId);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("UPDATE SpendingCustomCategory s SET s.deletedAt = NOW() WHERE s.user.id = :userId AND s.deletedAt IS NULL")
+    void deleteAllByUserIdInQuery(Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingRepository.java
@@ -13,11 +13,6 @@ public interface SpendingRepository extends ExtendedRepository<Spending, Long>, 
     @Transactional(readOnly = true)
     boolean existsByIdAndUser_Id(Long id, Long userId);
 
-    @Transactional
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE Spending s SET s.deletedAt = NOW() WHERE s.spendingCustomCategory.id = :categoryId AND s.deletedAt IS NULL")
-    void deleteAllByCategoryIdAndDeletedAtNullInQuery(Long categoryId);
-
     @Transactional(readOnly = true)
     int countByUser_IdAndSpendingCustomCategory_Id(Long userId, Long categoryId);
 
@@ -26,11 +21,6 @@ public interface SpendingRepository extends ExtendedRepository<Spending, Long>, 
 
     @Transactional(readOnly = true)
     long countByUserIdAndIdIn(Long userId, List<Long> spendingIds);
-
-    @Modifying(clearAutomatically = true)
-    @Transactional
-    @Query("UPDATE Spending s SET s.deletedAt = NOW() where s.id IN :spendingIds AND s.deletedAt IS NULL")
-    void deleteAllByIdAndDeletedAtNullInQuery(List<Long> spendingIds);
 
     @Modifying(clearAutomatically = true)
     @Transactional
@@ -51,4 +41,19 @@ public interface SpendingRepository extends ExtendedRepository<Spending, Long>, 
     @Transactional
     @Query("UPDATE Spending s SET s.spendingCustomCategory = null, s.category = :toCategory WHERE s.spendingCustomCategory.id = :fromCategoryId AND s.deletedAt IS NULL")
     void updateCustomCategoryByCategoryInQuery(Long fromCategoryId, SpendingCategory toCategory);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("UPDATE Spending s SET s.deletedAt = NOW() where s.id IN :spendingIds AND s.deletedAt IS NULL")
+    void deleteAllByIdAndDeletedAtNullInQuery(List<Long> spendingIds);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("UPDATE Spending s SET s.deletedAt = NOW() WHERE s.user.id = :userId AND s.deletedAt IS NULL")
+    void deleteAllByUserIdInQuery(Long userId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Spending s SET s.deletedAt = NOW() WHERE s.spendingCustomCategory.id = :categoryId AND s.deletedAt IS NULL")
+    void deleteAllByCategoryIdAndDeletedAtNullInQuery(Long categoryId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/repository/SpendingRepository.java
@@ -24,36 +24,36 @@ public interface SpendingRepository extends ExtendedRepository<Spending, Long>, 
 
     @Modifying(clearAutomatically = true)
     @Transactional
-    @Query("UPDATE Spending s SET s.spendingCustomCategory.id = :toCategoryId, s.category = :custom WHERE s.category = :fromCategory AND s.deletedAt IS NULL")
+    @Query("UPDATE Spending s SET s.spendingCustomCategory.id = :toCategoryId, s.category = :custom WHERE s.category = :fromCategory")
     void updateCategoryByCustomCategoryInQuery(SpendingCategory fromCategory, Long toCategoryId, SpendingCategory custom);
 
     @Modifying(clearAutomatically = true)
     @Transactional
-    @Query("UPDATE Spending s SET s.category = :toCategory WHERE s.category = :fromCategory AND s.deletedAt IS NULL")
+    @Query("UPDATE Spending s SET s.category = :toCategory WHERE s.category = :fromCategory")
     void updateCategoryByCategoryInQuery(SpendingCategory fromCategory, SpendingCategory toCategory);
 
     @Modifying(clearAutomatically = true)
     @Transactional
-    @Query("UPDATE Spending s SET s.spendingCustomCategory.id = :toCategoryId WHERE s.spendingCustomCategory.id = :fromCategoryId AND s.deletedAt IS NULL")
+    @Query("UPDATE Spending s SET s.spendingCustomCategory.id = :toCategoryId WHERE s.spendingCustomCategory.id = :fromCategoryId")
     void updateCustomCategoryByCustomCategoryInQuery(Long fromCategoryId, Long toCategoryId);
 
     @Modifying(clearAutomatically = true)
     @Transactional
-    @Query("UPDATE Spending s SET s.spendingCustomCategory = null, s.category = :toCategory WHERE s.spendingCustomCategory.id = :fromCategoryId AND s.deletedAt IS NULL")
+    @Query("UPDATE Spending s SET s.spendingCustomCategory = null, s.category = :toCategory WHERE s.spendingCustomCategory.id = :fromCategoryId")
     void updateCustomCategoryByCategoryInQuery(Long fromCategoryId, SpendingCategory toCategory);
 
     @Modifying(clearAutomatically = true)
     @Transactional
-    @Query("UPDATE Spending s SET s.deletedAt = NOW() where s.id IN :spendingIds AND s.deletedAt IS NULL")
+    @Query("UPDATE Spending s SET s.deletedAt = NOW() where s.id IN :spendingIds")
     void deleteAllByIdAndDeletedAtNullInQuery(List<Long> spendingIds);
 
     @Modifying(clearAutomatically = true)
     @Transactional
-    @Query("UPDATE Spending s SET s.deletedAt = NOW() WHERE s.user.id = :userId AND s.deletedAt IS NULL")
+    @Query("UPDATE Spending s SET s.deletedAt = NOW() WHERE s.user.id = :userId")
     void deleteAllByUserIdInQuery(Long userId);
 
     @Transactional
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Spending s SET s.deletedAt = NOW() WHERE s.spendingCustomCategory.id = :categoryId AND s.deletedAt IS NULL")
+    @Query("UPDATE Spending s SET s.deletedAt = NOW() WHERE s.spendingCustomCategory.id = :categoryId")
     void deleteAllByCategoryIdAndDeletedAtNullInQuery(Long categoryId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingCustomCategoryService.java
@@ -40,4 +40,9 @@ public class SpendingCustomCategoryService {
     public void deleteSpendingCustomCategory(Long categoryId) {
         spendingCustomCategoryRepository.deleteById(categoryId);
     }
+
+    @Transactional
+    public void deleteSpendingCustomCategoriesByUserIdInQuery(Long userId) {
+        spendingCustomCategoryRepository.deleteAllByUserIdInQuery(userId);
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/spending/service/SpendingService.java
@@ -123,24 +123,9 @@ public class SpendingService {
         return spendingRepository.selectList(predicate, TotalSpendingAmount.class, bindings, queryHandler, sort);
     }
 
-    @Transactional
-    public void deleteSpendingsByCategoryIdInQuery(Long categoryId) {
-        spendingRepository.deleteAllByCategoryIdAndDeletedAtNullInQuery(categoryId);
-    }
-
     @Transactional(readOnly = true)
     public boolean isExistsSpending(Long userId, Long spendingId) {
         return spendingRepository.existsByIdAndUser_Id(spendingId, userId);
-    }
-
-    @Transactional
-    public void deleteSpending(Spending spending) {
-        spendingRepository.delete(spending);
-    }
-
-    @Transactional
-    public void deleteSpendingsInQuery(List<Long> spendingIds) {
-        spendingRepository.deleteAllByIdAndDeletedAtNullInQuery(spendingIds);
     }
 
     @Transactional(readOnly = true)
@@ -168,5 +153,25 @@ public class SpendingService {
     @Transactional
     public void updateCustomCategoryByCategory(Long fromId, SpendingCategory toCategory) {
         spendingRepository.updateCustomCategoryByCategoryInQuery(fromId, toCategory);
+    }
+
+    @Transactional
+    public void deleteSpending(Spending spending) {
+        spendingRepository.delete(spending);
+    }
+
+    @Transactional
+    public void deleteSpendingsInQuery(List<Long> spendingIds) {
+        spendingRepository.deleteAllByIdAndDeletedAtNullInQuery(spendingIds);
+    }
+
+    @Transactional
+    public void deleteSpendingsByUserIdInQuery(Long userId) {
+        spendingRepository.deleteAllByUserIdInQuery(userId);
+    }
+
+    @Transactional
+    public void deleteSpendingsByCategoryIdInQuery(Long categoryId) {
+        spendingRepository.deleteAllByCategoryIdAndDeletedAtNullInQuery(categoryId);
     }
 }


### PR DESCRIPTION
## 작업 이유
- User 삭제 시나리오에서 관여하는 Entity가 늘어남에 따라 관련 데이터 삭제 처리

<br/>

## 작업 사항
- Spending, SpendingCustomCategory 모두 soft delete 처리합니다.
- 디바이스 토큰은 is_activate를 false로 변경합니다. (미리미리 해둬야 나중에 배치가 덜 부담스러워 함.)
- hard delete해야 하는 notification은 삭제 처리하지 않습니다.
   - 어차피 해당 데이터는 사용자 본인을 제외하고 조회할 경우가 없음 (관리자도 굳이..)
   - 안 그래도 삭제할 작업 많은데, 데이터가 삽시간에 많아지는 notification bulk 삭제한다는 발상보다는 나중에 soft delete 처리한 사용자 보관 만료기간 끝날 때 DB에서 처리하는 게 효율적이라 판단함.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음

<br/>

## 발견한 이슈
- Fixture 컨벤션을 안 정해놨더니, 진짜 뭔 소린지 몬 알아먹겠음.. 어떻게 할 지 논의가 필요함.
