### PR TITLE
Batch: 🐛 Batch 애플리케이션 timezone 수정

### DIFF
--- a/pennyway-batch/src/main/java/kr/co/pennyway/PennywayBatchApplication.java
+++ b/pennyway-batch/src/main/java/kr/co/pennyway/PennywayBatchApplication.java
@@ -1,13 +1,21 @@
 package kr.co.pennyway;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableScheduling
 public class PennywayBatchApplication {
     public static void main(String[] args) {
         SpringApplication.run(PennywayBatchApplication.class, args);
+    }
+
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     }
 }


### PR DESCRIPTION
## 작업 이유
- 정기 알림이 새벽 5시에 전송되는 문제 발생

<br/>

## 작업 사항
- Batch 애플리케이션 실행 환경 타임존 수정

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음

<br/>

## 발견한 이슈
![image](https://github.com/user-attachments/assets/61c42852-3708-4000-862c-c6837f78072e)

문제가 발생했을 때는 시간이 올바르게 표시되었으나, 현재는 그렇지 않음.  
그런데 실제로 올바른 시간에 푸시 알림이 보내지는 건 위 이미지처럼 시간이 표시될 때;;  

EC2 타임존도 맞춰줬는데 이유를 잘 모르겠음.

