### PR TITLE
Ignore: 🐛 Devcie Token 삭제 시, 사용자가 정보 삭제되는 에러 핸들링

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceTokenUnregisterService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceTokenUnregisterService.java
@@ -4,9 +4,6 @@ import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
 import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorCode;
 import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
 import kr.co.pennyway.domain.domains.device.service.DeviceTokenService;
-import kr.co.pennyway.domain.domains.user.domain.User;
-import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
-import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
 import kr.co.pennyway.domain.domains.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,9 +19,7 @@ public class DeviceTokenUnregisterService {
 
     @Transactional
     public void execute(Long userId, String token) {
-        User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
-
-        DeviceToken deviceToken = deviceTokenService.readDeviceByUserIdAndToken(user.getId(), token).orElseThrow(
+        DeviceToken deviceToken = deviceTokenService.readDeviceByUserIdAndToken(userId, token).orElseThrow(
                 () -> new DeviceTokenErrorException(DeviceTokenErrorCode.NOT_FOUND_DEVICE)
         );
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/DeviceToken.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/DeviceToken.java
@@ -23,7 +23,7 @@ public class DeviceToken extends DateAuditable {
     @ColumnDefault("true")
     private Boolean activated;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/domain/User.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import kr.co.pennyway.domain.common.converter.ProfileVisibilityConverter;
 import kr.co.pennyway.domain.common.converter.RoleConverter;
 import kr.co.pennyway.domain.common.model.DateAuditable;
-import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
 import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
 import kr.co.pennyway.domain.domains.user.type.Role;
 import lombok.AccessLevel;
@@ -18,8 +17,6 @@ import org.hibernate.annotations.SQLRestriction;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -53,9 +50,6 @@ public class User extends DateAuditable {
     private NotifySetting notifySetting;
     @ColumnDefault("NULL")
     private LocalDateTime deletedAt;
-
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-    private List<DeviceToken> deviceTokens = new ArrayList<>();
 
     @Builder
     private User(String username, String name, String password, LocalDateTime passwordUpdatedAt, String profileImageUrl, String phone, Role role,


### PR DESCRIPTION
## 작업 이유
![image](https://github.com/user-attachments/assets/23d8a87c-6937-42ae-9b01-36bf0a89c246)

- device token을 삭제하면, 부모를 같이 삭제하는 1+1 이벤트 행사 중단.

<br/>

## 작업 사항
![image](https://github.com/user-attachments/assets/0f518d6d-5425-4ca6-b827-d70876cb8074)
![image](https://github.com/user-attachments/assets/2f2dcba0-7391-4564-a97e-5120dad99f36)

- 무슨 생각이었는지 모르겠지만...자식 Entity에서 cascade 옵션으로 `REMOVER`를 주면, 자식 Entity를 삭제할 때 부모도 같이 삭제된다.
- 자식이 부모에 대한 cascade 설정은 옵션값이므로 그냥 제거.

<br/>

![image](https://github.com/user-attachments/assets/6ab76049-7c9f-4bde-aed5-492c84d49849)

정상 동작 확인

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음

<br/>

## 발견한 이슈
- 없음.