### PR TITLE
Ignore: ✨ RabbitMQ 및 Socket 서버 연결 설정

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/InfraConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/InfraConfig.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Configuration;
 })
 @EnablePennywayInfraConfig({
         PennywayInfraConfigGroup.FCM,
-        PennywayInfraConfigGroup.DistributedCoordinationConfig
+        PennywayInfraConfigGroup.DISTRIBUTED_COORDINATION_CONFIG
 })
 public class InfraConfig {
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/CorsConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/security/CorsConfig.java
@@ -15,11 +15,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CorsConfig {
     private final ServerProperties serverProperties;
-    
+
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(serverProperties.getLocal(), serverProperties.getDev()));
+        configuration.setAllowedOriginPatterns(List.of(serverProperties.getLocal(), serverProperties.getDev()));
         configuration.setAllowedMethods(List.of("GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of(HttpHeaders.AUTHORIZATION, HttpHeaders.SET_COOKIE));

--- a/pennyway-infra/build.gradle
+++ b/pennyway-infra/build.gradle
@@ -33,4 +33,12 @@ dependencies {
     /* firebase */
     implementation 'com.google.firebase:firebase-admin:9.2.0'
 
+    /* Web Socket */
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    /* RabbitMQ */
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    /* TSID Generator */
+    implementation 'com.github.f4b6a3:tsid-creator:5.2.6'
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/broker/MessageBrokerAdapter.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/broker/MessageBrokerAdapter.java
@@ -1,0 +1,41 @@
+package kr.co.pennyway.infra.client.broker;
+
+import org.springframework.amqp.rabbit.core.RabbitMessagingTemplate;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.core.MessagePostProcessor;
+
+import java.util.Map;
+
+public class MessageBrokerAdapter {
+    private final RabbitMessagingTemplate rabbitMessagingTemplate;
+
+    public MessageBrokerAdapter(RabbitMessagingTemplate rabbitMessagingTemplate) {
+        this.rabbitMessagingTemplate = rabbitMessagingTemplate;
+    }
+
+    public void send(String exchange, String routingKey, Message<?> message) throws MessagingException {
+        rabbitMessagingTemplate.send(exchange, routingKey, message);
+    }
+
+    public void convertAndSend(String exchange, String routingKey, Object payload) throws MessagingException {
+        rabbitMessagingTemplate.convertAndSend(exchange, routingKey, payload);
+    }
+
+    public void convertAndSend(String exchange, String routingKey, Object payload,
+                               @Nullable Map<String, Object> headers) throws MessagingException {
+        rabbitMessagingTemplate.convertAndSend(exchange, routingKey, payload, headers);
+    }
+
+    public void convertAndSend(String exchange, String routingKey, Object payload,
+                               @Nullable MessagePostProcessor postProcessor) throws MessagingException {
+        rabbitMessagingTemplate.convertAndSend(exchange, routingKey, payload, postProcessor);
+    }
+
+    public void convertAndSend(String exchange, String routingKey, Object payload,
+                               @Nullable Map<String, Object> headers, @Nullable MessagePostProcessor postProcessor)
+            throws MessagingException {
+        rabbitMessagingTemplate.convertAndSend(exchange, routingKey, payload, headers, postProcessor);
+    }
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/importer/PennywayInfraConfigGroup.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/importer/PennywayInfraConfigGroup.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PennywayInfraConfigGroup {
     FCM(FcmConfig.class),
-    DistributedCoordinationConfig(DistributedCoordinationConfig.class),
+    DISTRIBUTED_COORDINATION_CONFIG(DistributedCoordinationConfig.class),
     MESSAGE_BROKER_CONFIG(MessageBrokerConfig.class);
 
     private final Class<? extends PennywayInfraConfig> configClass;

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/importer/PennywayInfraConfigGroup.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/importer/PennywayInfraConfigGroup.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.infra.common.importer;
 
 import kr.co.pennyway.infra.config.DistributedCoordinationConfig;
 import kr.co.pennyway.infra.config.FcmConfig;
+import kr.co.pennyway.infra.config.MessageBrokerConfig;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PennywayInfraConfigGroup {
     FCM(FcmConfig.class),
-    DistributedCoordinationConfig(DistributedCoordinationConfig.class);
+    DistributedCoordinationConfig(DistributedCoordinationConfig.class),
+    MESSAGE_BROKER_CONFIG(MessageBrokerConfig.class);
 
     private final Class<? extends PennywayInfraConfig> configClass;
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/ChatExchangeProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/ChatExchangeProperties.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Getter
 @RequiredArgsConstructor
 @ConfigurationProperties(prefix = "pennyway.rabbitmq.chat")
-public class RabbitMQProperties {
+public class ChatExchangeProperties {
     private final String exchange;
     private final String queue;
     private final String routingKey;

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/RabbitMQProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/RabbitMQProperties.java
@@ -1,0 +1,14 @@
+package kr.co.pennyway.infra.common.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "pennyway.rabbitmq.chat")
+public class RabbitMQProperties {
+    private final String exchange;
+    private final String queue;
+    private final String routing;
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/RabbitMQProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/RabbitMQProperties.java
@@ -10,5 +10,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class RabbitMQProperties {
     private final String exchange;
     private final String queue;
-    private final String routing;
+    private final String routingKey;
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/RabbitMqProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/RabbitMqProperties.java
@@ -13,4 +13,15 @@ public class RabbitMqProperties {
     private final String username;
     private final String password;
     private final String virtualHost;
+
+    @Override
+    public String toString() {
+        return "RabbitMqProperties{" +
+                "host='" + host + '\'' +
+                ", port=" + port +
+                ", username='" + username + '\'' +
+                ", password='" + password + '\'' +
+                ", virtualHost='" + virtualHost + '\'' +
+                '}';
+    }
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/RabbitMqProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/RabbitMqProperties.java
@@ -1,0 +1,16 @@
+package kr.co.pennyway.infra.common.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "spring.rabbitmq")
+public class RabbitMqProperties {
+    private final String host;
+    private final int port;
+    private final String username;
+    private final String password;
+    private final String virtualHost;
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MessageBrokerConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MessageBrokerConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import kr.co.pennyway.infra.client.broker.MessageBrokerAdapter;
 import kr.co.pennyway.infra.common.importer.PennywayInfraConfig;
 import kr.co.pennyway.infra.common.properties.RabbitMQProperties;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitMessagingTemplate;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
@@ -61,5 +63,15 @@ public class MessageBrokerConfig implements PennywayInfraConfig {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
         rabbitTemplate.setMessageConverter(messageConverter);
         return rabbitTemplate;
+    }
+
+    @Bean
+    public RabbitMessagingTemplate rabbitMessagingTemplate(RabbitTemplate rabbitTemplate) {
+        return new RabbitMessagingTemplate(rabbitTemplate);
+    }
+
+    @Bean
+    public MessageBrokerAdapter messageBrokerAdapter(RabbitMessagingTemplate rabbitMessagingTemplate) {
+        return new MessageBrokerAdapter(rabbitMessagingTemplate);
     }
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MessageBrokerConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MessageBrokerConfig.java
@@ -19,10 +19,12 @@ import org.springframework.amqp.rabbit.core.RabbitMessagingTemplate;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
 @EnableRabbit
 @RequiredArgsConstructor
+@EnableConfigurationProperties(RabbitMQProperties.class)
 public class MessageBrokerConfig implements PennywayInfraConfig {
     private final RabbitMQProperties rabbitMQProperties;
 
@@ -59,14 +61,14 @@ public class MessageBrokerConfig implements PennywayInfraConfig {
     }
 
     @Bean
-    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
+    public RabbitTemplate customRabbitTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
         rabbitTemplate.setMessageConverter(messageConverter);
         return rabbitTemplate;
     }
 
     @Bean
-    public RabbitMessagingTemplate rabbitMessagingTemplate(RabbitTemplate rabbitTemplate) {
+    public RabbitMessagingTemplate customRabbitMessagingTemplate(RabbitTemplate rabbitTemplate) {
         return new RabbitMessagingTemplate(rabbitTemplate);
     }
 

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MessageBrokerConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MessageBrokerConfig.java
@@ -1,0 +1,65 @@
+package kr.co.pennyway.infra.config;
+
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import kr.co.pennyway.infra.common.importer.PennywayInfraConfig;
+import kr.co.pennyway.infra.common.properties.RabbitMQProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+
+@EnableRabbit
+@RequiredArgsConstructor
+public class MessageBrokerConfig implements PennywayInfraConfig {
+    private final RabbitMQProperties rabbitMQProperties;
+
+    @Bean
+    public Queue chatQueue() {
+        return new Queue(rabbitMQProperties.getQueue(), true);
+    }
+
+    @Bean
+    public TopicExchange chatExchange() {
+        return new TopicExchange(rabbitMQProperties.getExchange());
+    }
+
+    @Bean
+    public Binding chatBinding(Queue chatQueue, TopicExchange chatExchange) {
+        return BindingBuilder
+                .bind(chatQueue)
+                .to(chatExchange)
+                .with(rabbitMQProperties.getRoutingKey());
+    }
+
+    @Bean
+    public Module dateTimeModule() {
+        return new JavaTimeModule();
+    }
+
+    @Bean
+    public MessageConverter messageConverter(Module dateTimeModule) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
+        objectMapper.registerModule(dateTimeModule);
+
+        return new Jackson2JsonMessageConverter(objectMapper);
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(messageConverter);
+        return rabbitTemplate;
+    }
+}

--- a/pennyway-infra/src/main/resources/application-infra.yml
+++ b/pennyway-infra/src/main/resources/application-infra.yml
@@ -58,7 +58,7 @@ pennyway:
     chat:
       queue: ${RABBITMQ_CHAT_QUEUE:chat.queue}
       exchange: ${RABBITMQ_CHAT_EXCHANGE:chat.exchange}
-      routing: ${RABBITMQ_CHAT_ROUTING:chat.room.*}
+      routing-key: ${RABBITMQ_CHAT_ROUTING:chat.room.*}
 
 oauth2:
   client:

--- a/pennyway-infra/src/main/resources/application-infra.yml
+++ b/pennyway-infra/src/main/resources/application-infra.yml
@@ -28,6 +28,13 @@ spring:
       cloudfront:
         domain: ${AWS_CLOUDFRONT_DOMAIN:https://cdn.cloudfront.net}
 
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USERNAME:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+    virtual-host: ${RABBITMQ_VIRTUAL_HOST:/}
+
 app:
   question-address: ${ADMIN_ADDRESS:team.collabu@gmail.com}
   mail:
@@ -46,6 +53,12 @@ pennyway:
     domain:
       local: ${PENNYWAY_DOMAIN_LOCAL:127.0.0.1:8080}
       dev: ${PENNYWAY_DOMAIN_DEV:127.0.0.1:8080}
+
+  rabbitmq:
+    chat:
+      queue: ${RABBITMQ_CHAT_QUEUE:chat.queue}
+      exchange: ${RABBITMQ_CHAT_EXCHANGE:chat.exchange}
+      routing: ${RABBITMQ_CHAT_ROUTING:chat.room.*}
 
 oauth2:
   client:

--- a/pennyway-socket/.gitignore
+++ b/pennyway-socket/.gitignore
@@ -40,3 +40,7 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### Test ###
+src/main/resources/compose.yml
+src/main/resources/static/

--- a/pennyway-socket/build.gradle
+++ b/pennyway-socket/build.gradle
@@ -16,4 +16,7 @@ dependencies {
     implementation project(':pennyway-common')
     implementation project(':pennyway-domain')
     implementation project(':pennyway-infra')
+
+    /* Web Socket */
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }

--- a/pennyway-socket/build.gradle
+++ b/pennyway-socket/build.gradle
@@ -19,4 +19,7 @@ dependencies {
 
     /* Web Socket */
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    /* Reactor Netty */
+    implementation "org.springframework.boot:spring-boot-starter-reactor-netty"
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/properties/ChatServerProperties.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/properties/ChatServerProperties.java
@@ -12,4 +12,12 @@ import java.util.List;
 public class ChatServerProperties {
     private final String endpoint;
     private final List<String> allowedOriginPatterns;
+
+    @Override
+    public String toString() {
+        return "ChatServerProperties{" +
+                "endpoint='" + endpoint + '\'' +
+                ", allowedOriginPatterns=" + allowedOriginPatterns +
+                '}';
+    }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/properties/ChatServerProperties.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/properties/ChatServerProperties.java
@@ -1,0 +1,15 @@
+package kr.co.pennyway.socket.common.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "pennyway.socket.chat")
+public class ChatServerProperties {
+    private final String endpoint;
+    private final List<String> allowedOriginPatterns;
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/properties/MessageBrokerProperties.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/properties/MessageBrokerProperties.java
@@ -1,0 +1,17 @@
+package kr.co.pennyway.socket.common.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "message-broker.external")
+public class MessageBrokerProperties {
+    private final String host;
+    private final int port;
+    private final String systemId;
+    private final String systemPassword;
+    private final String userPrefix;
+    private final String publishExchange;
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/properties/MessageBrokerProperties.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/properties/MessageBrokerProperties.java
@@ -12,6 +12,22 @@ public class MessageBrokerProperties {
     private final int port;
     private final String systemId;
     private final String systemPassword;
+    private final String clientId;
+    private final String clientPassword;
     private final String userPrefix;
     private final String publishExchange;
+
+    @Override
+    public String toString() {
+        return "MessageBrokerProperties{" +
+                "host='" + host + '\'' +
+                ", port=" + port +
+                ", systemId='" + systemId + '\'' +
+                ", systemPassword='" + systemPassword + '\'' +
+                ", clientId='" + clientId + '\'' +
+                ", clientPassword='" + clientPassword + '\'' +
+                ", userPrefix='" + userPrefix + '\'' +
+                ", publishExchange='" + publishExchange + '\'' +
+                '}';
+    }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/InfraConfig.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/InfraConfig.java
@@ -1,0 +1,12 @@
+package kr.co.pennyway.socket.config;
+
+import kr.co.pennyway.infra.common.importer.EnablePennywayInfraConfig;
+import kr.co.pennyway.infra.common.importer.PennywayInfraConfigGroup;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnablePennywayInfraConfig({
+        PennywayInfraConfigGroup.MESSAGE_BROKER_CONFIG
+})
+public class InfraConfig {
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/WebSocketMessageBrokerConfig.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/WebSocketMessageBrokerConfig.java
@@ -33,9 +33,12 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
         config.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue")
+                .setAutoStartup(true)
                 .setTcpClient(createTcpClient())
                 .setSystemLogin(messageBrokerProperties.getSystemId())
                 .setSystemPasscode(messageBrokerProperties.getSystemPassword())
+                .setClientLogin(messageBrokerProperties.getClientId())
+                .setClientPasscode(messageBrokerProperties.getClientPassword())
                 .setRelayHost(messageBrokerProperties.getHost())
                 .setRelayPort(messageBrokerProperties.getPort());
 

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/WebSocketMessageBrokerConfig.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/WebSocketMessageBrokerConfig.java
@@ -1,0 +1,41 @@
+package kr.co.pennyway.socket.config;
+
+import kr.co.pennyway.socket.common.properties.ChatServerProperties;
+import kr.co.pennyway.socket.common.properties.MessageBrokerProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Slf4j
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfigurer {
+    private final ChatServerProperties chatServerProperties;
+    private final MessageBrokerProperties messageBrokerProperties;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint(chatServerProperties.getEndpoint())
+                .setAllowedOriginPatterns(chatServerProperties.getAllowedOriginPatterns().toArray(new String[0]));
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue")
+                .setAutoStartup(true)
+                .setRelayHost(messageBrokerProperties.getHost())
+                .setRelayPort(messageBrokerProperties.getPort())
+                .setSystemLogin(messageBrokerProperties.getSystemId())
+                .setSystemPasscode(messageBrokerProperties.getSystemPassword());
+
+        config.setUserDestinationPrefix(messageBrokerProperties.getUserPrefix());
+        config.setPathMatcher(new AntPathMatcher("."));
+        config.setApplicationDestinationPrefixes(messageBrokerProperties.getPublishExchange());
+    }
+}

--- a/pennyway-socket/src/main/resources/application.yml
+++ b/pennyway-socket/src/main/resources/application.yml
@@ -4,6 +4,9 @@ spring:
       local: common, domain, infra
       dev: common, domain, infra
 
+server:
+  port: ${SOCKET_SERVER_PORT:8081}
+
 pennyway:
   socket:
     chat:

--- a/pennyway-socket/src/main/resources/application.yml
+++ b/pennyway-socket/src/main/resources/application.yml
@@ -19,6 +19,8 @@ message-broker:
     port: ${MESSAGE_BROKER_PORT:5672}
     system-id: ${MESSAGE_BROKER_SYSTEM_ID:guest}
     system-password: ${MESSAGE_BROKER_SYSTEM_PASSWORD:guest}
+    client-id: ${MESSAGE_BROKER_CLIENT_ID:guest}
+    client-password: ${MESSAGE_BROKER_CLIENT_PASSWORD:guest}
     user-prefix: ${MESSAGE_BROKER_USER_PREFIX:/usr}
     publish-exchange: ${MESSAGE_BROKER_PUBLISH_EXCHANGE:/topic}
 

--- a/pennyway-socket/src/main/resources/application.yml
+++ b/pennyway-socket/src/main/resources/application.yml
@@ -4,6 +4,21 @@ spring:
       local: common, domain, infra
       dev: common, domain, infra
 
+pennyway:
+  socket:
+    chat:
+      endpoint: ${SOCKET_CHAT_ENDPOINT:/ws}
+      allowded-origin-patterns: ${ALLOWED_ORIGIN_PATTERNS:http://localhost:3000}
+
+message-broker:
+  external:
+    host: ${MESSAGE_BROKER_HOST:localhost}
+    port: ${MESSAGE_BROKER_PORT:5672}
+    system-id: ${MESSAGE_BROKER_SYSTEM_ID:guest}
+    system-password: ${MESSAGE_BROKER_SYSTEM_PASSWORD:guest}
+    user-prefix: ${MESSAGE_BROKER_USER_PREFIX:/user}
+    publish-exchange: ${MESSAGE_BROKER_PUBLISH_EXCHANGE:/topic}
+
 ---
 spring:
   config:

--- a/pennyway-socket/src/main/resources/application.yml
+++ b/pennyway-socket/src/main/resources/application.yml
@@ -8,7 +8,7 @@ pennyway:
   socket:
     chat:
       endpoint: ${SOCKET_CHAT_ENDPOINT:/ws}
-      allowded-origin-patterns: ${ALLOWED_ORIGIN_PATTERNS:http://localhost:3000}
+      allowed-origin-patterns: ${ALLOWED_ORIGIN_PATTERNS:*}
 
 message-broker:
   external:
@@ -16,7 +16,7 @@ message-broker:
     port: ${MESSAGE_BROKER_PORT:5672}
     system-id: ${MESSAGE_BROKER_SYSTEM_ID:guest}
     system-password: ${MESSAGE_BROKER_SYSTEM_PASSWORD:guest}
-    user-prefix: ${MESSAGE_BROKER_USER_PREFIX:/user}
+    user-prefix: ${MESSAGE_BROKER_USER_PREFIX:/usr}
     publish-exchange: ${MESSAGE_BROKER_PUBLISH_EXCHANGE:/topic}
 
 ---


### PR DESCRIPTION
## 작업 이유
- WebSocket Server Stomp 및 External Broker 연결 설정
- Message Queue 중앙 관리를 위한 RabbitMQ 연결 설정

<br/>

## 작업 사항
![image](https://github.com/user-attachments/assets/83d62225-f1b7-42da-9388-db5dfdd7ffeb)

- RabbitMQ와 Socket Server 간에 AMQP(port: 5672) 연결 설정 완료
- Client 측에서 웹 소켓 연결 시, STOMP(port: 61613) 연결 설정 완료 

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
![image](https://github.com/user-attachments/assets/5ba7cb6a-964c-48d7-96da-8c9304680848)

- 테스트를 위한 html과 js를 구현해두었습니다. 코드는 secret 채널에 압축 파일로 올려둘테니, `pennyway-socket` 모듈 하위의 `resource`에 넣어주고 `docker-compose up -d` 실행 후, html 열어보면 됩니다. (이슈 하나 있는데, 아래 적음)
- 추가된 속성이..매우 많습니다.

<br/>

## 발견한 이슈
- 이유를 모르겠으나, IntelliJ로 실행하면 Socket Server가 RabbitMQ와 연결은 하는데 ConnectFactory 생성과 Exchange 등록을 정상적으로 수행하질 않음. (??)
- 이미 혼자 공부하면서 똑같이 설정했을 때 모두 동작했고, 로컬에서 실행하면 여전히 잘 되기 때문에 이유를 못 찾는 중.

```
PENNYWAY_PROXY_IP=*
CHAT_SERVER_URL=ws://localhost:8081/chat
SOCKET_SERVER_PORT=8081
```

- 만약, 테스트를 해보고 싶다면, 위와 같이 환경 변수 수정 → `socket` 컨테이너 내리고 인텔리제이로 실행하시면 됩니다.
