### PR TITLE
🔧 Blue-Green 배포를 위한 deploy script 수정

### DIFF
--- a/.github/workflows/deploy-external-api.yml
+++ b/.github/workflows/deploy-external-api.yml
@@ -83,6 +83,8 @@ jobs:
       - name: AWS SSM Send-Command
         uses: peterkimzz/aws-ssm-send-command@master
         id: ssm
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -93,52 +95,5 @@ jobs:
             docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             docker system prune -a -f
             docker pull pennyway/pennyway-was
-            
-            # 현재 활성 포트 확인
-            CURRENT_PORT=$(docker-compose ps | grep "was" | grep -oP "0.0.0.0:\K\d+")
-            
-            if [ "$CURRENT_PORT" == "8080" ]; then
-              NEW_PORT="8081"
-            else
-              NEW_PORT="8080"
-            fi
-            
-            # docker-compose.yml 파일 업데이트
-            sed -i "s/WAS_PORT=.*/WAS_PORT=$NEW_PORT/" .env
-            sed -i "s/WAS_VERSION=.*/WAS_VERSION=${{ steps.get_version.outputs.VERSION }}/" .env
-            
-            # 새 버전 배포
-            docker-compose up -d was
-            
-            # 새 버전 헬스 체크
-            for i in {1..30}; do
-              if curl -s http://localhost:$NEW_PORT/health | grep -q "UP"; then
-                echo "New version is healthy"
-            
-                # 이전 버전 종료
-                if [ -n "$CURRENT_PORT" ]; then
-                  docker-compose stop was
-                  docker-compose rm -f was
-                fi
-            
-                echo "Deployment successful"
-                exit 0
-              fi
-              sleep 10
-            done
-            
-            echo "New version failed health check. Rolling back."
-            docker-compose stop was
-            docker-compose rm -f was
-            sed -i "s/WAS_PORT=.*/WAS_PORT=$CURRENT_PORT/" .env
-            sed -i "s/WAS_VERSION=.*/$CURRENT_VERSION/" .env
-            docker-compose up -d was
-            exit 1
-
-      # 8. 배포 결과 확인
-      - name: Check deployment result
-        if: failure()
-        run: |
-          echo "Deployment failed. Please check the logs and take necessary actions."
-          exit 1
-
+            chmod +x deploy.sh
+            bash -x ./deploy.sh

--- a/.github/workflows/deploy-external-api.yml
+++ b/.github/workflows/deploy-external-api.yml
@@ -74,4 +74,52 @@ jobs:
             docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             docker system prune -a -f
             docker pull pennyway/pennyway-was
-            docker-compose up -d
+            
+            # 현재 활성 포트 확인
+            CURRENT_PORT=$(docker-compose ps | grep "was" | grep -oP "0.0.0.0:\K\d+")
+            
+            if [ "$CURRENT_PORT" == "8080" ]; then
+              NEW_PORT="8081"
+            else
+              NEW_PORT="8080"
+            fi
+            
+            # docker-compose.yml 파일 업데이트
+            sed -i "s/WAS_PORT=.*/WAS_PORT=$NEW_PORT/" .env
+            sed -i "s/WAS_VERSION=.*/WAS_VERSION=${{ steps.get_version.outputs.VERSION }}/" .env
+            
+            # 새 버전 배포
+            docker-compose up -d was
+            
+            # 새 버전 헬스 체크
+            for i in {1..30}; do
+              if curl -s http://localhost:$NEW_PORT/health | grep -q "UP"; then
+                echo "New version is healthy"
+            
+                # 이전 버전 종료
+                if [ -n "$CURRENT_PORT" ]; then
+                  docker-compose stop was
+                  docker-compose rm -f was
+                fi
+            
+                echo "Deployment successful"
+                exit 0
+              fi
+              sleep 10
+            done
+            
+            echo "New version failed health check. Rolling back."
+            docker-compose stop was
+            docker-compose rm -f was
+            sed -i "s/WAS_PORT=.*/WAS_PORT=$CURRENT_PORT/" .env
+            sed -i "s/WAS_VERSION=.*/$CURRENT_VERSION/" .env
+            docker-compose up -d was
+            exit 1
+
+      # 8. 배포 결과 확인
+      - name: Check deployment result
+        if: failure()
+        run: |
+          echo "Deployment failed. Please check the logs and take necessary actions."
+          exit 1
+

--- a/.github/workflows/deploy-external-api.yml
+++ b/.github/workflows/deploy-external-api.yml
@@ -7,6 +7,25 @@ on:
         description: '배포할 Api 모듈 태그 정보 (Api-v*.*.*)'
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
+      tags:
+        description: 'Test scenario tags'
+        required: false
+        type: boolean
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## 작업 이유

- 서비스 안정성 향상을 위한 무중단 필요성 대두

<br/>

## 작업 사항

### 프로세스

```mermaid
graph TD
	A[시작] --> B{현재 실행 중인 서비스 확인}
	B -->|Blue| C[Green 서비스 선택]
	B -->|Green| D[Blue 서비스 선택]
	C --> E[새 버전 이미지로 선택된 서비스 시작]
	D --> E
	E --> F{헬스 체크}
	F -->|성공| G[이전 서비스 중지 및 제거]
	F -->|실패| H[새 서비스 중지 및 제거]
	G --> I[nginx 설정 업데이트]
	H --> J[이전 서비스 재시작]
	I --> K[배포 완료]
	J --> L[롤백 완료]
```

