### PR TITLE
Api: ✨ 분산 코디네이션 도입을 고려한 서비스 탐색 서비스 API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/socket/api/SocketApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/socket/api/SocketApi.java
@@ -1,0 +1,16 @@
+package kr.co.pennyway.api.apis.socket.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "[서비스 탐색 API]")
+public interface SocketApi {
+    @Operation(summary = "연결 가능한 채팅 서버 정보 조회", description = "요청 헤더, 바디를 기반으로 연결 가능한 채팅 서버 정보를 조회한 후, 채팅 서버 정보를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "연결 가능한 채팅 서버 정보 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "url", schema = @Schema(type = "string", description = "채팅 서버 URL"))))
+    ResponseEntity<?> getChatServerInfo();
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/socket/controller/SocketController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/socket/controller/SocketController.java
@@ -1,0 +1,26 @@
+package kr.co.pennyway.api.apis.socket.controller;
+
+import kr.co.pennyway.api.apis.socket.api.SocketApi;
+import kr.co.pennyway.api.apis.socket.usecase.SocketUseCase;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/socket")
+public class SocketController implements SocketApi {
+    private static final String CHAT_SERVER_URL = "chatServerUrl";
+    private final SocketUseCase socketUseCase;
+
+    @Override
+    @GetMapping("/chat")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getChatServerInfo() {
+        return ResponseEntity.ok(SuccessResponse.from(CHAT_SERVER_URL, socketUseCase.getChatServerUrl()));
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/socket/service/ChatServerSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/socket/service/ChatServerSearchService.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.api.apis.socket.service;
+
+import kr.co.pennyway.infra.client.coordinator.CoordinatorService;
+import kr.co.pennyway.infra.client.coordinator.WebSocket;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatServerSearchService {
+    private final CoordinatorService defaultCoordinatorService;
+
+    public String getChatServerUrl() {
+        WebSocket.ChatServerUrl response = defaultCoordinatorService.readChatServerUrl(null, null);
+
+        return response.url();
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/socket/usecase/SocketUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/socket/usecase/SocketUseCase.java
@@ -1,8 +1,7 @@
 package kr.co.pennyway.api.apis.socket.usecase;
 
+import kr.co.pennyway.api.apis.socket.service.ChatServerSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
-import kr.co.pennyway.infra.client.coordinator.CoordinatorService;
-import kr.co.pennyway.infra.client.coordinator.WebSocket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -10,11 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 @UseCase
 @RequiredArgsConstructor
 public class SocketUseCase {
-    private final CoordinatorService defaultCoordinatorService;
+    private final ChatServerSearchService chatServerSearchService;
 
     public String getChatServerUrl() {
-        WebSocket.ChatServerUrl response = defaultCoordinatorService.readChatServerUrl(null, null);
-
-        return response.url();
+        return chatServerSearchService.getChatServerUrl();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/socket/usecase/SocketUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/socket/usecase/SocketUseCase.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.api.apis.socket.usecase;
+
+import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.infra.client.coordinator.CoordinatorService;
+import kr.co.pennyway.infra.client.coordinator.WebSocket;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class SocketUseCase {
+    private final CoordinatorService defaultCoordinatorService;
+
+    public String getChatServerUrl() {
+        WebSocket.ChatServerUrl response = defaultCoordinatorService.readChatServerUrl(null, null);
+
+        return response.url();
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/InfraConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/InfraConfig.java
@@ -17,7 +17,8 @@ import org.springframework.context.annotation.Configuration;
         KakaoOidcProperties.class
 })
 @EnablePennywayInfraConfig({
-        PennywayInfraConfigGroup.FCM
+        PennywayInfraConfigGroup.FCM,
+        PennywayInfraConfigGroup.DistributedCoordinationConfig
 })
 public class InfraConfig {
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/SwaggerConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/SwaggerConfig.java
@@ -102,6 +102,17 @@ public class SwaggerConfig {
     }
 
     @Bean
+    public GroupedOpenApi socketApi() {
+        String[] targets = {"kr.co.pennyway.api.apis.socket"};
+
+        return GroupedOpenApi.builder()
+                .packagesToScan(targets)
+                .group("서비스 탐색 서비스")
+                .addOperationCustomizer(customizer())
+                .build();
+    }
+
+    @Bean
     public GroupedOpenApi backOfficeApi() {
         String[] targets = {"kr.co.pennyway.api.apis.question"};
 

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/coordinator/CoordinatorService.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/coordinator/CoordinatorService.java
@@ -1,0 +1,13 @@
+package kr.co.pennyway.infra.client.coordinator;
+
+import java.util.Map;
+
+public interface CoordinatorService {
+    /**
+     * 채팅 서버에 연결하려는 클라이언트에게 유효한 채팅 서버의 URL을 반환합니다.
+     * 이 메서드는 다양한 방식으로 구현될 수 있습니다.
+     * 예를 들어, 단일 채팅 서버 환경에서는 고정된 채팅 서버 URL을 반환할 수 있습니다.
+     * 분산 채팅 서버 환경이라면, 분산 코디네이션과 같은 서비스를 통해 사용자의 지리적 위치, 채팅 서버의 부하 상태 등을 고려하여 적절한 채팅 서버 URL을 반환할 수 있습니다.
+     */
+    WebSocket.ChatServerUrl readChatServerUrl(Map<String, String> headers, Object payload);
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/coordinator/DefaultCoordinatorService.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/coordinator/DefaultCoordinatorService.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.infra.client.coordinator;
+
+import java.util.Map;
+
+/**
+ * 이 클래스는 단일 채팅 서버 환경에서 사용할 수 있는 기본적인 {@link CoordinatorService} 구현체입니다.
+ * 미리 정의된 채팅 서버 URL을 반환합니다.
+ */
+public class DefaultCoordinatorService implements CoordinatorService {
+    private final String chatServerUrl;
+
+    public DefaultCoordinatorService(String chatServerUrl) {
+        this.chatServerUrl = chatServerUrl;
+    }
+
+    @Override
+    public WebSocket.ChatServerUrl readChatServerUrl(Map<String, String> headers, Object payload) {
+        return WebSocket.ChatServerUrl.of(chatServerUrl);
+    }
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/coordinator/WebSocket.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/coordinator/WebSocket.java
@@ -7,5 +7,9 @@ public final class WebSocket {
         public ChatServerUrl {
             Objects.requireNonNull(url, "url must not be null");
         }
+
+        public static ChatServerUrl of(String url) {
+            return new ChatServerUrl(url);
+        }
     }
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/coordinator/WebSocket.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/coordinator/WebSocket.java
@@ -1,0 +1,11 @@
+package kr.co.pennyway.infra.client.coordinator;
+
+import java.util.Objects;
+
+public final class WebSocket {
+    public record ChatServerUrl(String url) {
+        public ChatServerUrl {
+            Objects.requireNonNull(url, "url must not be null");
+        }
+    }
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/importer/PennywayInfraConfigGroup.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/importer/PennywayInfraConfigGroup.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.infra.common.importer;
 
+import kr.co.pennyway.infra.config.DistributedCoordinationConfig;
 import kr.co.pennyway.infra.config.FcmConfig;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -7,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum PennywayInfraConfigGroup {
-    FCM(FcmConfig.class);
+    FCM(FcmConfig.class),
+    DistributedCoordinationConfig(DistributedCoordinationConfig.class);
 
     private final Class<? extends PennywayInfraConfig> configClass;
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/DistributedCoordinationConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/DistributedCoordinationConfig.java
@@ -1,6 +1,20 @@
 package kr.co.pennyway.infra.config;
 
+import kr.co.pennyway.infra.client.coordinator.CoordinatorService;
+import kr.co.pennyway.infra.client.coordinator.DefaultCoordinatorService;
 import kr.co.pennyway.infra.common.importer.PennywayInfraConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 
 public class DistributedCoordinationConfig implements PennywayInfraConfig {
+    private final String chatServerUrl;
+
+    public DistributedCoordinationConfig(@Value("${distributed-coordination.chat-server.url}") String chatServerUrl) {
+        this.chatServerUrl = chatServerUrl;
+    }
+
+    @Bean
+    public CoordinatorService defaultCoordinatorService() {
+        return new DefaultCoordinatorService(chatServerUrl);
+    }
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/DistributedCoordinationConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/DistributedCoordinationConfig.java
@@ -1,0 +1,6 @@
+package kr.co.pennyway.infra.config;
+
+import kr.co.pennyway.infra.common.importer.PennywayInfraConfig;
+
+public class DistributedCoordinationConfig implements PennywayInfraConfig {
+}

--- a/pennyway-infra/src/main/resources/application-infra.yml
+++ b/pennyway-infra/src/main/resources/application-infra.yml
@@ -61,6 +61,10 @@ oauth2:
         jwks-uri: ${APPLE_JWKS_URI:http://localhost}
         secret: ${APPLE_CLIENT_SECRET:pennyway-jayang-was}
 
+distributed-coordination:
+  chat-server:
+    url: ${CHAT_SERVER_URL:ws://localhost:8000/chat}
+
 ---
 spring:
   config:


### PR DESCRIPTION
## 작업 이유

<div align="center">
   <img src="https://github.com/user-attachments/assets/49427472-f4b2-4af4-bf05-0b91f3efba4e" width="500px"/>
</div>

채팅 서버와 Socket 연결을 위해, Client는 1차적으로 클라이언트의 `물리적 위치(geographical location)`와 `서버의 용량(capacity)`을 기반으로 최적의 채팅 서버 url을 알아야 합니다.  
이번 작업은 이러한 기능을 고려하여 설계되었습니다.  

<br/>

## 작업 사항

<div align="center">
   <img src="https://github.com/user-attachments/assets/7cb680bd-17e8-41e2-b916-f916947d7aa8" width="500px"/>
</div>

초기 설계안이라 현재 클래스명과 다소 차이가 있습니다.  

우선 위 설계는 한 가지 가정을 두고 시작합니다.  
- 채팅 서버는 언제든지 유연하게 scale-out 될 수 있다.
- API 서버는 이 채팅 서버 중, 클라이언트에게 가장 최적의 채팅 서버 url을 반환해주어야 한다.

이를 완벽하게 구현하기 위해서는 Apache Zookeeper와 같은 분산 코디네이션 서비스(Distributed Coordination Service)를 사용하겠지만, 당연히 저희는 사용하지 않습니다! 😆

단, 수요가 있을 때, 언제든지 빠르게 적용하기 위해 모듈화의 이점을 극대화하여 위와 같이 설계하게 되었습니다.  

**📝 API Spec**
- 요청: `GET /v2/socket/chat`
   - 해당 요청은 API 서버 인증 권한 검사를 수행합니다.
- 응답
   ```json
   {
       "code": "2000",
       "data": {
           "chatServerUrl": ""
       }
   }
   ```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- URL 명이 조금 구리네요. 아름다운 이름이 없을까..


<br/>

## 발견한 이슈
![image](https://github.com/user-attachments/assets/b8e1b623-0e1d-4be1-bcfc-420dd59b0821)
ChatServerSearchService를 확인하면, CoordinatorService 빈에 주입이 제대로 이루어지지 않고 있다고 나올 텐데, 이상은 없습니다.

infra 모듈의 Config 파일에 `@Configuration`을 사용하지 않고, 아래와 같이 의존성을 api 모듈이 제어하게 만듦으로써, IDE이 빈을 탐색하지 못할 뿐.  
실제 컴파일 타입에선 문제 없이 동작합니다. ^^

```java
@EnablePennywayInfraConfig({
        PennywayInfraConfigGroup.FCM,
        PennywayInfraConfigGroup.DistributedCoordinationConfig
})
public class InfraConfig {
}
```

