### PR TITLE
Api: ✏️ HttpRequestMethodNotSupportedException 전역 예외 설정

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/handler/GlobalExceptionHandler.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/handler/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -53,6 +54,21 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.of(e.getBaseErrorCode().causedBy().getCode(), e.getBaseErrorCode().getExplainError());
 
         return ResponseEntity.status(e.getBaseErrorCode().causedBy().statusCode().getCode()).body(response);
+    }
+
+    /**
+     * API 호출 시 'Method' 내에 데이터 값이 유효하지 않은 경우
+     *
+     * @see HttpRequestMethodNotSupportedException
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    @JsonView(CustomJsonView.Common.class)
+    protected ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.warn("handleHttpRequestMethodNotSupportedException : {}", e.getMessage());
+        String code = String.valueOf(StatusCode.BAD_REQUEST.getCode() * 10 + ReasonCode.INVALID_REQUEST.getCode());
+
+        return ErrorResponse.of(code, e.getMessage());
     }
 
     /**


### PR DESCRIPTION
## 작업 이유
- 전역 예외 핸들러 설정 추가

<br/>

## 작업 사항
![image](https://github.com/user-attachments/assets/0b89db88-56c5-4c2b-bbaa-c1c6fcae1e7b)

잘못된 요청 메서드에 대해 서버사 500 에러를 반환하는 문제가 있었음.

![image](https://github.com/user-attachments/assets/0e21ebec-d9f8-49ae-8c75-4f7e21649428)

전역 예외 핸들러에서 `HttpRequestMethodNotSupportedException`를 처리하도록 수정

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음.

<br/>

## 발견한 이슈
- 없음.