- docker-compose.yml 수정 (was)
  ```yml
  ...
  was_blue:
	container_name: was_blue
	image: pennyway/pennyway-was:${WAS_VERSION}
	ports:
	  - "${WAS_BLUE_PORT:-8080}:8080"
	environment:
	  - TZ=Asia/Seoul
	env_file:
	  - .env
	depends_on:
	  - rdb
	  - cache
	
  was_green:
	container_name: was_green
	image: pennyway/pennyway-was:${WAS_VERSION}
	ports:
		- "${WAS_GREEN_PORT:-8081}:8080"
	environment:
		- TZ=Asia/Seoul
	env_file:
		- .env
	depends_on:
		- rdb
		- cache
  ```
- nginx.conf 수정 (bastion)

  ```yml
  upstream backend {
    server xxx.xxx.xxx.xxx:8080;
    server xxx.xxx.xxx.xxx:8081;
  }
  ...    
  ```
  
- deploy.yml 수정
  ```yml
  ...
  # 별도 script 파일을 분리하여 동작
  chmod +x deploy.sh 
  bash -x ./deploy.sh
  ```
- deploy.sh 작성
  ```sh
	#!/bin/bash
	
	set -e
	
	# 현재 실행 중인 서비스 확인
	CURRENT_SERVICE=$(docker-compose ps --services --filter "status=running" | grep "was_")
	
	# 새 서비스 결정
	if [ "$CURRENT_SERVICE" = "was_blue" ]; then
	  NEW_SERVICE="was_green"
	  NEW_PORT="8081"
	else
	  NEW_SERVICE="was_blue"
	  NEW_PORT="8080"
	fi
	
	echo "Current service: $CURRENT_SERVICE"
	echo "New service: $NEW_SERVICE"
	echo "New port: $NEW_PORT"
	
	# 버전 설정
	if [ -z "$VERSION" ]; then
	  VERSION="latest"
	fi
	echo "Version: $VERSION"
	
	# .env 파일 업데이트
	sed -i "s/WAS_VERSION=.*/WAS_VERSION=$VERSION/" .env
	
	# 새 서비스 시작
	docker-compose up -d $NEW_SERVICE
	
	echo "Waiting for service to start..."
	sleep 30
	
	# 헬스 체크
	for i in {1..30}; do
	  echo "Attempting health check ($i/30)..."
	  echo "Checking port: $NEW_PORT"
	
	  if nc -z localhost $NEW_PORT; then
	    echo "Port $NEW_PORT is open. Proceeding with HTTP check."
	
	    CURL_OUTPUT=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$NEW_PORT/v3/api-docs)
	
	    if [ "$CURL_OUTPUT" -eq 200 ]; then
	      echo "Health check passed. New version is healthy."
	
	      # 이전 서비스 중지 및 제거
	      if [ -n "$CURRENT_SERVICE" ] && [ "$CURRENT_SERVICE" != "$NEW_SERVICE" ]; then
	        echo "Stopping and removing old service: $CURRENT_SERVICE"
	        docker-compose stop $CURRENT_SERVICE
	        docker-compose rm -f $CURRENT_SERVICE
	      else
	        echo "No old service to remove or new service is the same as current service."
	      fi
	
	      # 새 서비스가 실행 중인지 확인
	      echo "Verifying new service is running..."
	      RUNNING_SERVICE=$(docker-compose ps --services --filter "status=running" | grep "was_")
	      if [ "$RUNNING_SERVICE" = "$NEW_SERVICE" ]; then
	        echo "Deployment successful. New service $NEW_SERVICE is running."
	        exit 0
	      else
	        echo "Error: New service $NEW_SERVICE is not running after deployment."
	        exit 1
	      fi
	    else
	      echo "Health check failed. HTTP status: $CURL_OUTPUT"
	    fi
	  else
	    echo "Port $NEW_PORT is not open yet."
	  fi
	
	  echo "Checking container status and logs:"
	  docker-compose ps $NEW_SERVICE
	  docker-compose logs --tail=50 $NEW_SERVICE
	
	  echo "Waiting 20 seconds before next attempt..."
	  sleep 20
	done
	
	echo "Health check failed after 30 attempts. Rolling back..."
	docker-compose stop $NEW_SERVICE
	docker-compose rm -f $NEW_SERVICE
	if [ -n "$CURRENT_SERVICE" ]; then
	  echo "Ensuring old service is running: $CURRENT_SERVICE"
	  docker-compose up -d $CURRENT_SERVICE
	fi
	echo "Rollback complete. Deployment failed."
	exit 1
  ```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- fork 레포지토리에서 테스트 완료하였고, Notion에 누락되었던 환경 변수 업데이트(새로 추가된 사항은 없음)하였습니다.
- [Blog 포스팅](https://jinlee.kr/devops/2024-08-24-blue-green-deployment/)

<br/>

## 동작 결과

`deploy.sh`를 실행할 때마다 blue-green 배포가 실행됩니다.

### Blue 배포

<img width="1372" alt="image" src="https://github.com/user-attachments/assets/45e2459b-5866-4ca8-a45d-ce86a9c5873f">

### Green 배포

<img width="1388" alt="image" src="https://github.com/user-attachments/assets/404453d1-d63c-468f-bb54-f5b225cd0973">

## 발견한 이슈

- 없음

