### PR TITLE
Ignore: ✨ 프로필 사진 삭제 API 및 수정 API 픽스, 리팩토링

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/storage/api/StorageApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/storage/api/StorageApi.java
@@ -1,8 +1,5 @@
 package kr.co.pennyway.api.apis.storage.api;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -14,37 +11,40 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.pennyway.api.apis.storage.dto.PresignedUrlDto;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 
 @Tag(name = "[S3 이미지 저장을 위한 Presigned URL 발급 API]")
 public interface StorageApi {
-	@Operation(summary = "S3 이미지 저장을 위한 Presigned URL 발급", description = "S3에 이미지를 저장하기 위한 Presigned URL을 발급합니다.")
-	@Parameters({
-			@Parameter(name = "type", description = "이미지 종류", required = true, in = ParameterIn.QUERY, examples = {
-					@ExampleObject(value = "PROFILE"),
-					@ExampleObject(value = "FEED"),
-					@ExampleObject(value = "CHATROOM_PROFILE"),
-					@ExampleObject(value = "CHAT"),
-					@ExampleObject(value = "CHAT_PROFILE")
-			}),
-			@Parameter(name = "ext", description = "파일 확장자", required = true, examples = {
-					@ExampleObject(value = "jpg"),
-					@ExampleObject(value = "png"),
-					@ExampleObject(value = "jpeg")
-			}),
-			@Parameter(name = "userId", description = "사용자 ID", example = "1"),
-			@Parameter(name = "chatroomId", description = "채팅방 ID", example = "12345678-1234-5678-1234-567812345678"),
-			@Parameter(name = "request", hidden = true)
-	})
-	@ApiResponses({
-			@ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PresignedUrlDto.Res.class))),
-			@ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
-					@ExampleObject(name = "필수 파라미터 누락", value = """
-							    {
-							        "code": "4001",
-							        "message": "필수 파라미터가 누락되었습니다."
-							    }
-							""")
-			})),
-	})
-	ResponseEntity<?> getPresignedUrl(@Validated PresignedUrlDto.Req req);
+    @Operation(summary = "S3 이미지 저장을 위한 Presigned URL 발급", description = "S3에 이미지를 저장하기 위한 Presigned URL을 발급합니다.")
+    @Parameters({
+            @Parameter(name = "type", description = "이미지 종류", required = true, in = ParameterIn.QUERY, examples = {
+                    @ExampleObject(value = "PROFILE"),
+                    @ExampleObject(value = "FEED"),
+                    @ExampleObject(value = "CHATROOM_PROFILE"),
+                    @ExampleObject(value = "CHAT"),
+                    @ExampleObject(value = "CHAT_PROFILE")
+            }),
+            @Parameter(name = "ext", description = "파일 확장자", required = true, examples = {
+                    @ExampleObject(value = "jpg"),
+                    @ExampleObject(value = "png"),
+                    @ExampleObject(value = "jpeg")
+            }),
+            @Parameter(name = "chatroomId", description = "채팅방 ID", example = "12345678-1234-5678-1234-567812345678"),
+            @Parameter(name = "request", hidden = true)
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = PresignedUrlDto.Res.class))),
+            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "필수 파라미터 누락", value = """
+                                {
+                                    "code": "4001",
+                                    "message": "필수 파라미터가 누락되었습니다."
+                                }
+                            """)
+            })),
+    })
+    ResponseEntity<?> getPresignedUrl(@Validated PresignedUrlDto.Req req, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/storage/controller/StorageController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/storage/controller/StorageController.java
@@ -1,29 +1,30 @@
 package kr.co.pennyway.api.apis.storage.controller;
 
+import kr.co.pennyway.api.apis.storage.api.StorageApi;
+import kr.co.pennyway.api.apis.storage.dto.PresignedUrlDto;
+import kr.co.pennyway.api.apis.storage.usecase.StorageUseCase;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import kr.co.pennyway.api.apis.storage.api.StorageApi;
-import kr.co.pennyway.api.apis.storage.dto.PresignedUrlDto;
-import kr.co.pennyway.api.apis.storage.usecase.StorageUseCase;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/storage")
 public class StorageController implements StorageApi {
-	private final StorageUseCase storageUseCase;
+    private final StorageUseCase storageUseCase;
 
-	@Override
-	@GetMapping("/presigned-url")
-	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<?> getPresignedUrl(@Validated PresignedUrlDto.Req request) {
-		return ResponseEntity.ok(storageUseCase.getPresignedUrl(request));
-	}
+    @Override
+    @GetMapping("/presigned-url")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getPresignedUrl(@Validated PresignedUrlDto.Req request, @AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(storageUseCase.getPresignedUrl(user.getUserId(), request));
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/storage/dto/PresignedUrlDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/storage/dto/PresignedUrlDto.java
@@ -14,8 +14,6 @@ public class PresignedUrlDto {
             @Schema(description = "파일 확장자", example = "jpg/png/jpeg")
             @NotBlank(message = "파일 확장자는 필수입니다.")
             String ext,
-            @Schema(description = "사용자 ID", example = "1")
-            String userId,
             @Schema(description = "채팅방 ID", example = "12345678-1234-5678-1234-567812345678")
             String chatroomId
     ) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/storage/usecase/StorageUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/storage/usecase/StorageUseCase.java
@@ -10,11 +10,11 @@ import lombok.extern.slf4j.Slf4j;
 @UseCase
 @RequiredArgsConstructor
 public class StorageUseCase {
-	private final AwsS3Provider awsS3Provider;
+    private final AwsS3Provider awsS3Provider;
 
-	public PresignedUrlDto.Res getPresignedUrl(PresignedUrlDto.Req request) {
-		return PresignedUrlDto.Res.of(
-				awsS3Provider.generatedPresignedUrl(request.type(), request.ext(), request.userId(), request.chatroomId())
-		);
-	}
+    public PresignedUrlDto.Res getPresignedUrl(Long userId, PresignedUrlDto.Req request) {
+        return PresignedUrlDto.Res.of(
+                awsS3Provider.generatedPresignedUrl(request.type(), request.ext(), userId.toString(), request.chatroomId())
+        );
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -239,6 +239,7 @@ public interface UserAccountApi {
 
     @Operation(summary = "사용자 프로필 사진 등록", description = "사용자의 프로필 사진을 수정합니다.")
     @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(schemaProperties = @SchemaProperty(name = "profileImageUrl", schema = @Schema(implementation = String.class, example = "https://cdn.co.kr/abc.jpg", description = "이미지 저장 경로")))),
             @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(name = "프로필 사진 URL이 유효하지 않은 경우", value = """
                             {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -257,4 +257,15 @@ public interface UserAccountApi {
             }))
     })
     ResponseEntity<?> putProfileImage(@RequestBody @Validated UserProfileUpdateDto.ProfileImageReq request, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "사용자 프로필 사진 삭제", description = "사용자의 프로필 사진을 삭제합니다.")
+    @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
+            @ExampleObject(name = "프로필 사진 URL이 존재하지 않는 경우", value = """
+                    {
+                        "code": "4040",
+                        "message": "프로필 이미지가 할당되지 않았습니다."
+                    }
+                    """)
+    }))
+    ResponseEntity<?> deleteProfileImage(@AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -115,6 +115,7 @@ public class UserAccountController implements UserAccountApi {
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 
+    @Override
     @DeleteMapping("/profile-image")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> deleteProfileImage(@AuthenticationPrincipal SecurityUserDetails user) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -111,8 +111,7 @@ public class UserAccountController implements UserAccountApi {
     @PutMapping("/profile-image")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> putProfileImage(@Validated UserProfileUpdateDto.ProfileImageReq request, @AuthenticationPrincipal SecurityUserDetails user) {
-        userAccountUseCase.updateProfileImage(user.getUserId(), request);
-        return ResponseEntity.ok(SuccessResponse.noContent());
+        return ResponseEntity.ok(SuccessResponse.from("profileImageUrl", userAccountUseCase.updateProfileImage(user.getUserId(), request)));
     }
 
     @Override

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/controller/UserAccountController.java
@@ -110,8 +110,15 @@ public class UserAccountController implements UserAccountApi {
     @Override
     @PutMapping("/profile-image")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> putProfileImage(@Validated UserProfileUpdateDto.ProfileImageReq request, SecurityUserDetails user) {
+    public ResponseEntity<?> putProfileImage(@Validated UserProfileUpdateDto.ProfileImageReq request, @AuthenticationPrincipal SecurityUserDetails user) {
         userAccountUseCase.updateProfileImage(user.getUserId(), request);
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
+
+    @DeleteMapping("/profile-image")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> deleteProfileImage(@AuthenticationPrincipal SecurityUserDetails user) {
+        userAccountUseCase.deleteProfileImage(user.getUserId());
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
@@ -59,13 +59,13 @@ public record UserProfileDto(
         Objects.requireNonNull(oauthAccount);
     }
 
-    public static UserProfileDto from(User user, OauthAccountDto oauthAccount) {
+    public static UserProfileDto from(User user, String profileImageUrl, OauthAccountDto oauthAccount) {
         return UserProfileDto.builder()
                 .id(user.getId())
                 .username(user.getUsername())
                 .name(user.getName())
                 .passwordUpdatedAt(user.getPasswordUpdatedAt())
-                .profileImageUrl(Objects.toString(user.getProfileImageUrl(), ""))
+                .profileImageUrl(profileImageUrl)
                 .phone(user.getPhone())
                 .profileVisibility(user.getProfileVisibility())
                 .locked(user.isLocked())

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/dto/UserProfileDto.java
@@ -65,7 +65,7 @@ public record UserProfileDto(
                 .username(user.getUsername())
                 .name(user.getName())
                 .passwordUpdatedAt(user.getPasswordUpdatedAt())
-                .profileImageUrl(profileImageUrl)
+                .profileImageUrl(Objects.toString(profileImageUrl, ""))
                 .phone(user.getPhone())
                 .profileVisibility(user.getProfileVisibility())
                 .locked(user.isLocked())

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/mapper/UserProfileMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/mapper/UserProfileMapper.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 @Mapper
 public class UserProfileMapper {
-    public static UserProfileDto toUserProfileDto(User user, Set<Oauth> oauths) {
+    public static UserProfileDto toUserProfileDto(User user, Set<Oauth> oauths, String objectPrefix) {
         boolean kakao, google, apple;
         kakao = google = apple = false;
 
@@ -24,7 +24,9 @@ public class UserProfileMapper {
             }
         }
 
-        return UserProfileDto.from(user, OauthAccountDto.of(kakao, google, apple));
+        String profileImageUrl = (user.getProfileImageUrl() == null) ? "" : objectPrefix + user.getProfileImageUrl();
+
+        return UserProfileDto.from(user, profileImageUrl, OauthAccountDto.of(kakao, google, apple));
     }
 
     public static UserProfileUpdateDto.NotifySettingUpdateRes toNotifySettingUpdateRes(NotifySetting.NotifyType type, Boolean flag) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileSearchService.java
@@ -1,7 +1,5 @@
 package kr.co.pennyway.api.apis.users.service;
 
-import kr.co.pennyway.api.apis.users.dto.UserProfileDto;
-import kr.co.pennyway.api.apis.users.mapper.UserProfileMapper;
 import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
 import kr.co.pennyway.domain.domains.oauth.service.OauthService;
 import kr.co.pennyway.domain.domains.user.domain.User;
@@ -24,10 +22,12 @@ public class UserProfileSearchService {
     private final OauthService oauthService;
 
     @Transactional(readOnly = true)
-    public UserProfileDto readMyAccount(Long userId) {
-        User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
-        Set<Oauth> oauths = oauthService.readOauthsByUserId(userId).stream().filter(oauth -> !oauth.isDeleted()).collect(Collectors.toUnmodifiableSet());
+    public User readMyAccount(Long userId) {
+        return userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
+    }
 
-        return UserProfileMapper.toUserProfileDto(user, oauths);
+    @Transactional(readOnly = true)
+    public Set<Oauth> readMyOauths(Long userId) {
+        return oauthService.readOauthsByUserId(userId).stream().filter(oauth -> !oauth.isDeleted()).collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
@@ -63,6 +63,11 @@ public class UserProfileUpdateService {
         User user = readUserOrThrow(userId);
 
         String profileImageUrl = user.getProfileImageUrl();
+
+        if (profileImageUrl == null) {
+            throw new UserErrorException(UserErrorCode.NOT_ALLOCATED_PROFILE_IMAGE);
+        }
+
         user.updateProfileImageUrl(null);
 
         return profileImageUrl;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserProfileUpdateService.java
@@ -43,11 +43,19 @@ public class UserProfileUpdateService {
         user.updateUsername(newUsername);
     }
 
+    /**
+     * 프로필 이미지를 업데이트한다.
+     *
+     * @return 사용자가 이미 프로필 이미지를 가지고 있는 경우, 값을 교체하고 이전 이미지 키를 반환한다. (없으면 null 반환)
+     */
     @Transactional
-    public void updateProfileImage(Long userId, String profileImageKey) {
+    public String updateProfileImage(Long userId, String profileImageKey) {
         User user = readUserOrThrow(userId);
+        String oldProfileImageUrl = user.getProfileImageUrl();
 
         user.updateProfileImageUrl(profileImageKey);
+
+        return oldProfileImageUrl;
     }
 
     @Transactional

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -68,14 +68,15 @@ public class UserAccountUseCase {
         passwordUpdateService.execute(userId, oldPassword, newPassword);
     }
 
-    public void updateProfileImage(Long userId, UserProfileUpdateDto.ProfileImageReq request) {
+    public String updateProfileImage(Long userId, UserProfileUpdateDto.ProfileImageReq request) {
         String originImageUrl = awsS3Adapter.saveImage(request.profileImageUrl(), ObjectKeyType.PROFILE);
-
         String oldImageUrl = userProfileUpdateService.updateProfileImage(userId, originImageUrl);
 
         if (oldImageUrl != null) {
             awsS3Adapter.deleteImage(oldImageUrl);
         }
+
+        return awsS3Adapter.getObjectPrefix() + originImageUrl;
     }
 
     public void deleteProfileImage(Long userId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -71,7 +71,17 @@ public class UserAccountUseCase {
     public void updateProfileImage(Long userId, UserProfileUpdateDto.ProfileImageReq request) {
         String originImageUrl = awsS3Adapter.saveImage(request.profileImageUrl(), ObjectKeyType.PROFILE);
 
-        userProfileUpdateService.updateProfileImage(userId, originImageUrl);
+        String oldImageUrl = userProfileUpdateService.updateProfileImage(userId, originImageUrl);
+
+        if (oldImageUrl != null) {
+            awsS3Adapter.deleteImage(oldImageUrl);
+        }
+    }
+
+    public void deleteProfileImage(Long userId) {
+        String profileImageUrl = userProfileUpdateService.deleteProfileImage(userId);
+
+        awsS3Adapter.deleteImage(profileImageUrl);
     }
 
     public void updatePhone(Long userId, UserProfileUpdateDto.PhoneReq request) {
@@ -88,12 +98,6 @@ public class UserAccountUseCase {
         userProfileUpdateService.updateNotifySetting(userId, type, Boolean.FALSE);
 
         return UserProfileMapper.toNotifySettingUpdateRes(type, Boolean.FALSE);
-    }
-
-    public void deleteProfileImage(Long userId) {
-        String profileImageUrl = userProfileUpdateService.deleteProfileImage(userId);
-
-        awsS3Adapter.deleteImage(profileImageUrl);
     }
 
     public void deleteAccount(Long userId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/usecase/UserAccountUseCase.java
@@ -9,11 +9,15 @@ import kr.co.pennyway.api.apis.users.service.*;
 import kr.co.pennyway.api.common.storage.AwsS3Adapter;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
+import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
 import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
+import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.infra.client.aws.s3.ObjectKeyType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
 
 @Slf4j
 @UseCase
@@ -40,8 +44,12 @@ public class UserAccountUseCase {
         deviceTokenUnregisterService.execute(userId, token);
     }
 
+    @Transactional(readOnly = true)
     public UserProfileDto getMyAccount(Long userId) {
-        return userProfileSearchService.readMyAccount(userId);
+        User user = userProfileSearchService.readMyAccount(userId);
+        Set<Oauth> oauths = userProfileSearchService.readMyOauths(userId);
+
+        return UserProfileMapper.toUserProfileDto(user, oauths, awsS3Adapter.getObjectPrefix());
     }
 
     public void updateName(Long userId, String newName) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/storage/AwsS3Adapter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/storage/AwsS3Adapter.java
@@ -45,4 +45,8 @@ public class AwsS3Adapter {
 
         awsS3Provider.deleteObject(key);
     }
+
+    public String getObjectPrefix() {
+        return awsS3Provider.getObjectPrefix();
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/storage/AwsS3Adapter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/storage/AwsS3Adapter.java
@@ -1,0 +1,48 @@
+package kr.co.pennyway.api.common.storage;
+
+import kr.co.pennyway.common.annotation.Adapter;
+import kr.co.pennyway.infra.client.aws.s3.AwsS3Provider;
+import kr.co.pennyway.infra.client.aws.s3.ObjectKeyType;
+import kr.co.pennyway.infra.common.exception.StorageErrorCode;
+import kr.co.pennyway.infra.common.exception.StorageException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Adapter
+@RequiredArgsConstructor
+public class AwsS3Adapter {
+    private final AwsS3Provider awsS3Provider;
+
+    /**
+     * 임시 저장 경로에서 원본 저장 경로로 사진을 복사하고, 원본이 저장된 키를 반환합니다.
+     *
+     * @param deleteImageUrl 임시 저장 이미지 URL
+     * @param type           프로필 이미지 타입 {@link ObjectKeyType}
+     * @return 프로필 이미지 원본이 저장된 key
+     * @throws StorageException 프로필 이미지 URL이 유효하지 않을 때
+     */
+    public String saveImage(String deleteImageUrl, ObjectKeyType type) {
+        if (!awsS3Provider.isObjectExist(deleteImageUrl)) {
+            log.info("프로필 이미지 URL이 유효하지 않습니다.");
+            throw new StorageException(StorageErrorCode.NOT_FOUND);
+        }
+
+        return awsS3Provider.copyObject(type, deleteImageUrl);
+    }
+
+    /**
+     * 프로필 이미지를 삭제합니다.
+     *
+     * @param key 프로필 이미지 key
+     * @throws StorageException 프로필 이미지 URL이 유효하지 않을 때
+     */
+    public void deleteImage(String key) {
+        if (!awsS3Provider.isObjectExist(key)) {
+            log.info("프로필 이미지 URL이 유효하지 않습니다.");
+            throw new StorageException(StorageErrorCode.NOT_FOUND);
+        }
+
+        awsS3Provider.deleteObject(key);
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/storage/controller/StorageControllerTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/storage/controller/StorageControllerTest.java
@@ -1,10 +1,11 @@
 package kr.co.pennyway.api.apis.storage.controller;
 
-import static org.mockito.BDDMockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
+import kr.co.pennyway.api.apis.storage.dto.PresignedUrlDto;
+import kr.co.pennyway.api.apis.storage.usecase.StorageUseCase;
+import kr.co.pennyway.api.config.WebConfig;
+import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
+import kr.co.pennyway.infra.common.exception.StorageErrorCode;
+import kr.co.pennyway.infra.common.exception.StorageException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,77 +20,64 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import kr.co.pennyway.api.apis.storage.dto.PresignedUrlDto;
-import kr.co.pennyway.api.apis.storage.usecase.StorageUseCase;
-import kr.co.pennyway.api.config.WebConfig;
-import kr.co.pennyway.infra.common.exception.StorageErrorCode;
-import kr.co.pennyway.infra.common.exception.StorageException;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = StorageController.class, excludeFilters = {
-		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)})
 @ActiveProfiles("test")
 class StorageControllerTest {
-	@Autowired
-	private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
-	@MockBean
-	private StorageUseCase storageUseCase;
+    @MockBean
+    private StorageUseCase storageUseCase;
 
-	@BeforeEach
-	void setUp(WebApplicationContext webApplicationContext) {
-		this.mockMvc = MockMvcBuilders
-				.webAppContextSetup(webApplicationContext)
-				.defaultRequest(post("/**").with(csrf()))
-				.build();
-	}
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .defaultRequest(post("/**").with(csrf()))
+                .build();
+    }
 
-	@Test
-	@DisplayName("Type이 PROFILE이고, UserId가 NULL일 때 400 응답을 반환한다.")
-	void getPresignedUrlWithNullUserId() throws Exception {
-		// given
-		PresignedUrlDto.Req request = new PresignedUrlDto.Req("PROFILE", "jpg", null, null);
-		given(storageUseCase.getPresignedUrl(request)).willThrow(new StorageException(StorageErrorCode.MISSING_REQUIRED_PARAMETER));
+    @Test
+    @WithSecurityMockUser
+    @DisplayName("Type이 CHAT이고, ChatroomId가 NULL일 때 400 응답을 반환한다.")
+    void getPresignedUrlWithNullChatroomId() throws Exception {
+        // given
+        PresignedUrlDto.Req request = new PresignedUrlDto.Req("CHAT", "jpg", null);
+        given(storageUseCase.getPresignedUrl(1L, request)).willThrow(new StorageException(StorageErrorCode.MISSING_REQUIRED_PARAMETER));
 
-		// when
-		ResultActions resultActions = getPresignedUrlRequest(request);
+        // when
+        ResultActions resultActions = getPresignedUrlRequest(request);
 
-		// then
-		resultActions.andExpect(status().isBadRequest());
-	}
+        // then
+        resultActions.andExpect(status().isBadRequest());
+    }
 
-	@Test
-	@DisplayName("Type이 CHAT이고, ChatroomId가 NULL일 때 400 응답을 반환한다.")
-	void getPresignedUrlWithNullChatroomId() throws Exception {
-		// given
-		PresignedUrlDto.Req request = new PresignedUrlDto.Req("CHAT", "jpg", "userId", null);
-		given(storageUseCase.getPresignedUrl(request)).willThrow(new StorageException(StorageErrorCode.MISSING_REQUIRED_PARAMETER));
+    @Test
+    @WithSecurityMockUser
+    @DisplayName("Type이 CHATROOM_PROFILE이고, ChatroomId가 NULL일 때 400 응답을 반환한다.")
+    void getPresignedUrlWithNullChatroomIdForChatroomProfile() throws Exception {
+        // given
+        PresignedUrlDto.Req request = new PresignedUrlDto.Req("CHATROOM_PROFILE", "jpg", null);
+        given(storageUseCase.getPresignedUrl(1L, request)).willThrow(new StorageException(StorageErrorCode.MISSING_REQUIRED_PARAMETER));
 
-		// when
-		ResultActions resultActions = getPresignedUrlRequest(request);
+        // when
+        ResultActions resultActions = getPresignedUrlRequest(request);
 
-		// then
-		resultActions.andExpect(status().isBadRequest());
-	}
+        // then
+        resultActions.andExpect(status().isBadRequest());
+    }
 
-	@Test
-	@DisplayName("Type이 CHATROOM_PROFILE이고, ChatroomId가 NULL일 때 400 응답을 반환한다.")
-	void getPresignedUrlWithNullChatroomIdForChatroomProfile() throws Exception {
-		// given
-		PresignedUrlDto.Req request = new PresignedUrlDto.Req("CHATROOM_PROFILE", "jpg", "userId", null);
-		given(storageUseCase.getPresignedUrl(request)).willThrow(new StorageException(StorageErrorCode.MISSING_REQUIRED_PARAMETER));
-
-		// when
-		ResultActions resultActions = getPresignedUrlRequest(request);
-
-		// then
-		resultActions.andExpect(status().isBadRequest());
-	}
-
-	private ResultActions getPresignedUrlRequest(PresignedUrlDto.Req request) throws Exception {
-		return mockMvc.perform(get("/v1/storage/presigned-url")
-				.param("type", request.type())
-				.param("ext", request.ext())
-				.param("userId", request.userId())
-				.param("chatRoomId", request.chatroomId()));
-	}
+    private ResultActions getPresignedUrlRequest(PresignedUrlDto.Req request) throws Exception {
+        return mockMvc.perform(get("/v1/storage/presigned-url")
+                .param("type", request.type())
+                .param("ext", request.ext())
+                .param("chatRoomId", request.chatroomId()));
+    }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/controller/UserAccountControllerUnitTest.java
@@ -540,6 +540,7 @@ public class UserAccountControllerUnitTest {
         void registerProfileImageSuccess() throws Exception {
             // given
             String profileImageUrl = "delete/profile/1/154aa3bd-da02-4311-a735-3bf7e4bb68d2_1717446100295.jpeg";
+            given(userAccountUseCase.updateProfileImage(1L, new UserProfileUpdateDto.ProfileImageReq(profileImageUrl))).willReturn("https://cdn.com/adj.jbg");
 
             // when
             ResultActions result = performRegisterProfileImageRequest(profileImageUrl);

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
@@ -19,6 +19,9 @@ public enum UserErrorCode implements BaseErrorCode {
     ALREADY_WITHDRAWAL(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "이미 탈퇴한 유저입니다."),
     DO_NOT_GENERAL_SIGNED_UP(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "일반 회원가입 계정이 아닙니다."),
 
+    /* 404 NOT_FOUND */
+    NOT_ALLOCATED_PROFILE_IMAGE(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "프로필 이미지가 할당되지 않았습니다."),
+
     /* 409 Conflict */
     ALREADY_SIGNUP(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 회원가입한 유저입니다."),
     ALREADY_EXIST_USERNAME(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 존재하는 아이디입니다."),

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/aws/s3/AwsS3Provider.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/aws/s3/AwsS3Provider.java
@@ -81,7 +81,6 @@ public class AwsS3Provider {
      * @param ext        : 파일 확장자 (jpg, png, jpeg)
      * @param userId     : 사용자 ID (PK) - PROFILE, CHAT_PROFILE
      * @param chatroomId : 채팅방 ID (PK) - CHATROOM_PROFILE, CHAT, CHAT_PROFILE
-     * @return
      */
     private Map<String, String> generateObjectKeyVariables(String type, String ext, String userId, String chatroomId) {
         ObjectKeyType objectType;
@@ -125,13 +124,15 @@ public class AwsS3Provider {
      * @param sourceKey : 복사할 파일의 키
      * @return 복사된 파일의 키
      */
-    public void copyObject(ObjectKeyType type, String sourceKey) {
+    public String copyObject(ObjectKeyType type, String sourceKey) {
+        String originKey = type.convertDeleteKeyToOriginKey(sourceKey);
+
         try {
             CopyObjectRequest copyObjRequest = CopyObjectRequest.builder()
                     .sourceBucket(awsS3Config.getBucketName())
                     .sourceKey(sourceKey)
                     .destinationBucket(awsS3Config.getBucketName())
-                    .destinationKey(type.convertDeleteKeyToOriginKey(sourceKey))
+                    .destinationKey(originKey)
                     .storageClass(StorageClass.ONEZONE_IA)
                     .build();
 
@@ -140,6 +141,8 @@ public class AwsS3Provider {
             log.error("파일 복사 중 오류 발생", e);
             throw new StorageException(StorageErrorCode.INVALID_FILE);
         }
+
+        return originKey;
     }
 
     public String getObjectPrefix() {

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/aws/s3/AwsS3Provider.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/aws/s3/AwsS3Provider.java
@@ -145,4 +145,18 @@ public class AwsS3Provider {
     public String getObjectPrefix() {
         return awsS3Config.getObjectPrefix();
     }
+
+    public void deleteObject(String key) {
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(awsS3Config.getBucketName())
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+        } catch (Exception e) {
+            log.error("파일 삭제 중 오류 발생", e);
+            throw new StorageException(StorageErrorCode.INVALID_FILE);
+        }
+    }
 }


### PR DESCRIPTION
## 작업 이유
- 프로필 사진 삭제 API 개발
- 기존 presigned url 발급, 프로필 이미지 저장 로직 리팩토링

<br/>

## 작업 사항
- 프로필 사진 삭제 요청을 하면, DB와 S3 모두 데이터 제거
- 기존 로직에서 외부 API 호출이 Tx 내부에서 실행되는 문제가 있어, `AwsS3Adapter`로 분리
- DB에 cdn 경로를 저장하는 부분은 key만 저장하도록 수정
   - 어느 cdn에서 이미지를 받을 지는 요청 패킷 아이피 혹은 쿼리 파라미터로 결정하는 게 맞다고 생각.
   - cdn 경로를 삽입하면, 이미지 삭제를 위해 문자열 파싱을 해야 하는데 번거로움.
- 사용자 정보 조회 시, 완성된 프로필 사진 URL을 받을 수 있도록 수정.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- DB에 cdn 경로가 아닌 key만을 저장하는 부분이 합리적인지.

<br/>

## 발견한 이슈
- 없음.
