### PR TITLE
Ignore: 🐛 Missing Request Cookie Header 예외 핸들러 추가

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/handler/GlobalExceptionHandler.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/handler/GlobalExceptionHandler.java
@@ -21,6 +21,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -54,6 +55,21 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.of(e.getBaseErrorCode().causedBy().getCode(), e.getBaseErrorCode().getExplainError());
 
         return ResponseEntity.status(e.getBaseErrorCode().causedBy().statusCode().getCode()).body(response);
+    }
+
+    /**
+     * API 호출 시 'Cookie' 내에 데이터 값이 유효하지 않은 경우
+     *
+     * @see MissingRequestCookieException
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingRequestCookieException.class)
+    @JsonView(CustomJsonView.Common.class)
+    protected ErrorResponse handleMissingRequestCookieException(MissingRequestCookieException e) {
+        log.warn("handleMissingRequestCookieException : {}", e.getMessage());
+        String code = String.valueOf(StatusCode.BAD_REQUEST.getCode() * 10 + ReasonCode.MISSING_REQUIRED_PARAMETER.getCode());
+
+        return ErrorResponse.of(code, e.getMessage());
     }
 
     /**


### PR DESCRIPTION
## 작업 이유
- 사용자가 쿠키를 삽입하지 않고 요청을 보냈을 때 500 에러를 반환하는 문제

<br/>

## 작업 사항
![image](https://github.com/user-attachments/assets/20a78341-a964-4176-b7e4-d666d68f104a)

![image](https://github.com/user-attachments/assets/c0560b13-6727-4390-ab30-35f1b1a70023)


<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음

<br/>

## 발견한 이슈
- 없음

