### PR TITLE
Api: ✏️ OAuth 계정 연동 누락된 예외처리 수정 (OAuth 연동 정책 수정)

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/api/UserAuthApi.java
@@ -13,7 +13,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.pennyway.api.apis.auth.dto.AuthStateDto;
 import kr.co.pennyway.api.apis.auth.dto.SignInReq;
+import kr.co.pennyway.api.common.annotation.ApiExceptionExplanation;
+import kr.co.pennyway.api.common.annotation.ApiResponseExplanations;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.domain.domains.oauth.exception.OauthErrorCode;
 import kr.co.pennyway.domain.domains.oauth.type.Provider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -67,14 +70,12 @@ public interface UserAuthApi {
     @Parameter(name = "provider", description = "소셜 제공자", examples = {
             @ExampleObject(name = "카카오", value = "kakao"), @ExampleObject(name = "애플", value = "apple"), @ExampleObject(name = "구글", value = "google")
     }, required = true, in = ParameterIn.QUERY)
-    @ApiResponse(responseCode = "409", content = @Content(mediaType = "application/json", examples = {
-            @ExampleObject(name = "해당 provider로 로그인한 이력이 이미 존재함", value = """
-                    {
-                        "code": "4091",
-                        "message": "이미 해당 제공자로 가입된 사용자입니다."
-                    }
-                    """)
-    }))
+    @ApiResponseExplanations(
+            errors = {
+                    @ApiExceptionExplanation(value = OauthErrorCode.class, constant = "ALREADY_USED_OAUTH", name = "다른 사용자가 사용 중"),
+                    @ApiExceptionExplanation(value = OauthErrorCode.class, constant = "ALREADY_SIGNUP_OAUTH", name = "이미 연동된 계정")
+            }
+    )
     ResponseEntity<?> linkOauth(@RequestParam Provider provider, @RequestBody @Validated SignInReq.Oauth request, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "소셜 계정 연동 해제", description = "인증된 사용자의 소셜 계정 연동을 해제한다. 연동되지 않은 계정을 해제하려고 하는 경우에는 404 에러를 반환한다. 미인증 사용자는 해당 API를 사용할 수 없다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/UserSyncDto.java
@@ -1,10 +1,5 @@
 package kr.co.pennyway.api.apis.auth.dto;
 
-import kr.co.pennyway.domain.domains.oauth.domain.Oauth;
-import kr.co.pennyway.domain.domains.oauth.type.Provider;
-
-import java.time.LocalDateTime;
-
 /**
  * 전화번호 검증 후, 시나리오 분기 정보를 위한 DTO
  */
@@ -13,59 +8,31 @@ public record UserSyncDto(
         boolean isSignUpAllowed,
         boolean isExistAccount,
         Long userId,
-        String username,
-        /* 계정과 연동하기 위한 oauth 정보. 없다면 null */
-        OauthSync oauthSync
+        String username
 ) {
     /**
      * @param isSignUpAllowed boolean : 회원가입 시나리오 가능 여부 (true: 회원가입 혹은 계정 연동 가능, false: 불가능)
      * @param isExistAccount  boolean : 이미 존재하는 계정 여부
      * @param userId          Long : 사용자 ID. 없다면 null
      * @param username        String : 사용자 이름. 없다면 null
-     * @param oauthSync       {@link OauthSync} : 연동할 Oauth 정보. 없다면 null
      */
-    public static UserSyncDto of(boolean isSignUpAllowed, boolean isExistAccount, Long userId, String username, OauthSync oauthSync) {
-        return new UserSyncDto(isSignUpAllowed, isExistAccount, userId, username, oauthSync);
+    public static UserSyncDto of(boolean isSignUpAllowed, boolean isExistAccount, Long userId, String username) {
+        return new UserSyncDto(isSignUpAllowed, isExistAccount, userId, username);
     }
 
     /**
      * 이미 회원이 존재하는 경우 사용하는 편의용 메서드. <br/>
-     * 내부에서 {@link UserSyncDto#of(boolean, boolean, Long, String, OauthSync)}를 호출한다.
+     * 내부에서 {@link UserSyncDto#of(boolean, boolean, Long, String)}를 호출한다.
      */
     public static UserSyncDto abort(Long userId, String username) {
-        return UserSyncDto.of(false, true, userId, username, null);
+        return UserSyncDto.of(false, true, userId, username);
     }
 
     /**
      * 회원 가입 이력이 없는 경우 사용하는 편의용 메서드. <br/>
-     * 내부에서 {@link UserSyncDto#of(boolean, boolean, Long, String, OauthSync)}를 호출한다.
+     * 내부에서 {@link UserSyncDto#of(boolean, boolean, Long, String)}를 호출한다.
      */
     public static UserSyncDto signUpAllowed() {
-        return UserSyncDto.of(true, false, null, null, null);
-    }
-
-    /**
-     * 기존의 soft delete된 Oauth 정보가 있는지 확인한다.
-     */
-    public boolean isExistOauthAccount() {
-        return oauthSync != null;
-    }
-
-    public record OauthSync(
-            Long id,
-            String oauthId,
-            Provider provider,
-            LocalDateTime deletedAt
-    ) {
-        /**
-         * Oauth 정보를 OauthSync로 변환한다. <br/>
-         * Oauth 정보가 없는 경우 null을 반환한다.
-         */
-        public static OauthSync from(Oauth oauth) {
-            if (oauth == null) {
-                return null;
-            }
-            return new OauthSync(oauth.getId(), oauth.getOauthId(), oauth.getProvider(), oauth.getDeletedAt());
-        }
+        return UserSyncDto.of(true, false, null, null);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserGeneralSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserGeneralSignService.java
@@ -47,7 +47,7 @@ public class UserGeneralSignService {
         }
 
         log.info("소셜 회원가입 사용자입니다. user: {}", user.get());
-        return UserSyncDto.of(true, true, user.get().getId(), user.get().getUsername(), null);
+        return UserSyncDto.of(true, true, user.get().getId(), user.get().getUsername());
     }
 
     /**

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
@@ -76,13 +76,8 @@ public class UserOauthSignService {
 
         // 이미 해당 Oauth 계정에 연동되어 있는 경우
         if (oauth.isPresent() && !oauth.get().isDeleted()) {
-            if (oauth.get().isDeleted()) {
-                log.info("이미 연동 해지된 Oauth 계정입니다. userId: {}, provider: {}", userId, provider);
-
-            } else {
-                log.info("이미 해당 Oauth 계정에 연동되어 있습니다. userId: {}, provider: {}", userId, provider);
-                throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
-            }
+            log.info("이미 해당 Oauth 계정에 연동되어 있습니다. userId: {}, provider: {}", userId, provider);
+            throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
         }
 
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
@@ -65,12 +65,24 @@ public class UserOauthSignService {
      * @return {@link UserSyncDto}
      */
     @Transactional(readOnly = true)
-    public UserSyncDto isLinkAllowed(Long userId, Provider provider) {
+    public UserSyncDto isLinkAllowed(Long userId, String oauthId, Provider provider) {
+        // 소셜 계정을 다른 사용자가 사용 중인 경우
+        if (oauthService.isExistOauthByOauthIdAndProvider(oauthId, provider)) {
+            log.info("이미 다른 사용자가 사용 중인 Oauth 계정입니다. oauthId: {}, provider: {}", oauthId, provider);
+            throw new OauthException(OauthErrorCode.ALREADY_USED_OAUTH);
+        }
+
         Optional<Oauth> oauth = oauthService.readOauthByUserIdAndProvider(userId, provider);
 
+        // 이미 해당 Oauth 계정에 연동되어 있는 경우
         if (oauth.isPresent() && !oauth.get().isDeleted()) {
-            log.info("이미 동일한 Provider로 가입된 사용자입니다. userId: {}, provider: {}", userId, provider);
-            throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
+            if (oauth.get().isDeleted()) {
+                log.info("이미 연동 해지된 Oauth 계정입니다. userId: {}, provider: {}", userId, provider);
+
+            } else {
+                log.info("이미 해당 Oauth 계정에 연동되어 있습니다. userId: {}, provider: {}", userId, provider);
+                throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
+            }
         }
 
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
@@ -132,7 +144,7 @@ public class UserOauthSignService {
     private Oauth readOrCreateOauth(UserSyncDto userSync, Provider provider, String oauthId, User user) {
         if (userSync.isExistOauthAccount()) {
             Oauth oauth = oauthService.readOauth(userSync.oauthSync().id()).orElseThrow(() -> new OauthException(OauthErrorCode.NOT_FOUND_OAUTH));
-            oauth.revertDelete(oauthId);
+            oauth.revertDelete(oauthId, user);
             log.info("기존 Oauth 계정을 복구합니다. oauth: {}", oauth);
 
             return oauth;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/service/UserOauthSignService.java
@@ -48,15 +48,13 @@ public class UserOauthSignService {
             return UserSyncDto.signUpAllowed();
         }
 
-        Optional<Oauth> oauth = oauthService.readOauthByUserIdAndProvider(user.get().getId(), provider);
-
-        if (oauth.isPresent() && !oauth.get().isDeleted()) {
+        if (oauthService.isExistOauthByUserIdAndProvider(user.get().getId(), provider)) {
             log.info("이미 동일한 Provider로 가입된 사용자입니다. phone: {}, provider: {}", phone, provider);
             return UserSyncDto.abort(user.get().getId(), user.get().getUsername());
         }
 
         log.info("소셜 회원가입 사용자입니다. user: {}", user.get());
-        return UserSyncDto.of(true, true, user.get().getId(), user.get().getUsername(), UserSyncDto.OauthSync.from(oauth.orElse(null)));
+        return UserSyncDto.of(true, true, user.get().getId(), user.get().getUsername());
     }
 
     /**
@@ -78,7 +76,7 @@ public class UserOauthSignService {
 
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
 
-        return UserSyncDto.of(true, true, user.getId(), user.getUsername(), UserSyncDto.OauthSync.from(null));
+        return UserSyncDto.of(true, true, user.getId(), user.getUsername());
     }
 
     /**

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/UserAuthUseCase.java
@@ -49,7 +49,7 @@ public class UserAuthUseCase {
     public void linkOauth(Provider provider, SignInReq.Oauth request, Long userId) {
         OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.oauthId(), request.idToken(), request.nonce());
 
-        UserSyncDto userSync = userOauthSignService.isLinkAllowed(userId, provider);
+        UserSyncDto userSync = userOauthSignService.isLinkAllowed(userId, request.oauthId(), provider);
         userOauthSignService.saveUser(null, userSync, provider, payload.sub());
     }
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/OAuthControllerIntegrationTest.java
@@ -527,7 +527,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         @Test
         @WithAnonymousUser
         @Transactional
-        @DisplayName("같은 provider로 Oauth 로그인 이력이 soft delete 되었으면, Oauth 정보가 복구되고 새로운 oauth_id를 반영한다.")
+        @DisplayName("같은 provider로 Oauth 로그인 이력이 soft delete 되었으면, 새로운 Oauth 정보가 추가되고 로그인에 성공한다.")
         void signUpWithDeletedOauth() throws Exception {
             // given
             Provider provider = Provider.KAKAO;
@@ -552,10 +552,8 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andDo(print());
             Oauth savedOauth = oauthService.readOauthByOauthIdAndProvider("newOauthId", provider).get();
             assertEquals(user.getId(), savedOauth.getUser().getId());
-            assertEquals(oauth.getId(), savedOauth.getId());
             assertEquals("newOauthId", savedOauth.getOauthId());
             assertFalse(savedOauth.isDeleted());
-            log.debug("oauth : {}", savedOauth);
         }
 
         private ResultActions performOauthSignUpAccountLinking(Provider provider, String code, String oauthId) throws Exception {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
@@ -243,7 +243,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @DisplayName("provider로 로그인한 이력이 있다면, 사용자는 계정 연동에 실패하고 409 에러를 반환한다.")
+        @DisplayName("이미 해당 소셜 계정에 연동했다면, ALREADY_SIGNUP_OAUTH 에러를 반환한다.")
         @Transactional
         void linkOauthWithHistory() throws Exception {
             // given
@@ -264,7 +264,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @DisplayName("해당 provider가 soft delete된 이력이 존재한다면, deleted_at을 null로 업데이트하고 최신 oauth_id를 반영하여 계정 연동에 성공한다.")
+        @DisplayName("해당 소셜 계정으로 연동했었던 삭제 이력이 있다면, 삭제 이력을 복구하고 연동에 성공한다.")
         @Transactional
         void linkOauthWithDeletedHistory() throws Exception {
             // given
@@ -289,7 +289,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @DisplayName("provider, oauthId에 해당하는 Oauth 데이터에 연동된 계정이 존재할 경우, 409 ALREADY_USED_OAUTH 에러를 반환한다.")
+        @DisplayName("다른 계정에 이미 해당 소셜 계정이 연동되어 있다면, 409 ALREADY_USED_OAUTH 에러를 반환한다.")
         @Transactional
         void linkOauthWithAlreadyUsedOauth() throws Exception {
             // given
@@ -314,7 +314,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @DisplayName("provider, oauthId에 해당하는 Oauth 데이터가 다른 계정에 연동된 이력이 존재하나, soft delete 되었다면 user_id를 갱신해 연동에 성공한다.")
+        @DisplayName("다른 계정에서 해당 소셜 계정을 연동했었던 이력이 있다면, 삭제 이력을 복구하고 사용자 정보를 갱신하여 연동에 성공한다.")
         @Transactional
         void linkOauthWithDeletedOauth() throws Exception {
             // given

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
@@ -281,11 +281,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
             // then
             result.andExpect(status().isOk()).andDo(print());
-            Oauth savedOauth = oauthService.readOauth(oauth.getId()).orElse(null);
-            assertNotNull(savedOauth);
-            assertEquals("newOauthId", savedOauth.getOauthId());
-            assertNull(savedOauth.getDeletedAt());
-            log.info("연동된 Oauth 정보 : {}", savedOauth);
         }
 
         @Test
@@ -336,7 +331,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Oauth savedOauth = oauthService.readOauthsByUserId(user2.getId()).stream().filter(o -> o.getProvider().equals(provider)).findFirst().orElse(null);
             assertNotNull(savedOauth);
             assertNull(savedOauth.getDeletedAt());
-            log.info("연동된 Oauth 정보 : {}", savedOauth);
         }
 
         private ResultActions performLinkOauth(Provider provider, String oauthId, User requestUser) throws Exception {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
@@ -315,7 +315,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
         @Test
         @DisplayName("다른 계정에서 해당 소셜 계정을 연동했었던 이력이 있다면, 삭제 이력을 복구하고 사용자 정보를 갱신하여 연동에 성공한다.")
-        @Transactional
         void linkOauthWithDeletedOauth() throws Exception {
             // given
             User user1 = userService.createUser(UserFixture.GENERAL_USER.toUser());

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
@@ -239,7 +239,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
 
             // then
             result.andExpect(status().isOk()).andDo(print());
-            assertTrue(oauthService.isExistOauthAccount(user.getId(), expectedProvider));
+            assertTrue(oauthService.isExistOauthByUserIdAndProvider(user.getId(), expectedProvider));
         }
 
         @Test
@@ -264,7 +264,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @DisplayName("해당 소셜 계정으로 연동했었던 삭제 이력이 있다면, 삭제 이력을 복구하고 연동에 성공한다.")
+        @DisplayName("해당 소셜 계정으로 연동했었던 이력이 삭제되어 있다면, 새로운 데이터를 생성하고 연동에 성공한다.")
         @Transactional
         void linkOauthWithDeletedHistory() throws Exception {
             // given
@@ -314,7 +314,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         @Test
-        @DisplayName("다른 계정에서 해당 소셜 계정을 연동했었던 이력이 있다면, 삭제 이력을 복구하고 사용자 정보를 갱신하여 연동에 성공한다.")
+        @DisplayName("다른 계정에서 해당 소셜 계정을 연동했었던 삭제 이력이 있다면, 새로운 데이터를 생성하고 연동에 성공한다.")
         void linkOauthWithDeletedOauth() throws Exception {
             // given
             User user1 = userService.createUser(UserFixture.GENERAL_USER.toUser());
@@ -322,7 +322,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             String oauthId = "oauthId";
             Oauth oauth = oauthService.createOauth(Oauth.of(provider, oauthId, user1));
             log.info("생성된 Oauth 정보 : {}", oauth);
-            Long deletedAuthPk = oauth.getId();
             oauthService.deleteOauth(oauth);
 
             User user2 = userService.createUser(UserFixture.OAUTH_USER.toUser());
@@ -337,7 +336,6 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             Oauth savedOauth = oauthService.readOauthsByUserId(user2.getId()).stream().filter(o -> o.getProvider().equals(provider)).findFirst().orElse(null);
             assertNotNull(savedOauth);
             assertNull(savedOauth.getDeletedAt());
-            assertEquals(deletedAuthPk, savedOauth.getId());
             log.info("연동된 Oauth 정보 : {}", savedOauth);
         }
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -92,7 +92,6 @@ public class Oauth {
                 ", oauthId='" + oauthId + '\'' +
                 ", createdAt=" + createdAt +
                 ", deletedAt=" + deletedAt +
-                ", user=" + user +
                 '}';
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -68,15 +68,19 @@ public class Oauth {
         return deletedAt != null;
     }
 
-    public void revertDelete(String oauthId) {
+    public void revertDelete(String oauthId, User user) {
         if (deletedAt == null) {
             throw new IllegalStateException("삭제되지 않은 oauth 정보 갱신 요청입니다. oauthId: " + oauthId);
+        }
+        if (user == null) {
+            throw new IllegalArgumentException("user는 null이 될 수 없습니다.");
         }
         if (!StringUtils.hasText(oauthId)) {
             throw new IllegalArgumentException("oauthId는 null이거나 빈 문자열이 될 수 없습니다.");
         }
 
         this.oauthId = oauthId;
+        this.user = user;
         this.deletedAt = null;
     }
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/domain/Oauth.java
@@ -68,22 +68,6 @@ public class Oauth {
         return deletedAt != null;
     }
 
-    public void revertDelete(String oauthId, User user) {
-        if (deletedAt == null) {
-            throw new IllegalStateException("삭제되지 않은 oauth 정보 갱신 요청입니다. oauthId: " + oauthId);
-        }
-        if (user == null) {
-            throw new IllegalArgumentException("user는 null이 될 수 없습니다.");
-        }
-        if (!StringUtils.hasText(oauthId)) {
-            throw new IllegalArgumentException("oauthId는 null이거나 빈 문자열이 될 수 없습니다.");
-        }
-
-        this.oauthId = oauthId;
-        this.user = user;
-        this.deletedAt = null;
-    }
-
     @Override
     public String toString() {
         return "Oauth{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/exception/OauthErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/exception/OauthErrorCode.java
@@ -21,6 +21,7 @@ public enum OauthErrorCode implements BaseErrorCode {
 
     /* 409 Conflict */
     CANNOT_UNLINK_OAUTH(StatusCode.CONFLICT, ReasonCode.REQUEST_CONFLICTS_WITH_CURRENT_STATE_OF_RESOURCE, "해당 제공자로만 가입된 사용자는 연동을 해제할 수 없습니다."),
+    ALREADY_USED_OAUTH(StatusCode.CONFLICT, ReasonCode.REQUEST_CONFLICTS_WITH_CURRENT_STATE_OF_RESOURCE, "이미 다른 계정에서 사용 중인 계정입니다."),
     ALREADY_SIGNUP_OAUTH(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 해당 제공자로 가입된 사용자입니다."),
 
     /* 422 Unprocessable Entity */

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/repository/OauthRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/repository/OauthRepository.java
@@ -13,11 +13,11 @@ import java.util.Set;
 public interface OauthRepository extends JpaRepository<Oauth, Long> {
     Optional<Oauth> findByOauthIdAndProviderAndDeletedAtIsNull(String oauthId, Provider provider);
 
-    Optional<Oauth> findByUser_IdAndProvider(Long userId, Provider provider);
+    Optional<Oauth> findByUser_IdAndProviderAndDeletedAtIsNull(Long userId, Provider provider);
 
     Set<Oauth> findAllByUser_Id(Long userId);
 
-    boolean existsByUser_IdAndProvider(Long userId, Provider provider);
+    boolean existsByUser_IdAndProviderAndDeletedAtIsNull(Long userId, Provider provider);
 
     boolean existsByOauthIdAndProviderAndDeletedAtIsNull(String oauthId, Provider provider);
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/repository/OauthRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/repository/OauthRepository.java
@@ -19,6 +19,8 @@ public interface OauthRepository extends JpaRepository<Oauth, Long> {
 
     boolean existsByUser_IdAndProvider(Long userId, Provider provider);
 
+    boolean existsByOauthIdAndProviderAndDeletedAtIsNull(String oauthId, Provider provider);
+
     @Transactional
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Oauth o SET o.deletedAt = NOW() WHERE o.user.id = :userId AND o.deletedAt IS NULL")

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -33,9 +33,12 @@ public class OauthService {
         return oauthRepository.findByOauthIdAndProviderAndDeletedAtIsNull(oauthId, provider);
     }
 
+    /**
+     * userId와 provider로 Oauth를 조회한다. 이 때, deletedAt이 null인 Oauth만 조회한다.
+     */
     @Transactional(readOnly = true)
     public Optional<Oauth> readOauthByUserIdAndProvider(Long userId, Provider provider) { // delete_at 옵션 없어서 불안
-        return oauthRepository.findByUser_IdAndProvider(userId, provider);
+        return oauthRepository.findByUser_IdAndProviderAndDeletedAtIsNull(userId, provider);
     }
 
     @Transactional(readOnly = true)
@@ -43,9 +46,12 @@ public class OauthService {
         return oauthRepository.findAllByUser_Id(userId);
     }
 
+    /**
+     * userId와 provider로 Oauth가 존재하는지 확인한다. 이 때, deletedAt이 null인 Oauth만 조회한다.
+     */
     @Transactional(readOnly = true)
-    public boolean isExistOauthAccount(Long userId, Provider provider) { // delete_at 옵션 없어서 불안
-        return oauthRepository.existsByUser_IdAndProvider(userId, provider);
+    public boolean isExistOauthByUserIdAndProvider(Long userId, Provider provider) { // delete_at 옵션 없어서 불안
+        return oauthRepository.existsByUser_IdAndProviderAndDeletedAtIsNull(userId, provider);
     }
 
     /**

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -33,14 +33,6 @@ public class OauthService {
         return oauthRepository.findByOauthIdAndProviderAndDeletedAtIsNull(oauthId, provider);
     }
 
-    /**
-     * userId와 provider로 Oauth를 조회한다. 이 때, deletedAt이 null인 Oauth만 조회한다.
-     */
-    @Transactional(readOnly = true)
-    public Optional<Oauth> readOauthByUserIdAndProvider(Long userId, Provider provider) { // delete_at 옵션 없어서 불안
-        return oauthRepository.findByUser_IdAndProviderAndDeletedAtIsNull(userId, provider);
-    }
-
     @Transactional(readOnly = true)
     public Set<Oauth> readOauthsByUserId(Long userId) {
         return oauthRepository.findAllByUser_Id(userId);
@@ -50,7 +42,7 @@ public class OauthService {
      * userId와 provider로 Oauth가 존재하는지 확인한다. 이 때, deletedAt이 null인 Oauth만 조회한다.
      */
     @Transactional(readOnly = true)
-    public boolean isExistOauthByUserIdAndProvider(Long userId, Provider provider) { // delete_at 옵션 없어서 불안
+    public boolean isExistOauthByUserIdAndProvider(Long userId, Provider provider) {
         return oauthRepository.existsByUser_IdAndProviderAndDeletedAtIsNull(userId, provider);
     }
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -34,7 +34,7 @@ public class OauthService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<Oauth> readOauthByUserIdAndProvider(Long userId, Provider provider) {
+    public Optional<Oauth> readOauthByUserIdAndProvider(Long userId, Provider provider) { // delete_at 옵션 없어서 불안
         return oauthRepository.findByUser_IdAndProvider(userId, provider);
     }
 
@@ -44,7 +44,7 @@ public class OauthService {
     }
 
     @Transactional(readOnly = true)
-    public boolean isExistOauthAccount(Long userId, Provider provider) {
+    public boolean isExistOauthAccount(Long userId, Provider provider) { // delete_at 옵션 없어서 불안
         return oauthRepository.existsByUser_IdAndProvider(userId, provider);
     }
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/oauth/service/OauthService.java
@@ -48,6 +48,14 @@ public class OauthService {
         return oauthRepository.existsByUser_IdAndProvider(userId, provider);
     }
 
+    /**
+     * oauthId와 provider로 Oauth가 존재하는지 확인한다. 이 때, deletedAt이 null인 Oauth만 조회한다.
+     */
+    @Transactional(readOnly = true)
+    public boolean isExistOauthByOauthIdAndProvider(String oauthId, Provider provider) {
+        return oauthRepository.existsByOauthIdAndProviderAndDeletedAtIsNull(oauthId, provider);
+    }
+
     @Transactional
     public void deleteOauth(Oauth oauth) {
         oauthRepository.delete(oauth);


### PR DESCRIPTION
## 작업 이유
- 연동하려는 소셜 계정이 이미 다른 사용자 계정에 연동되어 있을 때 예외 처리
- soft delete된 데이터를 복구하지 않는 정책으로 수정

<br/>

## 작업 사항
### 💡 OAuth 테이블 조회 시 주의 사항
- 필드: id, oauth_id, provider, created_at, deleted_at, user_id
- {id}는 유일성을 보장함.
- {oauth_id, provider}는 유일성을 보장하지 않음. candidate 성립 X
   - 임의의 provider 계정을 사용자1의 계정에 연동했다가 해지 후, 사용자2의 계정에 연동할 수 있기 때문
   - deleted_at이 NULL인 {oauth_id, provider}는 유일성을 보장해야 함. (임의의 provider의 계정이 연동된 서비스 계정은 최대 하나여야 한다.)
- {user_id, provider}는 유일성을 보장하지 않음.
   - 사용자가 임의의 provider 계정1에 연동했다가 해지 후, provider 계정2에 연동할 수 있기 때문
   - Optional<Oauth> readOauthByUserIdAndProvider(Long userId, Provider provider) 에러 발생 가능성 존재.
   - deleted_at이 NULL인 {user_id, provider}는 유일성을 보장해야 함. (사용자가 임의의 provider에 연동된 계정은 최대 하나여야 한다.)

<br/>

### 🤔 기존 방식의 문제점
- 완전히 새로운 소셜 계정 정보를 연동하는 경우를 제외하고는 삭제된 데이터를 복구하는 방식으로 데이터를 추가함.
- 이로 인해, candidate에 해당하지 않는 조건으로 OAuth 정보를 조회하면, 정보가 2개 이상일 수 있으므로 500 에러가 발생할 여지가 존재함.
- 만약 이 정책을 준수하려면, candidate가 아닌 조건으로 조회하는 모든 메서드 반환 타입을 Collection으로 수정하고 isDelelte 여부를 체크해야함. (휴먼 에러 가능성이 너무 높아짐)

또한 OAuth 계정 연동은 다음과 같은 복잡한 분기 처리가 필요해짐.
```
OAuth 계정 수정
1. 임의의 provider에 대한 oauth_id 등록 정보가 아예 존재하지 않는 경우
: 새로 생성

2. 임의의 provider에 대한 oauth_id 등록 정보가 존재하며, user_id가 본인인 경우
{provider, oauth_id, user_id}
: ALREADY SIGNUP OAUTH

3. 임의의 provider에 대한 oauth_id 등록 정보가 존재하며, user_id가 타인인 경우
{provider, oauth_id, user_id}
: ALREADY USED OAUTH

4. 임의의 provider에 대한 oauth_id 등록 정보가 존재하나, soft delete 되었고 user_id가 본인인 경우
{provider, oauth_id, user_id, deleted_at IS NOT NULL}
: delete 취소

5. 임의의 provider에 대한 oauth_id 등록 정보고 존재하나, soft delete 되었고 user_id가 타인인 경우
{provider, oauth_id, user_id, deleted_at IS NOT NULL}
: delete 취소 및 user_id 변경
```

이게 너무 복잡해져서 골치 아프기도 했고, 삭제된 정보를 복구하겠다는 생각이 너무 어리석었던 것 같아서 candidate가 아닌 조회 조건들 모두 `deleted_at is null` 조건을 추가함으로써, 문제를 개선함.  

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 추가 테스트 케이스로 OAuth 연동 시 발생할 문제점은 모두 잡았다고 생각하는데, 추가적으로 검수해야 할 예외 케이스가 존재하는지?
- 초반에 작성한 코드 너무 드릅다..

<br/>

## 발견한 이슈
```java
if (oauthService.isExistOauthByUserIdAndProvider(userId, provider)) {
    log.info("이미 해당 Oauth 계정에 연동되어 있습니다. userId: {}, provider: {}", userId, provider);
    throw new OauthException(OauthErrorCode.ALREADY_SIGNUP_OAUTH);
}
```
일어나서도 안 되는 경우고, 일어난다해도 문제가 되진 않으나 이상한 예외로 처리되는 경우가 존재합니다.   
예를 들어, 사용자가 A 구글 계정으로 연동된 상태에서 (비정상 요청으로) B 구글 계정 연동을 시도하는 경우  
"이미 연동된 구글 계정이 있음"을 알리는 것이 아닌, "B 계정에 연동되어 있음"이라는 잘못된 예외 문구가 반환되고 있습니다.  
