### PR TITLE
Ignore: ✨ 애플리케이션 헬스 체크를 위한 Actuator 의존성 추가

### DIFF
--- a/pennyway-app-external-api/build.gradle
+++ b/pennyway-app-external-api/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web:3.2.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.2.3'
 
+    /* Actuator */
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:3.3.2'
+
     /* testcontainer */
     testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
     testImplementation "org.testcontainers:testcontainers:1.19.7"

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/SecurityConfig.java
@@ -1,7 +1,6 @@
 package kr.co.pennyway.api.config.security;
 
-import static kr.co.pennyway.api.config.security.WebSecurityUrls.*;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.ConditionalOnDefaultWebSecurity;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
@@ -22,69 +21,69 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.web.cors.CorsConfigurationSource;
 
-import lombok.RequiredArgsConstructor;
+import static kr.co.pennyway.api.config.security.WebSecurityUrls.AUTHENTICATED_ENDPOINTS;
 
 @Configuration
 @EnableWebSecurity
 @ConditionalOnDefaultWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-	private static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {"/favicon.ico", "/v1/duplicate/**"};
-	private static final String[] PUBLIC_ENDPOINTS = {"/v1/questions/**"};
-	private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**", "/v1/phone/**", "/v1/find/**"};
-	private static final String[] SWAGGER_ENDPOINTS = {"/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",};
+    private static final String[] READ_ONLY_PUBLIC_ENDPOINTS = {"/favicon.ico", "/v1/duplicate/**", "/actuator/health"};
+    private static final String[] PUBLIC_ENDPOINTS = {"/v1/questions/**"};
+    private static final String[] ANONYMOUS_ENDPOINTS = {"/v1/auth/**", "/v1/phone/**", "/v1/find/**"};
+    private static final String[] SWAGGER_ENDPOINTS = {"/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger",};
 
-	private final SecurityAdapterConfig securityAdapterConfig;
-	private final CorsConfigurationSource corsConfigurationSource;
-	private final AccessDeniedHandler accessDeniedHandler;
-	private final AuthenticationEntryPoint authenticationEntryPoint;
+    private final SecurityAdapterConfig securityAdapterConfig;
+    private final CorsConfigurationSource corsConfigurationSource;
+    private final AccessDeniedHandler accessDeniedHandler;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
 
-	@Bean
-	@Profile({"local", "dev", "test"})
-	@Order(SecurityProperties.BASIC_AUTH_ORDER)
-	public SecurityFilterChain filterChainDev(HttpSecurity http) throws Exception {
-		return defaultSecurity(http)
-				.cors((cors) -> cors.configurationSource(corsConfigurationSource))
-				.authorizeHttpRequests(
-						auth -> defaultAuthorizeHttpRequests(auth)
-								.requestMatchers(SWAGGER_ENDPOINTS).permitAll()
-								.anyRequest().authenticated()
-				).build();
-	}
+    @Bean
+    @Profile({"local", "dev", "test"})
+    @Order(SecurityProperties.BASIC_AUTH_ORDER)
+    public SecurityFilterChain filterChainDev(HttpSecurity http) throws Exception {
+        return defaultSecurity(http)
+                .cors((cors) -> cors.configurationSource(corsConfigurationSource))
+                .authorizeHttpRequests(
+                        auth -> defaultAuthorizeHttpRequests(auth)
+                                .requestMatchers(SWAGGER_ENDPOINTS).permitAll()
+                                .anyRequest().authenticated()
+                ).build();
+    }
 
-	@Bean
-	@Profile({"prod"})
-	@Order(SecurityProperties.BASIC_AUTH_ORDER)
-	public SecurityFilterChain filterChainProd(HttpSecurity http) throws Exception {
-		return defaultSecurity(http)
-				.cors(AbstractHttpConfigurer::disable)
-				.authorizeHttpRequests(
-						auth -> defaultAuthorizeHttpRequests(auth).anyRequest().authenticated()
-				).build();
-	}
+    @Bean
+    @Profile({"prod"})
+    @Order(SecurityProperties.BASIC_AUTH_ORDER)
+    public SecurityFilterChain filterChainProd(HttpSecurity http) throws Exception {
+        return defaultSecurity(http)
+                .cors(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(
+                        auth -> defaultAuthorizeHttpRequests(auth).anyRequest().authenticated()
+                ).build();
+    }
 
-	private HttpSecurity defaultSecurity(HttpSecurity http) throws Exception {
-		return http.httpBasic(AbstractHttpConfigurer::disable)
-				.csrf(AbstractHttpConfigurer::disable)
-				.sessionManagement((sessionManagement) ->
-						sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-				.formLogin(AbstractHttpConfigurer::disable)
-				.logout(AbstractHttpConfigurer::disable)
-				.with(securityAdapterConfig, Customizer.withDefaults())
-				.exceptionHandling(
-						exception -> exception
-								.accessDeniedHandler(accessDeniedHandler)
-								.authenticationEntryPoint(authenticationEntryPoint)
-				);
-	}
+    private HttpSecurity defaultSecurity(HttpSecurity http) throws Exception {
+        return http.httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement((sessionManagement) ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .with(securityAdapterConfig, Customizer.withDefaults())
+                .exceptionHandling(
+                        exception -> exception
+                                .accessDeniedHandler(accessDeniedHandler)
+                                .authenticationEntryPoint(authenticationEntryPoint)
+                );
+    }
 
-	private AbstractRequestMatcherRegistry<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizedUrl> defaultAuthorizeHttpRequests(
-			AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth) {
-		return auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-				.requestMatchers(HttpMethod.OPTIONS, "*").permitAll()
-				.requestMatchers(HttpMethod.GET, READ_ONLY_PUBLIC_ENDPOINTS).permitAll()
-				.requestMatchers(PUBLIC_ENDPOINTS).permitAll()
-				.requestMatchers(AUTHENTICATED_ENDPOINTS).authenticated() // FIXME: 2024-04-23 /v1/auth가 anonymous로 설정되어 있어서 authenticated로 덮어씀.
-				.requestMatchers(ANONYMOUS_ENDPOINTS).anonymous();
-	}
+    private AbstractRequestMatcherRegistry<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizedUrl> defaultAuthorizeHttpRequests(
+            AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth) {
+        return auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                .requestMatchers(HttpMethod.OPTIONS, "*").permitAll()
+                .requestMatchers(HttpMethod.GET, READ_ONLY_PUBLIC_ENDPOINTS).permitAll()
+                .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+                .requestMatchers(AUTHENTICATED_ENDPOINTS).authenticated() // FIXME: 2024-04-23 /v1/auth가 anonymous로 설정되어 있어서 authenticated로 덮어씀.
+                .requestMatchers(ANONYMOUS_ENDPOINTS).anonymous();
+    }
 }


### PR DESCRIPTION
## 작업 이유
- 무중단 배포 환경 구축을 위해 actuator 설정

<br/>

## 작업 사항
- `GET /actuator/health`을 하면 애플리케이션 헬스 체크가 가능함.

![image](https://github.com/user-attachments/assets/5a2cf4ba-7ef3-455b-9c38-93082a5865b5)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음

<br/>

## 발견한 이슈
- 없음.