### PR TITLE
Ignore: ✨ Controller for updating the principal's expiresAt field 

### DIFF
--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/event/ReceiptEventHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/event/ReceiptEventHandler.java
@@ -1,0 +1,50 @@
+package kr.co.pennyway.socket.common.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.socket.common.dto.ServerSideMessage;
+import kr.co.pennyway.socket.common.util.StompMessageUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.AbstractSubscribableChannel;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReceiptEventHandler {
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    @Async
+    public CompletableFuture<ApplicationListener<RefreshEvent<ServerSideMessage>>> principalRefreshEventListener(final AbstractSubscribableChannel clientOutboundChannel) {
+        return CompletableFuture.completedFuture(event -> {
+            Message<ServerSideMessage> message = event.getMessage();
+            StompHeaderAccessor accessor = StompHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+            Message<byte[]> payload = StompMessageUtil.createMessage(accessor, message.getPayload(), objectMapper);
+
+            sendReceiptMessage(clientOutboundChannel, accessor, payload.getPayload());
+        });
+    }
+
+    private void sendReceiptMessage(AbstractSubscribableChannel clientOutboundChannel, StompHeaderAccessor accessor, byte[] payload) {
+        if (accessor != null && accessor.getReceipt() != null) {
+            accessor.setHeader("stompCommand", StompCommand.RECEIPT);
+            accessor.setReceiptId(accessor.getReceipt());
+
+            Message<byte[]> receiptMessage = MessageBuilder.createMessage(payload, accessor.getMessageHeaders());
+            log.info("receiptMessage: {}", receiptMessage);
+
+            clientOutboundChannel.send(receiptMessage);
+        }
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/event/ReceiptEventHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/event/ReceiptEventHandler.java
@@ -42,7 +42,6 @@ public class ReceiptEventHandler {
             accessor.setReceiptId(accessor.getReceipt());
 
             Message<byte[]> receiptMessage = MessageBuilder.createMessage(payload, accessor.getMessageHeaders());
-            log.info("receiptMessage: {}", receiptMessage);
 
             clientOutboundChannel.send(receiptMessage);
         }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/event/RefreshEvent.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/event/RefreshEvent.java
@@ -1,0 +1,22 @@
+package kr.co.pennyway.socket.common.event;
+
+import kr.co.pennyway.socket.common.dto.ServerSideMessage;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.messaging.Message;
+
+public class RefreshEvent<T extends ServerSideMessage> extends ApplicationEvent {
+    private final Message<T> message;
+
+    private RefreshEvent(Message<T> message) {
+        super(message);
+        this.message = message;
+    }
+
+    public static <T extends ServerSideMessage> RefreshEvent<T> of(Message<T> message) {
+        return new RefreshEvent<>(message);
+    }
+
+    public Message<T> getMessage() {
+        return message;
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/AuthController.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/AuthController.java
@@ -23,8 +23,6 @@ public class AuthController {
     @MessageMapping("auth.refresh")
     @PreAuthorize("#principal instanceof T(kr.co.pennyway.socket.common.security.authenticate.UserPrincipal)")
     public void refreshPrincipal(@Header("Authorization") String authorization, Principal principal, StompHeaderAccessor accessor) {
-        log.info("refreshPrincipal AccessToken: {}", authorization);
-
         if (authorization == null || !authorization.startsWith("Bearer ")) {
             throw new JwtErrorException(JwtErrorCode.EMPTY_ACCESS_TOKEN);
         }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/AuthController.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/AuthController.java
@@ -1,0 +1,35 @@
+package kr.co.pennyway.socket.controller;
+
+import kr.co.pennyway.infra.common.exception.JwtErrorCode;
+import kr.co.pennyway.infra.common.exception.JwtErrorException;
+import kr.co.pennyway.socket.common.annotation.PreAuthorize;
+import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal;
+import kr.co.pennyway.socket.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @MessageMapping("auth.refresh")
+    @PreAuthorize("#principal instanceof T(kr.co.pennyway.socket.common.security.authenticate.UserPrincipal)")
+    public void refreshPrincipal(@Header("Authorization") String authorization, Principal principal, StompHeaderAccessor accessor) {
+        log.info("refreshPrincipal AccessToken: {}", authorization);
+
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            throw new JwtErrorException(JwtErrorCode.EMPTY_ACCESS_TOKEN);
+        }
+        String token = authorization.substring(7);
+
+        authService.refreshPrincipal(token, (UserPrincipal) principal, accessor);
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/AuthService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/AuthService.java
@@ -1,0 +1,43 @@
+package kr.co.pennyway.socket.service;
+
+import kr.co.pennyway.infra.common.exception.JwtErrorException;
+import kr.co.pennyway.socket.common.dto.ServerSideMessage;
+import kr.co.pennyway.socket.common.event.RefreshEvent;
+import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal;
+import kr.co.pennyway.socket.common.security.jwt.AccessTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final AccessTokenProvider accessTokenProvider;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void refreshPrincipal(String token, UserPrincipal principal, StompHeaderAccessor accessor) {
+        Message<ServerSideMessage> message;
+
+        try {
+            LocalDateTime expiresAt = accessTokenProvider.getExpiryDate(token);
+            principal.updateExpiresAt(expiresAt);
+
+            ServerSideMessage payload = ServerSideMessage.of("2000", "토큰 갱신 성공");
+            message = MessageBuilder.createMessage(payload, accessor.getMessageHeaders());
+        } catch (JwtErrorException e) {
+            log.info("refresh failed: {}", e.getErrorCode().getExplainError());
+
+            ServerSideMessage payload = ServerSideMessage.of(e.causedBy().getCode(), e.getErrorCode().getExplainError());
+            message = MessageBuilder.createMessage(payload, accessor.getMessageHeaders());
+        }
+
+        eventPublisher.publishEvent(RefreshEvent.of(message));
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/AuthService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/AuthService.java
@@ -32,7 +32,7 @@ public class AuthService {
             ServerSideMessage payload = ServerSideMessage.of("2000", "토큰 갱신 성공");
             message = MessageBuilder.createMessage(payload, accessor.getMessageHeaders());
         } catch (JwtErrorException e) {
-            log.info("refresh failed: {}", e.getErrorCode().getExplainError());
+            log.warn("refresh failed: {}", e.getErrorCode().getExplainError());
 
             ServerSideMessage payload = ServerSideMessage.of(e.causedBy().getCode(), e.getErrorCode().getExplainError());
             message = MessageBuilder.createMessage(payload, accessor.getMessageHeaders());


### PR DESCRIPTION
## 작업 이유
- 사용자의 Principal `expiresAt` 만료 시, refresh 요청을 처리하는 컨트롤러
- #166 의 후작업

<br/>

## 작업 사항
![image](https://github.com/user-attachments/assets/b0f54b43-49b2-4d78-bafd-80c2c90f7337)

- Connect 프레임에서 사용자 인증을 수행하지만, API 서버에서 사용자 권한이 만료되었음에도 WebSocket 연결은 가능하다는 문제가 존재함.
- 이에 `Principal`의 `expiresAt`을 access token 만료 시간으로 설정하여, `isAuthenticate` 메서드에서 만료 여부를 판단
- Client가 API 서버에서 refresh를 수행하여 성공하면, 이번에 작업한 path로 principal의 expiresAt 필드를 갱신할 수 있음.
- 성공 혹은 실패 여부를 클라이언트 측으로 receipt

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음.

<br/>

## 발견한 이슈
- 다 작성하고 생긴 의문. Principal은 client - server 간에 맺어진 헤더를 기반으로 추출함. 그렇다면 클라이언트에서 이 값을 조작할 수 있지 않은가?
   - 일반적인 시나리오에선 Connect 단계에서 검증했기 때문에, 문제가 되지 않음.
   - 만약 토큰을 탈취한 공격자가 한 번이라도 웹 소켓 연결에 성공하면, 이 값을 조작하여 무한 연결을 유지할 우려가 존재함.
- 따라서, 클라이언트 측에서 헤더를 조작할 수 있는 지 검증 후 대안책을 마련할 필요가 존재함.
