### PR TITLE
Socket: 🐛 Resolving the issue where Spring Boot does not create a RabbitMQ connection factory

### DIFF
--- a/pennyway-infra/build.gradle
+++ b/pennyway-infra/build.gradle
@@ -4,6 +4,9 @@ jar { enabled = true }
 dependencies {
     implementation project(':pennyway-common')
 
+    /* Jackson DataType */
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.18.0'
+
     /* jwt */
     api group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.5'
@@ -33,11 +36,8 @@ dependencies {
     /* firebase */
     implementation 'com.google.firebase:firebase-admin:9.2.0'
 
-    /* Web Socket */
-    implementation 'org.springframework.boot:spring-boot-starter-websocket'
-
     /* RabbitMQ */
-    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-amqp', version: '3.3.4'
 
     /* TSID Generator */
     implementation 'com.github.f4b6a3:tsid-creator:5.2.6'

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/ChatExchangeProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/ChatExchangeProperties.java
@@ -11,4 +11,13 @@ public class ChatExchangeProperties {
     private final String exchange;
     private final String queue;
     private final String routingKey;
+
+    @Override
+    public String toString() {
+        return "ChatExchangeProperties{" +
+                "exchange='" + exchange + '\'' +
+                ", queue='" + queue + '\'' +
+                ", routingKey='" + routingKey + '\'' +
+                '}';
+    }
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MessageBrokerConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MessageBrokerConfig.java
@@ -10,21 +10,25 @@ import kr.co.pennyway.infra.common.importer.PennywayInfraConfig;
 import kr.co.pennyway.infra.common.properties.ChatExchangeProperties;
 import kr.co.pennyway.infra.common.properties.RabbitMqProperties;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitMessagingTemplate;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 
+@Slf4j
 @EnableRabbit
 @RequiredArgsConstructor
 @EnableConfigurationProperties({ChatExchangeProperties.class, RabbitMqProperties.class})
@@ -75,6 +79,19 @@ public class MessageBrokerConfig implements PennywayInfraConfig {
         factory.setPort(rabbitMqProperties.getPort());
         factory.setVirtualHost(rabbitMqProperties.getVirtualHost());
 
+        return factory;
+    }
+
+    @Bean
+    ApplicationRunner connectionFactoryRunner(ConnectionFactory cf) {
+        return args -> cf.createConnection().close();
+    }
+
+    @Bean
+    public SimpleRabbitListenerContainerFactory simpleRabbitListenerContainerFactory(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(messageConverter);
         return factory;
     }
 

--- a/pennyway-socket/build.gradle
+++ b/pennyway-socket/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     implementation project(':pennyway-infra')
 
     /* Web Socket */
-    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-websocket', version: '3.3.4'
 
     /* Reactor Netty */
-    implementation "org.springframework.boot:spring-boot-starter-reactor-netty"
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-reactor-netty', version: '3.3.4'
 }


### PR DESCRIPTION
## 작업 이유
![image](https://github.com/user-attachments/assets/db48c185-57fc-49ea-b21e-f80d62501579)
![image](https://github.com/user-attachments/assets/b2a49826-e6a4-4d83-98dd-0f65c329e34a)

로컬 환경에서 실행할 때는 RabbitMQ의 connection factory가 정상적으로 생성되었고,  
심지어 테스트를 위해 개인적으로 구축해놓은 환경에서도 멀쩡하게 동작했으나,  
도커 컨테이너로 올리기만 하면 일을 안 하는 스프링 덕분에 참으로 힘겹고 고단한 시간을 보냈습니다.  

심지어 아무런 로그도 안 뜨고, 그냥 연결이 안 되는 최악의 상황  

close #171 

<br/>

## 작업 사항
```java
@Bean
ApplicationRunner connectionFactoryRunner(ConnectionFactory cf) {
    return args -> cf.createConnection().close();
}
```
결론부터 이야기하면, 위 방법으로 해결했습니다.  
Application이 시작하면, 강제로 ConnectionFactory 연결을 실행하도록 하여 작업을 수행합니다.  

<br/>

눈물없인 볼 수 없는 고생한 과정들.
1. 빈 초기화가 되는 것을 확인하기 위해 로그를 출력했는데, 모두 정상 초기화가 되고 있었음. (빈 초기화 문제 아님)
2. 로컬에서 dev 프로필로 실행해도 성공, 도커 컨테이너에서 local 프로필로 실행하면 실패. (프로필 문제는 아님)
3. 환경 변수 오기입을 했으면, 인증 실패 예외가 발생했을 것이므로 패스. (socket에서 STOMP 연결은 무사히 성공하는 것만 봐도 이건 아님)
4. docker-compose 설정 문제 → 기존에 성공했던 테스트 프로젝트와 완전히 동일한 세팅임에도 실패
5. 로그를 살펴보니 serverlet 단에서 연결을 수행 중. web 의존성이 없기 때문인가 했는데, socket 모듈의 web-socket은 web 의존성을 가지고 있었기에 아님.
6. stack overflow에서 actuator 없으면 실패한다고 했는데, 이것도 해봤으나 아님.
7. 기본 생성되는 connect factory로 수정했으나, 이 또한 실패.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 왜 도커 컨테이너로 올리니까 안 되는 걸까~~~~~~~~~ 이유를 모르겠네요. 지연 초기화와 관련이 있는 걸 수도 있을 거 같은데, 도저히 알 수가 없습니다 ㅜㅜㅜㅜㅜ

<br/>

## 발견한 이슈
- EC2 서버 터짐. ㅋ ㅋ ㅋ ㅋ ㅋ

