### PR TITLE
Api: ✏️  확인 알림과 미확인 알림 조회 API 분리

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "[알림 API]")
 public interface NotificationApi {
-    @Operation(summary = "수신한 알림 목록 무한 스크롤 조회")
+    @Operation(summary = "수신한 읽음 알림 목록 무한 스크롤 조회")
     @Parameters({
             @Parameter(
                     in = ParameterIn.QUERY,
@@ -56,7 +56,7 @@ public interface NotificationApi {
                     )
             ), @Parameter(name = "pageable", hidden = true)})
     @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "notifications", schema = @Schema(implementation = NotificationDto.SliceRes.class))))
-    ResponseEntity<?> getNotifications(
+    ResponseEntity<?> getReadNotifications(
             @PageableDefault(page = 0, size = 30) @SortDefault(sort = "notification.createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal SecurityUserDetails user
     );

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
@@ -62,7 +62,7 @@ public interface NotificationApi {
     );
 
     @Operation(summary = "수신한 미확인 알림 목록 조회")
-    @ApiResponse(responseCode = "200", description = "미확인 알림 목록 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "notifications", schema = @Schema(implementation = NotificationDto.ListRes.class))))
+    @ApiResponse(responseCode = "200", description = "미확인 알림 목록 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "notifications", array = @ArraySchema(schema = @Schema(implementation = NotificationDto.Info.class)))))
     ResponseEntity<?> getUnreadNotifications(@AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "수신한 알림 중 미확인 알림 존재 여부 조회")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
@@ -63,7 +63,7 @@ public interface NotificationApi {
 
     @Operation(summary = "수신한 알림 중 미확인 알림 존재 여부 조회")
     @ApiResponse(responseCode = "200", description = "미확인 알림 존재 여부 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "hasUnread", schema = @Schema(type = "boolean"))))
-    ResponseEntity<?> getUnreadNotifications(@AuthenticationPrincipal SecurityUserDetails user);
+    ResponseEntity<?> getHasUnreadNotification(@AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "수신한 알림 읽음 처리", description = "사용자가 수신한 알림을 읽음처리 합니다. 단, 읽음 처리할 알림의 pk는 사용자가 receiver여야 하며, 미확인 알림만 포함되어 있어야 합니다.")
     @ApiResponses({

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
@@ -61,6 +61,10 @@ public interface NotificationApi {
             @AuthenticationPrincipal SecurityUserDetails user
     );
 
+    @Operation(summary = "수신한 미확인 알림 목록 조회")
+    @ApiResponse(responseCode = "200", description = "미확인 알림 목록 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "notifications", schema = @Schema(implementation = NotificationDto.ListRes.class))))
+    ResponseEntity<?> getUnreadNotifications(@AuthenticationPrincipal SecurityUserDetails user);
+
     @Operation(summary = "수신한 알림 중 미확인 알림 존재 여부 조회")
     @ApiResponse(responseCode = "200", description = "미확인 알림 존재 여부 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "hasUnread", schema = @Schema(type = "boolean"))))
     ResponseEntity<?> getHasUnreadNotification(@AuthenticationPrincipal SecurityUserDetails user);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/api/NotificationApi.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "[알림 API]")
 public interface NotificationApi {
-    @Operation(summary = "수신한 읽음 알림 목록 무한 스크롤 조회")
+    @Operation(summary = "수신한 알림 중 확인한 알림 목록 무한 스크롤 조회")
     @Parameters({
             @Parameter(
                     in = ParameterIn.QUERY,
@@ -61,7 +61,7 @@ public interface NotificationApi {
             @AuthenticationPrincipal SecurityUserDetails user
     );
 
-    @Operation(summary = "수신한 미확인 알림 목록 조회")
+    @Operation(summary = "수신한 알림 중 미확인 알림 목록 조회")
     @ApiResponse(responseCode = "200", description = "미확인 알림 목록 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "notifications", array = @ArraySchema(schema = @Schema(implementation = NotificationDto.Info.class)))))
     ResponseEntity<?> getUnreadNotifications(@AuthenticationPrincipal SecurityUserDetails user);
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
@@ -34,16 +34,18 @@ public class NotificationController implements NotificationApi {
             @PageableDefault(page = 0, size = 30) @SortDefault(sort = "notification.createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal SecurityUserDetails user
     ) {
-        return ResponseEntity.ok(SuccessResponse.from(NOTIFICATIONS, notificationUseCase.getNotifications(user.getUserId(), pageable)));
-    }
-
-    @Override
-    public ResponseEntity<?> getUnreadNotifications(@AuthenticationPrincipal SecurityUserDetails user) {
-        return null;
+        return ResponseEntity.ok(SuccessResponse.from(NOTIFICATIONS, notificationUseCase.getReadNotifications(user.getUserId(), pageable)));
     }
 
     @Override
     @GetMapping("/unread")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getUnreadNotifications(@AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(SuccessResponse.from(NOTIFICATIONS, notificationUseCase.getUnreadNotifications(user.getUserId())));
+    }
+
+    @Override
+    @GetMapping("/unread/exist")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getHasUnreadNotification(@AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from(HAS_UNREAD, notificationUseCase.hasUnreadNotification(user.getUserId())));

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
@@ -30,7 +30,7 @@ public class NotificationController implements NotificationApi {
     @Override
     @GetMapping("")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> getNotifications(
+    public ResponseEntity<?> getReadNotifications(
             @PageableDefault(page = 0, size = 30) @SortDefault(sort = "notification.createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal SecurityUserDetails user
     ) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
@@ -38,6 +38,11 @@ public class NotificationController implements NotificationApi {
     }
 
     @Override
+    public ResponseEntity<?> getUnreadNotifications(@AuthenticationPrincipal SecurityUserDetails user) {
+        return null;
+    }
+
+    @Override
     @GetMapping("/unread")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getHasUnreadNotification(@AuthenticationPrincipal SecurityUserDetails user) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/controller/NotificationController.java
@@ -40,7 +40,7 @@ public class NotificationController implements NotificationApi {
     @Override
     @GetMapping("/unread")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> getUnreadNotifications(@AuthenticationPrincipal SecurityUserDetails user) {
+    public ResponseEntity<?> getHasUnreadNotification(@AuthenticationPrincipal SecurityUserDetails user) {
         return ResponseEntity.ok(SuccessResponse.from(HAS_UNREAD, notificationUseCase.hasUnreadNotification(user.getUserId())));
     }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/dto/NotificationDto.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/dto/NotificationDto.java
@@ -23,6 +23,16 @@ public class NotificationDto {
     ) {
     }
 
+    @Schema(title = "푸시 알림 리스트 응답")
+    public record ListRes(
+            @Schema(description = "푸시 알림 리스트")
+            List<Info> notifications
+    ) {
+        public static ListRes from(List<Info> notifications) {
+            return new ListRes(notifications);
+        }
+    }
+
     @Schema(title = "푸시 알림 슬라이스 응답")
     public record SliceRes(
             @Schema(description = "푸시 알림 리스트")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/mapper/NotificationMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/mapper/NotificationMapper.java
@@ -7,9 +7,22 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.util.Comparator;
+import java.util.List;
+
 @Slf4j
 @Mapper
 public class NotificationMapper {
+    /**
+     * Notification 타입을 NotificationDto.Info 타입으로 변환한다.
+     */
+    public static List<NotificationDto.Info> toInfoList(List<Notification> notifications) {
+        return notifications.stream()
+                .map(NotificationDto.Info::from)
+                .sorted(Comparator.comparing(NotificationDto.Info::id).reversed())
+                .toList();
+    }
+
     /**
      * Slice<Notification> 타입을 무한 스크롤 응답 형태로 변환한다.
      */

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/service/NotificationSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/service/NotificationSearchService.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -18,6 +20,11 @@ public class NotificationSearchService {
     @Transactional(readOnly = true)
     public Slice<Notification> getNotifications(Long userId, Pageable pageable) {
         return notificationService.readNotificationsSlice(userId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Notification> getUnreadNotifications(Long userId) {
+        return notificationService.readUnreadNotifications(userId);
     }
 
     @Transactional(readOnly = true)

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
@@ -20,10 +20,16 @@ public class NotificationUseCase {
     private final NotificationSearchService notificationSearchService;
     private final NotificationSaveService notificationSaveService;
 
-    public NotificationDto.SliceRes getNotifications(Long userId, Pageable pageable) {
+    public NotificationDto.SliceRes getReadNotifications(Long userId, Pageable pageable) {
         Slice<Notification> notifications = notificationSearchService.getNotifications(userId, pageable);
 
         return NotificationMapper.toSliceRes(notifications, pageable);
+    }
+
+    public List<NotificationDto.Info> getUnreadNotifications(Long userId) {
+        List<Notification> notifications = notificationSearchService.getUnreadNotifications(userId);
+
+        return NotificationMapper.toInfoList(notifications);
     }
 
     public boolean hasUnreadNotification(Long userId) {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/notification/controller/GetNotificationsControllerUnitTest.java
@@ -59,7 +59,7 @@ public class GetNotificationsControllerUnitTest {
         Notification notification = NotificationFixture.ANNOUNCEMENT_DAILY_SPENDING.toEntity(UserFixture.GENERAL_USER.toUser());
         NotificationDto.Info info = NotificationDto.Info.from(notification);
 
-        given(notificationUseCase.getNotifications(eq(1L), any())).willReturn(NotificationDto.SliceRes.from(List.of(info), pa, numberOfElements, false));
+        given(notificationUseCase.getReadNotifications(eq(1L), any())).willReturn(NotificationDto.SliceRes.from(List.of(info), pa, numberOfElements, false));
 
         // when
         ResultActions result = performGetNotifications(page);
@@ -82,7 +82,7 @@ public class GetNotificationsControllerUnitTest {
         NotificationDto.Info info = NotificationDto.Info.from(notification);
         NotificationDto.SliceRes sliceRes = NotificationDto.SliceRes.from(List.of(info), pa, numberOfElements, false);
 
-        given(notificationUseCase.getNotifications(eq(1L), any())).willReturn(sliceRes);
+        given(notificationUseCase.getReadNotifications(eq(1L), any())).willReturn(sliceRes);
 
         // when
         ResultActions result = performGetNotifications(page);

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/repository/NotificationRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/repository/NotificationRepository.java
@@ -9,6 +9,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 public interface NotificationRepository extends ExtendedRepository<Notification, Long>, NotificationCustomRepository {
+    @Transactional(readOnly = true)
+    List<Notification> findByReceiver_IdAndReadAtIsNull(Long userId);
+
     @Modifying(clearAutomatically = true)
     @Transactional
     @Query("update Notification n set n.readAt = current_timestamp where n.id in ?1")

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/repository/NotificationRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/repository/NotificationRepository.java
@@ -9,9 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 public interface NotificationRepository extends ExtendedRepository<Notification, Long>, NotificationCustomRepository {
-    @Transactional(readOnly = true)
-    List<Notification> findByReceiver_IdAndReadAtIsNull(Long userId);
-
     @Modifying(clearAutomatically = true)
     @Transactional
     @Query("update Notification n set n.readAt = current_timestamp where n.id in ?1")

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/service/NotificationService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/service/NotificationService.java
@@ -38,6 +38,11 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
+    public List<Notification> readUnreadNotifications(Long userId) {
+        return notificationRepository.findByReceiver_IdAndReadAtIsNull(userId);
+    }
+
+    @Transactional(readOnly = true)
     public boolean isExistsUnreadNotification(Long userId) {
         return notificationRepository.existsUnreadNotification(userId);
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/service/NotificationService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/service/NotificationService.java
@@ -26,7 +26,7 @@ public class NotificationService {
 
     @Transactional(readOnly = true)
     public Slice<Notification> readNotificationsSlice(Long userId, Pageable pageable) {
-        Predicate predicate = notification.receiver.id.eq(userId);
+        Predicate predicate = notification.receiver.id.eq(userId).and(notification.readAt.isNull());
 
         QueryHandler queryHandler = query -> query
                 .offset(pageable.getOffset())

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/service/NotificationService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/service/NotificationService.java
@@ -26,7 +26,7 @@ public class NotificationService {
 
     @Transactional(readOnly = true)
     public Slice<Notification> readNotificationsSlice(Long userId, Pageable pageable) {
-        Predicate predicate = notification.receiver.id.eq(userId).and(notification.readAt.isNull());
+        Predicate predicate = notification.receiver.id.eq(userId).and(notification.readAt.isNotNull());
 
         QueryHandler queryHandler = query -> query
                 .offset(pageable.getOffset())
@@ -39,7 +39,9 @@ public class NotificationService {
 
     @Transactional(readOnly = true)
     public List<Notification> readUnreadNotifications(Long userId) {
-        return notificationRepository.findByReceiver_IdAndReadAtIsNull(userId);
+        Predicate predicate = notification.receiver.id.eq(userId).and(notification.readAt.isNull());
+
+        return notificationRepository.findList(predicate, null, null);
     }
 
     @Transactional(readOnly = true)

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/notification/repository/ReadNotificationsSliceUnitTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/notification/repository/ReadNotificationsSliceUnitTest.java
@@ -28,6 +28,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -64,6 +65,7 @@ public class ReadNotificationsSliceUnitTest extends ContainerMySqlTestConfig {
         List<Notification> notifications = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             Notification notification = new Notification.Builder(NoticeType.ANNOUNCEMENT, Announcement.DAILY_SPENDING, user).build();
+            ReflectionTestUtils.setField(notification, "readAt", LocalDateTime.now());
             notifications.add(notification);
         }
         bulkInsertNotifications(notifications);
@@ -97,8 +99,8 @@ public class ReadNotificationsSliceUnitTest extends ContainerMySqlTestConfig {
 
     private void bulkInsertNotifications(List<Notification> notifications) {
         String sql = String.format("""
-                INSERT INTO `%s` (type, announcement, created_at, updated_at, receiver, receiver_name)
-                VALUES (:type, :announcement, :createdAt, :updatedAt, :receiver, :receiverName);
+                INSERT INTO `%s` (type, announcement, created_at, updated_at, receiver, receiver_name, read_at)
+                VALUES (:type, :announcement, :createdAt, :updatedAt, :receiver, :receiverName, :readAt);
                 """, "notification");
 
         LocalDateTime date = LocalDateTime.now();
@@ -112,7 +114,8 @@ public class ReadNotificationsSliceUnitTest extends ContainerMySqlTestConfig {
                     .addValue("createdAt", date)
                     .addValue("updatedAt", date)
                     .addValue("receiver", notification.getReceiver().getId())
-                    .addValue("receiverName", notification.getReceiverName());
+                    .addValue("receiverName", notification.getReceiverName())
+                    .addValue("readAt", notification.getReadAt());
             date = date.minusDays(1);
         }
 


### PR DESCRIPTION
## 작업 이유
- 기존에 확인 알림과 미확인 알림을 합쳐버리니, 무한 스크롤이 뒤섞이는 문제가 발생함.
- iOS 측 요청에 따라 확인 알림과 미확인 알림을 분리

<br/>

## 작업 사항
- 기존 API 변경 사항
   - 미확인 알림 존재 여부를 판단하기 위한 URL이 `GET /notifications/unread` → `GET /notifications/unread/exist`로 수정
- 구현된 API
   - url: `GET /notification/unread`
   - 해당 경로로 요청한 데이터는 무한 스크롤이 아닌, 전체 데이터를 모두 반환함. (단, 모든 데이터는 시간 순(id)으로 역정렬되어, 최신순서가 가장 앞의 인덱스에 위치.)

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 미확인 알림 여부 조회를 위한 경로를 `/notifications/unread/exist`로 일단 지정해뒀는데, `exist` 대신 대체할 만한 게 있을 지..?

<br/>

## 발견한 이슈
- 현재 푸시 알림 타입 구분없이 모든 알림에 대해 무한 스크롤을 사용하는데, 채팅 메시지도 여기서 확인 가능하게 되면 문제가 생길 여지가 있음. 이에 대해 디자이너와 상의가 필요함.