### PR TITLE
Socket: ✨ GUID Configuration based on a Time-Sorted Identifier

### DIFF
--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/guid/IdGenerator.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/guid/IdGenerator.java
@@ -1,0 +1,8 @@
+package kr.co.pennyway.infra.client.guid;
+
+/**
+ * Global Unique Identifier 생성 인터페이스
+ */
+public interface IdGenerator<T> {
+    T generate();
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/guid/IdGenerator.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/guid/IdGenerator.java
@@ -2,6 +2,8 @@ package kr.co.pennyway.infra.client.guid;
 
 /**
  * Global Unique Identifier 생성 인터페이스
+ * <p>
+ * IdGenerator는 Integer, Long 또는 String과 같은 Wrapper 타입으로만 구현해야 한다.
  */
 public interface IdGenerator<T> {
     T generate();

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/guid/TsidGenerator.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/guid/TsidGenerator.java
@@ -1,12 +1,10 @@
 package kr.co.pennyway.infra.client.guid;
 
 import com.github.f4b6a3.tsid.TsidCreator;
-import org.springframework.stereotype.Component;
 
 /**
  * Time-Sorted ID 생성 클래스
  */
-@Component
 public class TsidGenerator implements IdGenerator<Long> {
 
     /**

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/guid/TsidGenerator.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/client/guid/TsidGenerator.java
@@ -1,0 +1,22 @@
+package kr.co.pennyway.infra.client.guid;
+
+import com.github.f4b6a3.tsid.TsidCreator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Time-Sorted ID 생성 클래스
+ */
+@Component
+public class TsidGenerator implements IdGenerator<Long> {
+
+    /**
+     * TSID 알고리즘 기반의 timestamp(42bit) + node(8bit) + counter(14bit)로 구성되는 64bit 정수를 반환한다.
+     * 생성된 ID는 ms당 16,383개의 Unique Id를 생성할 수 있으며, 정렬 순서는 생성 순서와 동일하다.
+     *
+     * @see <a href="https://github.com/psychology50/high-concurrency-unique-id-generator-test">GUID별 성능 지표</a>
+     */
+    @Override
+    public Long generate() {
+        return TsidCreator.getTsid256().toLong();
+    }
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/importer/PennywayInfraConfigGroup.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/importer/PennywayInfraConfigGroup.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.infra.common.importer;
 
 import kr.co.pennyway.infra.config.DistributedCoordinationConfig;
 import kr.co.pennyway.infra.config.FcmConfig;
+import kr.co.pennyway.infra.config.GuidConfig;
 import kr.co.pennyway.infra.config.MessageBrokerConfig;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,8 @@ import lombok.RequiredArgsConstructor;
 public enum PennywayInfraConfigGroup {
     FCM(FcmConfig.class),
     DISTRIBUTED_COORDINATION_CONFIG(DistributedCoordinationConfig.class),
-    MESSAGE_BROKER_CONFIG(MessageBrokerConfig.class);
+    MESSAGE_BROKER_CONFIG(MessageBrokerConfig.class),
+    GUID_GENERATOR_CONFIG(GuidConfig.class);
 
     private final Class<? extends PennywayInfraConfig> configClass;
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/GuidConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/GuidConfig.java
@@ -1,0 +1,13 @@
+package kr.co.pennyway.infra.config;
+
+import kr.co.pennyway.infra.client.guid.IdGenerator;
+import kr.co.pennyway.infra.client.guid.TsidGenerator;
+import kr.co.pennyway.infra.common.importer.PennywayInfraConfig;
+import org.springframework.context.annotation.Bean;
+
+public class GuidConfig implements PennywayInfraConfig {
+    @Bean
+    public IdGenerator<Long> idGenerator() {
+        return new TsidGenerator();
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/InfraConfig.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/InfraConfig.java
@@ -6,7 +6,8 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnablePennywayInfraConfig({
-        PennywayInfraConfigGroup.MESSAGE_BROKER_CONFIG
+        PennywayInfraConfigGroup.MESSAGE_BROKER_CONFIG,
+        PennywayInfraConfigGroup.GUID_GENERATOR_CONFIG
 })
 public class InfraConfig {
 }


### PR DESCRIPTION
## 작업 이유
- 실시간 채팅 정보를 DB에 저장하는 것에는 무리가 있기에, NoSQL에 일정 기간 캐싱을 해둘 예정.
- 이로 인해, `auto_increment` 방식의 고유 ID를 생성할 수 없음.
- 따라서, 애플리케이션 단에서 다음의 요구 사항을 충족하는 GUID 생성기를 구축할 필요성 제기
   - ID는 유일성을 보장해야 한다.
   - ID는 숫자로만 구성되어 있어야 한다.
   - ID는 64bit로 표현 가능해야 한다. 
   - ID는 발급 날짜에 따라 정렬 가능해야 한다.
   - 초당 10,000개의 ID를 만들 수 있어야 한다. (절충할 수 있는 부분)

<br/>

## 작업 사항
![image](https://github.com/user-attachments/assets/b6c0b437-ff21-4d75-ab09-527df1789775)
![image](https://github.com/user-attachments/assets/efc5e8eb-85b0-41da-91a7-cf126cf1f968)

- 라이브러리는 [f4b6a3](https://github.com/f4b6a3/tsid-creator)을 사용했습니다.
- 64-bit(timestamp(42bit) + node(8bit) + counter(14bit)) 크기를 가지며, 128-bit UUID에 비해 훨씬 적은 공간을 차지합니다.
   - node bit 8-bit는 Factory로 조절할 수 있지만, 저희가 채팅 서버를 8개나 띄울 일이 없습니다.
   - 분산 코디네이션 없이, 각 서버에게 node id를 할당하기도 어렵기 때문에 8-bit로 고정해버렸습니다.
- counter bit가 14-bit이므로, ms 당 16,383개의 고유 ID를 생성할 수 있습니다.
- 정수 데이터를 가지기 때문에 DB 조인 성능이 상당히 빠릅니다.
- ID 순서로 정렬하면, 곧 생성 순서와 동일합니다.
   - `created_at`은 동일 ms에서 생성한 데이터를 정렬하지 못 하기 때문에, id가 이를 수행할 수 있어야 합니다.
- ID 생성 시간 또한 가장 빠르진 않지만, 준수한 성능을 가집니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 직접 확인해보고 싶다면, [제 깃헙](https://github.com/psychology50/high-concurrency-unique-id-generator-test)을 참조해주세요.

<br/>

## 발견한 이슈
- 없음.

