### PR TITLE
Ignore: ✨ WebSocket Inbound & Exception Interceptor

### DIFF
--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/dto/ServerSideMessage.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/dto/ServerSideMessage.java
@@ -1,0 +1,23 @@
+package kr.co.pennyway.socket.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+public record ServerSideMessage(
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String code,
+        String reason
+) {
+    public ServerSideMessage {
+        Objects.requireNonNull(reason, "reason must not be null");
+    }
+
+    public static ServerSideMessage of(String reason) {
+        return new ServerSideMessage(null, reason);
+    }
+
+    public static ServerSideMessage of(String code, String reason) {
+        return new ServerSideMessage(code, reason);
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/InterceptorErrorCode.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/InterceptorErrorCode.java
@@ -1,0 +1,53 @@
+package kr.co.pennyway.socket.common.exception;
+
+import kr.co.pennyway.common.exception.BaseErrorCode;
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.ReasonCode;
+import kr.co.pennyway.common.exception.StatusCode;
+import org.springframework.messaging.simp.stomp.StompCommand;
+
+public enum InterceptorErrorCode implements BaseErrorCode {
+    // 400
+    INVALID_DESTINATION(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "유효하지 않은 목적지입니다", StompCommand.SEND, StompCommand.SUBSCRIBE, StompCommand.UNSUBSCRIBE),
+
+    // 403
+    UNAUTHORIZED_TO_SUBSCRIBE(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "해당 주제에 대한 구독 권한이 없습니다", StompCommand.SUBSCRIBE, StompCommand.UNSUBSCRIBE),
+    ;
+
+    private final StatusCode statusCode;
+    private final ReasonCode reasonCode;
+    private final String message;
+    private final StompCommand[] commands;
+
+    InterceptorErrorCode(StatusCode statusCode, ReasonCode reasonCode, String message, StompCommand... commands) {
+        this.statusCode = statusCode;
+        this.reasonCode = reasonCode;
+        this.message = message;
+        this.commands = commands;
+    }
+
+    @Override
+    public CausedBy causedBy() {
+        return CausedBy.of(statusCode, reasonCode);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldError {
+        return message;
+    }
+
+    /**
+     * StompCommand가 ErrorCode에서 지원하는 명령어인지 확인하는 편의용 메서드
+     *
+     * @param command {@link StompCommand}
+     * @return 해당 ErrorCode에서 지원하는 명령어라면 true, 아니라면 false
+     */
+    public boolean isSupportCommand(StompCommand command) {
+        for (StompCommand c : commands) {
+            if (c.equals(command)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/InterceptorErrorException.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/InterceptorErrorException.java
@@ -1,0 +1,21 @@
+package kr.co.pennyway.socket.common.exception;
+
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.GlobalErrorException;
+
+public class InterceptorErrorException extends GlobalErrorException {
+    private final InterceptorErrorCode errorCode;
+
+    public InterceptorErrorException(InterceptorErrorCode baseErrorCode) {
+        super(baseErrorCode);
+        this.errorCode = baseErrorCode;
+    }
+
+    public CausedBy causedBy() {
+        return errorCode.causedBy();
+    }
+
+    public InterceptorErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/StompCommandHandlerFactory.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/StompCommandHandlerFactory.java
@@ -1,0 +1,36 @@
+package kr.co.pennyway.socket.common.interceptor;
+
+import kr.co.pennyway.socket.common.interceptor.marker.StompCommandHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompCommandHandlerFactory {
+    private final Map<StompCommand, List<StompCommandHandler>> handlers = new EnumMap<>(StompCommand.class);
+
+    @Autowired
+    public StompCommandHandlerFactory(List<StompCommandHandler> allHandlers) {
+        allHandlers.forEach(this::registerHandler);
+        log.info("StompCommandHandlerFactory: handlers={}", handlers);
+    }
+
+    private void registerHandler(StompCommandHandler handler) {
+        Arrays.stream(StompCommand.values())
+                .filter(handler::isSupport)
+                .forEach(command -> {
+                    handlers.computeIfAbsent(command, k -> new ArrayList<>()).add(handler);
+                    log.info("Registered handler {} for command {}", handler.getClass().getSimpleName(), command);
+                });
+    }
+
+    public List<StompCommandHandler> getHandlers(StompCommand command) {
+        return handlers.getOrDefault(command, List.of());
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/StompExceptionInterceptor.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/StompExceptionInterceptor.java
@@ -1,0 +1,34 @@
+package kr.co.pennyway.socket.common.interceptor;
+
+import kr.co.pennyway.socket.common.interceptor.marker.StompExceptionHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompExceptionInterceptor extends StompSubProtocolErrorHandler {
+    private final List<StompExceptionHandler> interceptors;
+
+    @Override
+    @Nullable
+    public Message<byte[]> handleClientMessageProcessingError(@Nullable Message<byte[]> clientMessage, Throwable ex) {
+        Throwable cause = ex.getCause();
+
+        for (StompExceptionHandler interceptor : interceptors) {
+            if (interceptor.canHandle(cause)) {
+                log.warn("STOMP client message processing throw({}) catch handler {}", cause.getMessage(), interceptor);
+                return interceptor.handle(clientMessage, cause);
+            }
+        }
+
+        log.error("STOMP client message processing error: {}", ex.getMessage());
+        return super.handleClientMessageProcessingError(clientMessage, ex);
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/StompInboundInterceptor.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/StompInboundInterceptor.java
@@ -1,0 +1,34 @@
+package kr.co.pennyway.socket.common.interceptor;
+
+import kr.co.pennyway.socket.common.interceptor.marker.StompCommandHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompInboundInterceptor implements ChannelInterceptor {
+    private final StompCommandHandlerFactory stompCommandHandlerFactory;
+
+    @Override
+    public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor != null && accessor.getCommand() != null) {
+            log.info("[StompInboundInterceptor] command={}", accessor.getCommand());
+
+            for (StompCommandHandler handler : stompCommandHandlerFactory.getHandlers(accessor.getCommand())) {
+                handler.handle(message, accessor);
+            }
+        }
+
+        return message;
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/handler/AbstractStompExceptionHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/handler/AbstractStompExceptionHandler.java
@@ -1,0 +1,68 @@
+package kr.co.pennyway.socket.common.interceptor.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.socket.common.dto.ServerSideMessage;
+import kr.co.pennyway.socket.common.interceptor.marker.StompExceptionHandler;
+import kr.co.pennyway.socket.common.util.StompMessageUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+/**
+ * STOMP 예외 처리를 위한 추상 기본 클래스.
+ * 이 클래스는 공통적인 예외 처리 로직을 제공하며, 구체적인 예외 처리 동작은 하위 클래스에서 구현합니다.
+ */
+@Slf4j
+public abstract class AbstractStompExceptionHandler implements StompExceptionHandler {
+    protected final ObjectMapper objectMapper;
+
+    public AbstractStompExceptionHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Message<byte[]> handle(Message<byte[]> clientMessage, Throwable cause) {
+        if (isNullReturnRequired(clientMessage)) {
+            return null;
+        }
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(getStompCommand());
+        accessor.setLeaveMutable(true);
+        extractClientHeaderAccessor(clientMessage, accessor);
+        ServerSideMessage payload = getServerSideMessage(cause);
+
+        if (payload != null) {
+            accessor.setMessage(payload.code());
+        }
+
+        accessor.setImmutable();
+        return StompMessageUtil.createMessage(accessor, payload, objectMapper);
+    }
+
+    /**
+     * 클라이언트 메시지의 유효성을 검사합니다.
+     * 기본 구현은 항상 false를 반환합니다. 필요한 경우 하위 클래스에서 재정의할 수 있습니다.
+     *
+     * @param clientMessage 클라이언트로부터 받은 원본 메시지
+     * @return null을 반환해야 한다면 true, 그렇지 않다면 false
+     */
+    protected boolean isNullReturnRequired(Message<byte[]> clientMessage) {
+        return false;
+    }
+
+    /**
+     * 이 핸들러가 사용할 STOMP 명령을 반환합니다.
+     *
+     * @return STOMP 명령
+     */
+    protected abstract StompCommand getStompCommand();
+
+    /**
+     * 주어진 예외를 기반으로 {@link ServerSideMessage}를 생성합니다.
+     *
+     * @param cause 발생한 예외
+     * @return 생성된 ServerSideMessage
+     */
+    protected abstract ServerSideMessage getServerSideMessage(Throwable cause);
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/marker/ConnectCommandHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/marker/ConnectCommandHandler.java
@@ -1,0 +1,4 @@
+package kr.co.pennyway.socket.common.interceptor.marker;
+
+public interface ConnectCommandHandler extends StompCommandHandler {
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/marker/StompCommandHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/marker/StompCommandHandler.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.socket.common.interceptor.marker;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+/**
+ * STOMP 명령어 핸들러 인터페이스
+ */
+public interface StompCommandHandler {
+    /**
+     * 해당 핸들러가 지원하는 명령어인지 확인한다.
+     *
+     * @param command {@link StompCommand} 명령어
+     */
+    boolean isSupport(StompCommand command);
+
+    void handle(Message<?> message, StompHeaderAccessor accessor);
+}
+

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/marker/StompExceptionHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/marker/StompExceptionHandler.java
@@ -1,0 +1,50 @@
+package kr.co.pennyway.socket.common.interceptor.marker;
+
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+
+/**
+ * STOMP 인터셉터에서 발생한 예외를 처리하기 위한 인터페이스
+ */
+public interface StompExceptionHandler {
+    /**
+     * 해당 예외를 처리할 수 있는지 여부를 반환하는 메서드
+     *
+     * @return true: 해당 예외를 처리할 수 있음, false: 해당 예외를 처리할 수 없음
+     */
+    boolean canHandle(Throwable cause);
+
+    /**
+     * 예외를 처리하는 메서드.
+     * WebSocket 프로토콜에 의해 ERROR 커맨드를 사용하면, client와의 연결을 반드시 끊어야 한다.
+     * 이를 원치 않는 경우, {@link StompCommand#ERROR}를 사용하여 Accessor를 설정해서는 안 된다.
+     *
+     * @param clientMessage {@link Message}: client로부터 받은 메시지
+     * @param cause         Throwable: 발생한 예외
+     * @return {@link Message}: client에게 보낼 최종 메시지
+     */
+    @Nullable
+    Message<byte[]> handle(@Nullable Message<byte[]> clientMessage, Throwable cause);
+
+    /**
+     * 클라이언트 메시지에서 필요한 헤더 정보를 추출하여 새로운 StompHeaderAccessor에 설정합니다.
+     * 기본적으로 receiptId를 추출합니다. 하위 클래스에서 필요에 따라 재정의할 수 있습니다.
+     *
+     * @param clientMessage 클라이언트로부터 받은 원본 메시지 (null일 수 있음)
+     * @param accessor      새로 생성된 StompHeaderAccessor
+     */
+    default void extractClientHeaderAccessor(Message<?> clientMessage, StompHeaderAccessor accessor) {
+        if (clientMessage != null) {
+            StompHeaderAccessor clientHeaderAccessor = MessageHeaderAccessor.getAccessor(clientMessage, StompHeaderAccessor.class);
+            if (clientHeaderAccessor != null) {
+                String receiptId = clientHeaderAccessor.getReceipt();
+                if (receiptId != null) {
+                    accessor.setReceiptId(receiptId);
+                }
+            }
+        }
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/marker/SubscribeCommandHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/marker/SubscribeCommandHandler.java
@@ -1,0 +1,4 @@
+package kr.co.pennyway.socket.common.interceptor.marker;
+
+public interface SubscribeCommandHandler extends StompCommandHandler {
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/authenticate/UserPrincipal.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/authenticate/UserPrincipal.java
@@ -1,0 +1,89 @@
+package kr.co.pennyway.socket.common.security.authenticate;
+
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.type.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+@Getter
+public class UserPrincipal implements Principal {
+    private final Long userId;
+    private String name;
+    private String username;
+    private Role role;
+    private boolean isChatNotify;
+    private LocalDateTime expiresAt;
+
+    @Builder
+    private UserPrincipal(Long userId, String name, String username, Role role, boolean isChatNotify, LocalDateTime expiresAt) {
+        this.userId = userId;
+        this.name = name;
+        this.username = username;
+        this.role = role;
+        this.isChatNotify = isChatNotify;
+        this.expiresAt = expiresAt;
+    }
+
+    public static UserPrincipal from(User user, LocalDateTime expiresAt) {
+        return UserPrincipal.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .username(user.getUsername())
+                .role(user.getRole())
+                .isChatNotify(user.getNotifySetting().isChatNotify())
+                .expiresAt(expiresAt)
+                .build();
+    }
+
+    public void updateExpiresAt(LocalDateTime expiresAt) {
+        if (expiresAt.isBefore(this.expiresAt)) {
+            throw new IllegalArgumentException("만료 시간을 줄일 수 없습니다.");
+        }
+
+        this.expiresAt = expiresAt;
+    }
+
+    // Principal이 getName으로 사용자를 식별하는 메서드로 구현되어 있음.
+    @Override
+    public String getName() {
+        return userId.toString();
+    }
+
+    // name 필드를 조회하기 위한 메서드
+    public String getDefaultName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = userId.hashCode() * 31;
+        return result + username.hashCode() * 31;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        UserPrincipal that = (UserPrincipal) obj;
+        return userId.equals(that.userId);
+    }
+
+    @Override
+    public String toString() {
+        return "UserPrincipal{" +
+                "userId=" + userId +
+                ", name='" + name + '\'' +
+                ", username='" + username + '\'' +
+                ", role=" + role + '\'' +
+                ", isChatNotify=" + isChatNotify + '\'' +
+                ", expiresAt=" + expiresAt +
+                '}';
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/jwt/AccessTokenClaim.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/jwt/AccessTokenClaim.java
@@ -1,0 +1,25 @@
+package kr.co.pennyway.socket.common.security.jwt;
+
+import kr.co.pennyway.infra.common.jwt.JwtClaims;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class AccessTokenClaim implements JwtClaims {
+    private final Map<String, ?> claims;
+
+    public static AccessTokenClaim of(Long userId, String role) {
+        Map<String, Object> claims = Map.of(
+                AccessTokenClaimKeys.USER_ID.getValue(), userId.toString(),
+                AccessTokenClaimKeys.ROLE.getValue(), role
+        );
+        return new AccessTokenClaim(claims);
+    }
+
+    @Override
+    public Map<String, ?> getClaims() {
+        return claims;
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/jwt/AccessTokenClaimKeys.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/jwt/AccessTokenClaimKeys.java
@@ -1,0 +1,16 @@
+package kr.co.pennyway.socket.common.security.jwt;
+
+public enum AccessTokenClaimKeys {
+    USER_ID("id"),
+    ROLE("role");
+
+    private final String value;
+
+    AccessTokenClaimKeys(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/jwt/AccessTokenProvider.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/jwt/AccessTokenProvider.java
@@ -16,7 +16,6 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.Date;
@@ -27,18 +26,15 @@ import static kr.co.pennyway.socket.common.security.jwt.AccessTokenClaimKeys.USE
 
 @Slf4j
 @Primary
-@Component("chatAccessTokenProvider")
+@Component
 public class AccessTokenProvider implements JwtProvider {
     private final SecretKey secretKey;
-    private final Duration tokenExpiration;
 
     public AccessTokenProvider(
-            @Value("${jwt.secret-key.access-token}") String jwtSecretKey,
-            @Value("${jwt.expiration-time.access-token}") Duration tokenExpiration
+            @Value("${jwt.secret-key.access-token}") String jwtSecretKey
     ) {
         final byte[] secretKeyBytes = Base64.getDecoder().decode(jwtSecretKey);
         this.secretKey = Keys.hmacShaKeyFor(secretKeyBytes);
-        this.tokenExpiration = tokenExpiration;
     }
 
     @Override

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/jwt/AccessTokenProvider.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/jwt/AccessTokenProvider.java
@@ -1,0 +1,97 @@
+package kr.co.pennyway.socket.common.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import kr.co.pennyway.common.util.DateUtil;
+import kr.co.pennyway.infra.common.exception.JwtErrorCode;
+import kr.co.pennyway.infra.common.exception.JwtErrorException;
+import kr.co.pennyway.infra.common.jwt.JwtClaims;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
+import kr.co.pennyway.infra.common.util.JwtErrorCodeUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+import static kr.co.pennyway.socket.common.security.jwt.AccessTokenClaimKeys.ROLE;
+import static kr.co.pennyway.socket.common.security.jwt.AccessTokenClaimKeys.USER_ID;
+
+@Slf4j
+@Primary
+@Component("chatAccessTokenProvider")
+public class AccessTokenProvider implements JwtProvider {
+    private final SecretKey secretKey;
+    private final Duration tokenExpiration;
+
+    public AccessTokenProvider(
+            @Value("${jwt.secret-key.access-token}") String jwtSecretKey,
+            @Value("${jwt.expiration-time.access-token}") Duration tokenExpiration
+    ) {
+        final byte[] secretKeyBytes = Base64.getDecoder().decode(jwtSecretKey);
+        this.secretKey = Keys.hmacShaKeyFor(secretKeyBytes);
+        this.tokenExpiration = tokenExpiration;
+    }
+
+    @Override
+    public String generateToken(JwtClaims claims) {
+        throw new UnsupportedOperationException("채팅 서버에서는 AccessToken을 생성하지 않습니다.");
+    }
+
+    @Override
+    public JwtClaims getJwtClaimsFromToken(String token) {
+        Claims claims = getClaimsFromToken(token);
+        return AccessTokenClaim.of(Long.parseLong(claims.get(USER_ID.getValue(), String.class)), claims.get(ROLE.getValue(), String.class));
+    }
+
+    @Override
+    public LocalDateTime getExpiryDate(String token) {
+        Claims claims = getClaimsFromToken(token);
+        return DateUtil.toLocalDateTime(claims.getExpiration());
+    }
+
+    @Override
+    public boolean isTokenExpired(String token) {
+        try {
+            Claims claims = getClaimsFromToken(token);
+            return claims.getExpiration().before(new Date());
+        } catch (JwtErrorException e) {
+            if (JwtErrorCode.EXPIRED_TOKEN.equals(e.getErrorCode())) return true;
+            throw e;
+        }
+    }
+
+    @Override
+    public Claims getClaimsFromToken(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (JwtException e) {
+            final JwtErrorCode errorCode = JwtErrorCodeUtil.determineErrorCode(e, JwtErrorCode.FAILED_AUTHENTICATION);
+
+            log.warn("Error code : {}, Error - {},  {}", errorCode, e.getClass(), e.getMessage());
+            throw new JwtErrorException(errorCode);
+        }
+    }
+
+    private Map<String, Object> createHeader() {
+        return Map.of("typ", "JWT",
+                "alg", "HS256",
+                "regDate", System.currentTimeMillis());
+    }
+
+    private Date createExpireDate(final Date now, long expirationTime) {
+        return new Date(now.getTime() + expirationTime);
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/util/StompMessageUtil.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/util/StompMessageUtil.java
@@ -1,0 +1,42 @@
+package kr.co.pennyway.socket.common.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.socket.common.dto.ServerSideMessage;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * STOMP 메시지 처리를 위한 유틸리티 클래스.
+ * 이 클래스는 STOMP 헤더 액세서 생성 및 메시지 생성과 관련된 공통 기능을 제공합니다.
+ */
+@Slf4j
+@UtilityClass
+public class StompMessageUtil {
+    private static final byte[] EMPTY_PAYLOAD = new byte[0];
+
+    /**
+     * StompHeaderAccessor와 페이로드를 사용하여 STOMP 메시지를 생성합니다.
+     *
+     * @param accessor     {@link StompHeaderAccessor}
+     * @param payload      {@link ServerSideMessage} 메시지 페이로드 (null일 수 있음)
+     * @param objectMapper Jackson ObjectMapper
+     * @return 생성된 STOMP 메시지
+     */
+    public static Message<byte[]> createMessage(StompHeaderAccessor accessor, ServerSideMessage payload, ObjectMapper objectMapper) {
+        if (payload == null) {
+            return MessageBuilder.createMessage(EMPTY_PAYLOAD, accessor.getMessageHeaders());
+        }
+
+        try {
+            byte[] serializedPayload = objectMapper.writeValueAsBytes(payload);
+            return MessageBuilder.createMessage(serializedPayload, accessor.getMessageHeaders());
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing payload", e);
+            return MessageBuilder.createMessage(EMPTY_PAYLOAD, accessor.getMessageHeaders());
+        }
+    }
+}

--- a/pennyway-socket/src/main/resources/application.yml
+++ b/pennyway-socket/src/main/resources/application.yml
@@ -24,6 +24,10 @@ message-broker:
     user-prefix: ${MESSAGE_BROKER_USER_PREFIX:/usr}
     publish-exchange: ${MESSAGE_BROKER_PUBLISH_EXCHANGE:/topic}
 
+jwt:
+  secret-key:
+    access-token: ${JWT_ACCESS_SECRET_KEY:exampleSecretKeyForPennywaySystemAccessSecretKeyTestForPadding}
+
 ---
 spring:
   config:


### PR DESCRIPTION
## 작업 이유
- Interceptor 접근 시 필요한 작업을 반영하기 위한 환경 구축 (ex. 인증/인가 필터링)
- Interceptor 예외 발생 시, 전역 핸들링을 위한 환경 구축

<br/>

## 작업 사항
디자인 패턴을 있는 대로 때려박았습니다.  
Security 라이브러리처럼 친절하게 인터셉터를 등록할 수 있는 구조가 아니어서, 자체적으로 구현하게 됐습니다.  

**🟡 Inbound Interceptor**
1. 애플리케이션 시작 시, `StompCommandHandlerFactory`에서 마커 인터페이스 `StompCommandHandler`를 구현한 모든 핸들러를 가져와 STOMP 명령어 별로 핸들러를 구분합니다.
2. 클라이언트 요청이 들어오면, `ChannelInterceptor`를 구현한 `StompInboundInterceptor`에서 명령어 종류에 따라 `StompCommandHandlerFactory`에 등록한 핸들러를 실행시킵니다.

옵저버 패턴을 사용하지 않은 이유는 Interceptor의 실행 결과를 다시 돌려받아야 하기 때문..

**🟡 Exception Interceptor **  
위랑 거의 동일한데, 여기선 STOMP 프레임이 아닌 예외를 기준으로 핸들링하기 때문에 Factory는 나오지 않습니다.  
1. 예외 처리 필터를 등록하기 위해서는 `StompExceptionHandler` 인터페이스를 구현합니다.
    - 그러나 예외는 거의 비슷한 플로우로 처리되기 때문에, 이를 템플릿 메서드 패턴으로 구현해둔 `AbstractStompExceptionHandler`를 상속받아서 처리해도 됩니다.
2. `StompSubProtocolErrorHandler`를 구현한 `StompExceptionInterceptor`에서 예외 종류에 맞게 적절히 핸들러를 호출해서 처리합니다.

굳이 이렇게 만든 이유는 얘네가 자체적으로 N개의 인터셉터를 관리할 방법을 제시해주지 않았기 때문에  
코드가 한 곳으로 모이게 되면서 매우 난잡해지는 현상을 이미 목도했기 때문.  

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 비록 Interceptor 탐색을 하는 과정이 포함되지만, Interceptor가 작업 시간에 영향을 줄 정도로 많아질 일은 없다고 판단해서 그냥 무식하게 구현했습니다.
- 다만 Interceptor의 Bean 설정이 되는 지는 모르겠습니다. (예를 들어, Inbound에서 Inter1이 실행되고, Inter2가 실행됨을 보장한다고는 확신할 수 없습니다.)
- 이 외의 작업 (이후 Interceptor 작업에 필요한 것들만 구현함.)
   - Spring Security의 Principal과 동일한 사용 방법을 구사하기 위한 UserPrincipal 객체 정의
   - 인증/인가를 위한 Access Token Provider 정의 (단, 토큰 생성 메서드는 호출 불가능하게 막아둠)
   - ServerSideMessage DTO(기존의 SuccessResponse 같은 존재)와 Interceptor Error Code 등을 정의해두었습니다.

<br/>

## 발견한 이슈
- 없음.

