### PR TITLE
Api: ✏️ Device Token Session 관리를 위한 로직 수정

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/api/UserAccountApi.java
@@ -27,14 +27,6 @@ public interface UserAccountApi {
     @Operation(summary = "디바이스 등록", description = "사용자의 디바이스 정보를 등록합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schemaProperties = @SchemaProperty(name = "deviceToken", schema = @Schema(implementation = DeviceTokenDto.RegisterRes.class)))),
-            @ApiResponse(responseCode = "400", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "잘못된 디바이스 토큰 저장 요청", description = "서버에 동일한 이름의 토큰이 사용자에게 등록되어 있고, 해당 토큰이 만료처리되어 있을 경우에 해당한다. (애초에 발생해선 안 되는 에러)", value = """
-                            {
-                                "code": "4005",
-                                "message": "활성화되지 않은 디바이스 토큰 정보입니다."
-                            }
-                            """)
-            })),
             @ApiResponse(responseCode = "404", content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(name = "수정 요청 시, token에 매칭하는 디바이스 정보가 없는 경우", value = """
                             {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceTokenRegisterService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceTokenRegisterService.java
@@ -1,8 +1,6 @@
 package kr.co.pennyway.api.apis.users.service;
 
 import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
-import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorCode;
-import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
 import kr.co.pennyway.domain.domains.device.service.DeviceTokenService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
@@ -12,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -23,17 +23,25 @@ public class DeviceTokenRegisterService {
     @Transactional
     public DeviceToken execute(Long userId, String token) {
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
-        DeviceToken deviceToken = getOrCreateDevice(user, token);
 
-        if (!deviceToken.isActivated()) {
-            throw new DeviceTokenErrorException(DeviceTokenErrorCode.NOT_ACTIVATED_DEVICE);
-        }
-
-        return deviceToken;
+        return getOrCreateDevice(user, token);
     }
 
+    /**
+     * 사용자의 디바이스 토큰을 가져오거나 생성한다.
+     * <p>
+     * 이미 등록된 디바이스 토큰인 경우 마지막 로그인 시간을 갱신한다.
+     */
     private DeviceToken getOrCreateDevice(User user, String token) {
-        return deviceTokenService.readDeviceByUserIdAndToken(user.getId(), token)
-                .orElseGet(() -> deviceTokenService.createDevice(DeviceToken.of(token, user)));
+        Optional<DeviceToken> deviceToken = deviceTokenService.readDeviceByUserIdAndToken(user.getId(), token);
+
+        if (deviceToken.isPresent()) {
+            DeviceToken device = deviceToken.get();
+            device.activate();
+            device.updateLastSignedInAt();
+            return device;
+        } else {
+            return deviceTokenService.createDevice(DeviceToken.of(token, user));
+        }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceTokenUnregisterService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceTokenUnregisterService.java
@@ -23,6 +23,6 @@ public class DeviceTokenUnregisterService {
                 () -> new DeviceTokenErrorException(DeviceTokenErrorCode.NOT_FOUND_DEVICE)
         );
 
-        deviceTokenService.deleteDevice(deviceToken);
+        deviceToken.deactivate();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceTokenUnregisterService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/DeviceTokenUnregisterService.java
@@ -4,7 +4,6 @@ import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
 import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorCode;
 import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
 import kr.co.pennyway.domain.domains.device.service.DeviceTokenService;
-import kr.co.pennyway.domain.domains.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class DeviceTokenUnregisterService {
-    private final UserService userService;
     private final DeviceTokenService deviceTokenService;
 
     @Transactional

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/DeviceTokenRegisterServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/DeviceTokenRegisterServiceTest.java
@@ -8,8 +8,6 @@ import kr.co.pennyway.api.config.fixture.DeviceTokenFixture;
 import kr.co.pennyway.api.config.fixture.UserFixture;
 import kr.co.pennyway.domain.config.JpaConfig;
 import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
-import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorCode;
-import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
 import kr.co.pennyway.domain.domains.device.service.DeviceTokenService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.service.UserService;
@@ -25,7 +23,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.util.AssertionErrors.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -101,7 +98,7 @@ public class DeviceTokenRegisterServiceTest extends ExternalApiDBTestConfig {
 
     @Test
     @Transactional
-    @DisplayName("[3] token 등록 요청이 들어왔을 때, 활성화되지 않은 디바이스 토큰이 존재하는 경우 NOT_ACTIVATED_DEVICE 에러를 반환한다.")
+    @DisplayName("[3] token 등록 요청이 들어왔을 때, 활성화되지 않은 디바이스 토큰이 존재하는 경우 토큰을 활성화 상태로 변경한다.")
     void registerNewDeviceWhenDeviceIsNotActivated() {
         // given
         DeviceToken originDeviceToken = DeviceTokenFixture.INIT.toDevice(requestUser);
@@ -109,8 +106,10 @@ public class DeviceTokenRegisterServiceTest extends ExternalApiDBTestConfig {
         deviceTokenService.createDevice(originDeviceToken);
         DeviceTokenDto.RegisterReq request = DeviceTokenFixture.INIT.toRegisterReq();
 
-        // when - then
-        DeviceTokenErrorException ex = assertThrows(DeviceTokenErrorException.class, () -> deviceTokenRegisterService.execute(requestUser.getId(), request.token()));
-        assertEquals("활성화되지 않은 디바이스 토큰이 존재하는 경우 Not Activated Device를 반환한다.", DeviceTokenErrorCode.NOT_ACTIVATED_DEVICE, ex.getBaseErrorCode());
+        // when
+        DeviceToken response = deviceTokenRegisterService.execute(requestUser.getId(), request.token());
+
+        // then
+        assertTrue("디바이스가 활성화 상태여야 한다.", response.getActivated());
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/DeviceTokenUnregisterServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/users/usecase/DeviceTokenUnregisterServiceTest.java
@@ -24,11 +24,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.util.AssertionErrors.assertEquals;
-import static org.springframework.test.util.AssertionErrors.assertNull;
+import static org.springframework.test.util.AssertionErrors.assertFalse;
 
 @ExtendWith(MockitoExtension.class)
 @DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create")
@@ -56,7 +54,7 @@ public class DeviceTokenUnregisterServiceTest extends ExternalApiDBTestConfig {
 
     @Test
     @Transactional
-    @DisplayName("사용자 ID와 origin token에 매칭되는 활성 디바이스가 존재하는 경우 디바이스를 삭제한다.")
+    @DisplayName("사용자 ID와 origin token에 매칭되는 활성 디바이스가 존재하는 경우 디바이스를 비활성화한다.")
     void unregisterDevice() {
         // given
         DeviceToken deviceToken = DeviceTokenFixture.INIT.toDevice(requestUser);
@@ -66,8 +64,8 @@ public class DeviceTokenUnregisterServiceTest extends ExternalApiDBTestConfig {
         deviceTokenUnregisterService.execute(requestUser.getId(), deviceToken.getToken());
 
         // then
-        Optional<DeviceToken> deletedDevice = deviceTokenService.readDeviceByUserIdAndToken(requestUser.getId(), deviceToken.getToken());
-        assertNull("디바이스가 삭제되어 있어야 한다.", deletedDevice.orElse(null));
+        DeviceToken deletedDevice = deviceTokenService.readDeviceByUserIdAndToken(requestUser.getId(), deviceToken.getToken()).get();
+        assertFalse("디바이스가 비활성화 되어있어야 한다.", deletedDevice.isActivated());
     }
 
     @Test

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/DeviceToken.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/domain/DeviceToken.java
@@ -1,27 +1,36 @@
 package kr.co.pennyway.domain.domains.device.domain;
 
 import jakarta.persistence.*;
-import kr.co.pennyway.domain.common.model.DateAuditable;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
 @Getter
 @Table(name = "device_token")
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DeviceToken extends DateAuditable {
+public class DeviceToken {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String token;
+
     @ColumnDefault("true")
     private Boolean activated;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+    private LocalDateTime lastSignedInAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -31,6 +40,7 @@ public class DeviceToken extends DateAuditable {
         this.token = Objects.requireNonNull(token, "token은 null이 될 수 없습니다.");
         this.activated = Objects.requireNonNull(activated, "activated는 null이 될 수 없습니다.");
         this.user = Objects.requireNonNull(user, "user는 null이 될 수 없습니다.");
+        this.lastSignedInAt = LocalDateTime.now();
     }
 
     public static DeviceToken of(String token, User user) {
@@ -49,12 +59,19 @@ public class DeviceToken extends DateAuditable {
         this.activated = Boolean.FALSE;
     }
 
+    public void updateLastSignedInAt() {
+        this.lastSignedInAt = LocalDateTime.now();
+    }
+
     /**
-     * 디바이스 토큰을 갱신하고 활성화 상태로 변경한다.
+     * 디바이스 토큰이 만료되었는지 확인한다.
+     *
+     * @return 토큰이 갱신된지 7일이 지났으면 true, 그렇지 않으면 false
      */
-    public void updateToken(String token) {
-        this.activated = Boolean.TRUE;
-        this.token = token;
+    public boolean isExpired() {
+        LocalDateTime now = LocalDateTime.now();
+
+        return lastSignedInAt.plusDays(7).isBefore(now);
     }
 
     @Override

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/exception/DeviceTokenErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/exception/DeviceTokenErrorCode.java
@@ -8,9 +8,6 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum DeviceTokenErrorCode implements BaseErrorCode {
-    /* 400 BAD_REQUEST */
-    NOT_ACTIVATED_DEVICE(StatusCode.BAD_REQUEST, ReasonCode.CLIENT_ERROR, "활성화되지 않은 디바이스 토큰 정보입니다."),
-
     /* 404 NOT_FOUND */
     NOT_FOUND_DEVICE(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "디바이스를 찾을 수 없습니다.");
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceTokenService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/device/service/DeviceTokenService.java
@@ -24,12 +24,7 @@ public class DeviceTokenService {
     public Optional<DeviceToken> readDeviceByUserIdAndToken(Long userId, String token) {
         return deviceTokenRepository.findByUser_IdAndToken(userId, token);
     }
-
-    @Transactional
-    public void deleteDevice(DeviceToken deviceToken) {
-        deviceTokenRepository.delete(deviceToken);
-    }
-
+    
     @Transactional
     public void deleteDevicesByUserIdInQuery(Long userId) {
         deviceTokenRepository.deleteAllByUserIdInQuery(userId);


### PR DESCRIPTION
## 작업 이유
- 사용자의 세션이 만료된 Device Token 정보 관리를 위해 자동으로 Update되는 `updated_at` 필드가 아닌, `last_signed_in` 필드가 필요함.
- 로그아웃 시, token을 제거하는 로직이 추가됨에 따라 device_token 테이블에 너무 빈번한 CD 작업이 발생할 우려가 있음.

<br/>

## 작업 사항
### 1️⃣ Device Token 엔티티 수정
- Device Token의 `DateAuditable` 상속 제거
- 직접 created_at 자동 설정, 수동 last_sigend_up 업데이트를 위한 필드 및 메서드 추가

<br/>

### 2️⃣ 삭제 요청 (로그아웃 시)
- 원래는 회원 탈퇴만을 고려했었는데, 로그아웃 요청일 때도 device_token을 비활성화 할 필요가 있음
- 따라서 삭제 요청을 하면, device token을 삭제하지 않고 `deactivate` 시킴

<br/>

### 3️⃣ 저장 요청
- token에 대한 정보가 없으면 새로 생성하는 로직은 동일
- 만약 존재하면, 바로 반환하지 않고 `last_signed_in` 필드를 갱신하여 반환

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 왜 `last_signed_in`이 필요한가?
   - 사용자가 로그아웃을 하면, token을 비활성화 하여 푸시 알림이 보내지는 것을 방지하고 있습니다.
   - 하지만, 사용자가 로그아웃하지 않고 7일 이상 앱을 실행하지 않는다면, 저희 앱에선 "사실상 로그아웃 상태"로 취급합니다.
   - 따라서 푸시 알림을 전송하기 전에 Device Token의 유효성을 검사할 때, `last_signed_in` 토큰 또한 검사할 필요가 존재합니다.

<br/>

## 발견한 이슈
- 없음.

