### PR TITLE
Socket: ✨ Managing user session status on a socket server

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/ledger/dto/SpendingReq.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.ledger.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -70,6 +71,7 @@ public record SpendingReq(
     }
 
     @Schema(hidden = true)
+    @JsonIgnore
     public boolean isCustomCategory() {
         return !categoryId.equals(-1L);
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/ExternalApiDBTestConfig.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/ExternalApiDBTestConfig.java
@@ -11,7 +11,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 @ActiveProfiles("test")
 public abstract class ExternalApiDBTestConfig {
-    private static final String REDIS_CONTAINER_IMAGE = "redis:7.2.4-alpine";
+    private static final String REDIS_CONTAINER_IMAGE = "redis:7.4";
     private static final String MYSQL_CONTAINER_IMAGE = "mysql:8.0.26";
 
     private static final RedisContainer REDIS_CONTAINER;

--- a/pennyway-domain/build.gradle
+++ b/pennyway-domain/build.gradle
@@ -4,6 +4,9 @@ jar { enabled = true }
 dependencies {
     implementation project(':pennyway-common')
 
+    /* Jackson DataType */
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.18.0'
+
     /* MySQL */
     implementation group: 'com.mysql', name: 'mysql-connector-j', version: '8.3.0'
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/converter/UserStatusConverter.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/converter/UserStatusConverter.java
@@ -1,0 +1,13 @@
+package kr.co.pennyway.domain.common.converter;
+
+import jakarta.persistence.Converter;
+import kr.co.pennyway.domain.common.redis.session.UserStatus;
+
+@Converter
+public class UserStatusConverter extends AbstractLegacyEnumAttributeConverter<UserStatus> {
+    private static final String ENUM_NAME = "유저 상태";
+
+    public UserStatusConverter() {
+        super(UserStatus.class, false, ENUM_NAME);
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/SessionLuaScripts.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/SessionLuaScripts.java
@@ -1,0 +1,46 @@
+package kr.co.pennyway.domain.common.redis.session;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public enum SessionLuaScripts {
+    SAVE(
+            "redis.call('HSET', KEYS[1], ARGV[1], ARGV[2]) " +
+                    "return redis.call('HEXPIRE', KEYS[1], ARGV[3], 'FIELDS', '1', ARGV[1])",
+            List.class
+    ),
+    FIND(
+            "return redis.call('HGET', KEYS[1], ARGV[1])",
+            String.class
+    ),
+    FIND_ALL(
+            "return redis.call('HGETALL', KEYS[1])",
+            List.class
+    ),
+    GET_TTL(
+            "return redis.call('HTTL', KEYS[1], 'FIELDS', '1', ARGV[1])",
+            Long.class
+    ),
+    RESET_TTL(
+            "return redis.call('HEXPIRE', KEYS[1], ARGV[2], 'FIELDS', '1', ARGV[1])",
+            Long.class
+    ),
+    DELETE(
+            "return redis.call('HDEL', KEYS[1], ARGV[1])",
+            Long.class
+    );
+
+    private final String script;
+    private final Class<?> returnType;
+
+    public <T> RedisScript<T> getScript() {
+        return RedisScript.of(script, (Class<T>) returnType);
+    }
+
+    public <T> Class<T> getReturnType() {
+        return (Class<T>) returnType;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/SessionLuaScripts.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/SessionLuaScripts.java
@@ -24,6 +24,10 @@ public enum SessionLuaScripts {
             "return redis.call('HTTL', KEYS[1], 'FIELDS', '1', ARGV[1])",
             Long.class
     ),
+    EXISTS(
+            "return redis.call('HEXISTS', KEYS[1], ARGV[1])",
+            Boolean.class
+    ),
     RESET_TTL(
             "return redis.call('HEXPIRE', KEYS[1], ARGV[2], 'FIELDS', '1', ARGV[1])",
             Long.class

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSession.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSession.java
@@ -75,12 +75,22 @@ public class UserSession implements Serializable {
     }
 
     public void updateStatus(UserStatus status) {
+        validate(deviceName, status, lastActiveAt);
+
         this.status = status;
+        updateLastActiveAt();
     }
 
     public void updateStatus(UserStatus status, Long currentChatRoomId) {
+        validate(deviceName, status, lastActiveAt);
+
+        if (status.equals(UserStatus.ACTIVE_CHAT_ROOM) && (currentChatRoomId == null || currentChatRoomId <= 0)) {
+            throw new IllegalArgumentException("채팅방 ID는 null 혹은 0을 포함한 음수를 허용하지 않습니다.");
+        }
+
         this.status = status;
         this.currentChatRoomId = currentChatRoomId;
+        updateLastActiveAt();
     }
 
     /**

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSession.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSession.java
@@ -1,0 +1,149 @@
+package kr.co.pennyway.domain.common.redis.session;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Convert;
+import kr.co.pennyway.domain.common.converter.UserStatusConverter;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class UserSession implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private String deviceName;
+    @Convert(converter = UserStatusConverter.class)
+    private UserStatus status;
+    private Long currentChatRoomId;
+    private LocalDateTime lastActiveAt;
+    @JsonIgnore
+    private int hashCode;
+
+    @JsonCreator
+    private UserSession(
+            @JsonProperty("deviceName") String deviceName,
+            @JsonProperty("status") UserStatus status,
+            @JsonProperty("currentChatRoomId") Long currentChatRoomId,
+            @JsonProperty("lastActiveAt") LocalDateTime lastActiveAt
+    ) {
+        validate(deviceName, status, lastActiveAt);
+
+        this.deviceName = deviceName;
+        this.status = status;
+        this.currentChatRoomId = currentChatRoomId;
+        this.lastActiveAt = lastActiveAt;
+    }
+
+    /**
+     * 새로운 사용자 세션을 생성한다.
+     * 사용자의 상태는 ACTIVE_APP이며, 채팅방 관련 뷰룰 보고 있지 않음을 전제로 한다.
+     * 마지막 활동 시간은 현재 시간으로 설정된다.
+     */
+    public static UserSession of(String deviceName) {
+        return new UserSession(deviceName, UserStatus.ACTIVE_APP, null, LocalDateTime.now());
+    }
+
+    public String getDeviceName() {
+        return deviceName;
+    }
+
+    public UserStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * 사용자가 보고 있는 채팅방 ID를 반환한다.
+     *
+     * @return 사용자가 보고 있는 채팅방 ID. 채팅방을 보고 있지 않을 경우 -1을 반환한다.
+     */
+    public Long getCurrentChatRoomId() {
+        if (!this.status.equals(UserStatus.ACTIVE_CHAT_ROOM)) {
+            return -1L;
+        }
+
+        return currentChatRoomId;
+    }
+
+    public LocalDateTime getLastActiveAt() {
+        return lastActiveAt;
+    }
+
+    public void updateStatus(UserStatus status) {
+        this.status = status;
+    }
+
+    public void updateStatus(UserStatus status, Long currentChatRoomId) {
+        this.status = status;
+        this.currentChatRoomId = currentChatRoomId;
+    }
+
+    /**
+     * 사용자의 마지막 활동 시간을 현재 시간으로 갱신한다.
+     */
+    public void updateLastActiveAt() {
+        this.lastActiveAt = LocalDateTime.now();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserSession that = (UserSession) o;
+        return deviceName.equals(that.deviceName) && status == that.status && Objects.equals(currentChatRoomId, that.currentChatRoomId) && lastActiveAt.equals(that.lastActiveAt);
+    }
+
+    @Override
+    public int hashCode() {
+        if (hashCode != -1) {
+            return hashCode;
+        }
+
+        int result = deviceName.hashCode();
+        result = 31 * result + status.hashCode();
+        result = 31 * result + (currentChatRoomId != null ? currentChatRoomId.hashCode() : 0);
+        result = 31 * result + lastActiveAt.hashCode();
+        return hashCode = result;
+    }
+
+    @Serial
+    private void readObject(ObjectInputStream s) throws IOException, ClassNotFoundException {
+        s.defaultReadObject();
+
+        // 가변 요소를 방어적으로 복사
+        deviceName = String.copyValueOf(deviceName.toCharArray());
+        status = UserStatus.valueOf(status.name());
+        lastActiveAt = LocalDateTime.of(lastActiveAt.toLocalDate(), lastActiveAt.toLocalTime());
+        currentChatRoomId = this.currentChatRoomId == null ? null : Long.valueOf(currentChatRoomId);
+
+        // 불변식을 만족하는지 검사한다.
+        validate(deviceName, status, lastActiveAt);
+    }
+
+    private void validate(String deviceName, UserStatus status, LocalDateTime lastActiveAt) {
+        if (deviceName == null) {
+            throw new IllegalStateException("deviceName은 null일 수 없습니다.");
+        }
+        if (status == null) {
+            throw new IllegalStateException("status는 null일 수 없습니다.");
+        }
+        if (lastActiveAt == null) {
+            throw new IllegalStateException("lastActiveAt은 null일 수 없습니다.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "UserSession{" +
+                "deviceName='" + deviceName + '\'' +
+                ", status=" + status +
+                ", currentChatRoomId=" + currentChatRoomId +
+                ", lastActiveAt=" + lastActiveAt +
+                '}';
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepository.java
@@ -12,6 +12,8 @@ public interface UserSessionRepository {
 
     Long getSessionTtl(Long userId, String hashKey);
 
+    boolean exists(Long userId, String hashKey);
+
     void resetSessionTtl(Long userId, String hashKey);
 
     void delete(Long userId, String hashKey);

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepository.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.domain.common.redis.session;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface UserSessionRepository {
+    void save(Long userId, String hashKey, UserSession value);
+
+    Optional<UserSession> findUserSession(Long userId, String hashKey) throws JsonProcessingException;
+
+    Map<String, UserSession> findAllUserSessions(Long userId) throws JsonProcessingException;
+
+    Long getSessionTtl(Long userId, String hashKey);
+
+    void resetSessionTtl(Long userId, String hashKey);
+
+    void delete(Long userId, String hashKey);
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepository.java
@@ -1,16 +1,14 @@
 package kr.co.pennyway.domain.common.redis.session;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 import java.util.Map;
 import java.util.Optional;
 
 public interface UserSessionRepository {
     void save(Long userId, String hashKey, UserSession value);
 
-    Optional<UserSession> findUserSession(Long userId, String hashKey) throws JsonProcessingException;
+    Optional<UserSession> findUserSession(Long userId, String hashKey);
 
-    Map<String, UserSession> findAllUserSessions(Long userId) throws JsonProcessingException;
+    Map<String, UserSession> findAllUserSessions(Long userId);
 
     Long getSessionTtl(Long userId, String hashKey);
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepositoryImpl.java
@@ -1,0 +1,189 @@
+package kr.co.pennyway.domain.common.redis.session;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.domain.common.annotation.DomainRedisTemplate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Repository
+public class UserSessionRepositoryImpl implements UserSessionRepository {
+    private static final long ttlSeconds = 60 * 60 * 24 * 7; // 1주일 (초)
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, UserSession> redisTemplate;
+
+    public UserSessionRepositoryImpl(@DomainRedisTemplate RedisTemplate<String, UserSession> redisTemplate, ObjectMapper objectMapper) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void save(Long userId, String hashKey, UserSession value) {
+        String key = createKey(userId);
+
+        String luaScript =
+                "redis.call('HSET', KEYS[1], ARGV[1], ARGV[2]) " +
+                        "return redis.call('HEXPIRE', KEYS[1], ARGV[3], 'FIELDS', '1', ARGV[1])";
+
+        RedisScript<List> script = RedisScript.of(luaScript, List.class);
+
+        try {
+            List<Object> result = redisTemplate.execute(script,
+                    List.of(key),
+                    hashKey,
+                    serialize(value),
+                    ttlSeconds
+            );
+
+            log.info("User session saved for user {} with hash key {}. Result: {}", userId, hashKey, result);
+        } catch (Exception e) {
+            log.error("Error saving user session for user {} with hash key {}", userId, hashKey, e);
+            throw new RuntimeException("Failed to save user session", e);
+        }
+    }
+
+    @Override
+    public Optional<UserSession> findUserSession(Long userId, String hashKey) throws JsonProcessingException {
+        String luaScript =
+                "return redis.call('HGET', KEYS[1], ARGV[1])";
+
+        RedisScript<Object> script = RedisScript.of(luaScript, Object.class);
+
+        try {
+            Object result = redisTemplate.execute(script,
+                    List.of(createKey(userId)),
+                    hashKey
+            );
+
+            log.info("User session found for user {} with hash key {}: {}", userId, hashKey, result);
+
+            UserSession session = deserializeFromBase64((String) result);
+            log.debug("User session found for user {} with hash key {}: {}", userId, hashKey, session);
+
+            return Optional.ofNullable(session);
+        } catch (Exception e) {
+            log.error("Error finding user session for user {} with hash key {}", userId, hashKey, e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Map<String, UserSession> findAllUserSessions(Long userId) throws JsonProcessingException {
+        String luaScript =
+                "return redis.call('HGETALL', KEYS[1])";
+
+        RedisScript<List> script = RedisScript.of(luaScript, List.class);
+
+        try {
+            List<Object> result = redisTemplate.execute(script,
+                    List.of(createKey(userId))
+            );
+
+            Map<String, UserSession> sessions = new ConcurrentHashMap<>();
+            for (int i = 0; i < result.size(); i += 2) {
+                String key = result.get(i).toString();
+                UserSession value = deserializeFromBase64((String) result.get(i + 1));
+                log.debug("User session found for user {} with hash key {}: {}", userId, key, value);
+                sessions.put(key, value);
+            }
+
+            return sessions;
+        } catch (Exception e) {
+            log.error("Error finding all user sessions for user {}", userId, e);
+            return new ConcurrentHashMap<>();
+        }
+    }
+
+    @Override
+    public Long getSessionTtl(Long userId, String hashKey) {
+        String luaScript =
+                "return redis.call('HTTL', KEYS[1], 'FIELDS', '1', ARGV[1])";
+
+        RedisScript<Long> script = RedisScript.of(luaScript, Long.class);
+
+        try {
+            Long result = redisTemplate.execute(script,
+                    List.of(createKey(userId)),
+                    hashKey
+            );
+
+            return result != null ? result : -1L;
+        } catch (Exception e) {
+            log.error("Error getting session TTL for user {} with hash key {}", userId, hashKey, e);
+            return -1L;
+        }
+    }
+
+    @Override
+    public void resetSessionTtl(Long userId, String hashKey) {
+        String luaScript =
+                "return redis.call('HEXPIRE', KEYS[1], ARGV[1], 'FIELDS', '1', ARGV[2])";
+
+        RedisScript<Long> script = RedisScript.of(luaScript, Long.class);
+
+        try {
+            Long result = redisTemplate.execute(script,
+                    List.of(createKey(userId)),
+                    ttlSeconds,
+                    hashKey
+            );
+
+            log.debug("Reset session TTL for user {} with hash key {}. Result: {}", userId, hashKey, result);
+        } catch (Exception e) {
+            log.error("Error resetting session TTL for user {} with hash key {}", userId, hashKey, e);
+            throw new RuntimeException("Failed to reset session TTL", e);
+        }
+    }
+
+    @Override
+    public void delete(Long userId, String hashKey) {
+        String luaScript =
+                "return redis.call('HDEL', KEYS[1], ARGV[1])";
+
+        RedisScript<Long> script = RedisScript.of(luaScript, Long.class);
+
+        try {
+            Long result = redisTemplate.execute(script,
+                    List.of(createKey(userId)),
+                    hashKey
+            );
+
+            log.debug("Deleted session for user {} with hash key {}. Result: {}", userId, hashKey, result);
+        } catch (Exception e) {
+            log.error("Error deleting session for user {} with hash key {}", userId, hashKey, e);
+            throw new RuntimeException("Failed to delete session", e);
+        }
+    }
+
+    private byte[] serialize(UserSession value) {
+        try {
+            RedisSerializer<UserSession> valueSerializer = (RedisSerializer<UserSession>) redisTemplate.getValueSerializer();
+            return valueSerializer.serialize(value);
+        } catch (Exception e) {
+            log.error("Error serializing UserSession", e);
+            throw new RuntimeException("Failed to serialize UserSession", e);
+        }
+    }
+
+    private UserSession deserializeFromBase64(String base64String) throws IOException {
+        byte[] decodedBytes = Base64.getDecoder().decode(base64String);
+        String jsonString = new String(decodedBytes, StandardCharsets.UTF_8);
+        return objectMapper.readValue(jsonString, UserSession.class);
+    }
+
+    private String createKey(Long userId) {
+        return "user:" + userId;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepositoryImpl.java
@@ -49,6 +49,11 @@ public class UserSessionRepositoryImpl implements UserSessionRepository {
     }
 
     @Override
+    public boolean exists(Long userId, String hashKey) {
+        return executeScript(SessionLuaScripts.EXISTS, userId, hashKey);
+    }
+
+    @Override
     public void resetSessionTtl(Long userId, String hashKey) {
         executeScript(SessionLuaScripts.RESET_TTL, userId, hashKey, ttlSeconds);
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepositoryImpl.java
@@ -30,14 +30,14 @@ public class UserSessionRepositoryImpl implements UserSessionRepository {
     }
 
     @Override
-    public Optional<UserSession> findUserSession(Long userId, String hashKey) throws JsonProcessingException {
+    public Optional<UserSession> findUserSession(Long userId, String hashKey) {
         Object result = executeScript(SessionLuaScripts.FIND, userId, hashKey);
 
         return Optional.ofNullable(deserialize(result));
     }
 
     @Override
-    public Map<String, UserSession> findAllUserSessions(Long userId) throws JsonProcessingException {
+    public Map<String, UserSession> findAllUserSessions(Long userId) {
         List<Object> result = executeScript(SessionLuaScripts.FIND_ALL, userId);
 
         return deserializeMap(result);

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionRepositoryImpl.java
@@ -79,6 +79,7 @@ public class UserSessionRepositoryImpl implements UserSessionRepository {
         try {
             return objectMapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
+            log.error("Error serializing UserSession", e);
             throw new RuntimeException("Failed to serialize UserSession", e);
         }
     }
@@ -88,6 +89,7 @@ public class UserSessionRepositoryImpl implements UserSessionRepository {
         try {
             return objectMapper.readValue((String) value, UserSession.class);
         } catch (JsonProcessingException e) {
+            log.error("Error deserializing UserSession", e);
             throw new RuntimeException("Failed to deserialize UserSession", e);
         }
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -13,33 +14,66 @@ import java.util.Optional;
 public class UserSessionService {
     private final UserSessionRepository userSessionRepository;
 
-    public void create(Long userId, String domainId, UserSession value) {
-        userSessionRepository.save(userId, domainId, value);
+    public void create(Long userId, String deviceId, UserSession value) {
+        userSessionRepository.save(userId, deviceId, value);
     }
 
-    public Optional<UserSession> read(Long userId, String domainId) {
-        return userSessionRepository.findUserSession(userId, domainId);
+    public Optional<UserSession> read(Long userId, String deviceId) {
+        return userSessionRepository.findUserSession(userId, deviceId);
     }
 
     public Map<String, UserSession> readAll(Long userId) {
         return userSessionRepository.findAllUserSessions(userId);
     }
 
-    public boolean isExists(Long userId, String domainId) {
-        Optional<UserSession> userSession = userSessionRepository.findUserSession(userId, domainId);
-
-        return userSession.isPresent();
+    public boolean isExists(Long userId, String deviceId) {
+        return userSessionRepository.exists(userId, deviceId);
     }
 
-    public Long getSessionTtl(Long userId, String hashKey) {
-        return userSessionRepository.getSessionTtl(userId, hashKey);
+    /**
+     * 사용자 세션의 상태를 변경합니다.
+     * {@link UserStatus#ACTIVE_CHAT_ROOM} 이외에 사용자 세션의 상태를 변경할 때 사용합니다.
+     * 사용자 세션의 chatRoomId는 -1로 설정됩니다.
+     *
+     * @throws IllegalArgumentException 사용자 세션 정보를 찾을 수 없을 때 발생합니다.fix
+     */
+    public UserSession updateUserStatus(Long userId, String deviceId, UserStatus status) {
+        return updateUserStatus(userId, deviceId, -1L, status);
     }
 
-    public void resetSessionTtl(Long userId, String hashKey) {
-        userSessionRepository.resetSessionTtl(userId, hashKey);
+    /**
+     * 사용자 세션의 상태를 변경합니다.
+     * {@link UserStatus#ACTIVE_CHAT_ROOM}로 변경할 때 사용되며, chatRoomId는 null 혹은 0을 포함한 음수를 허용하지 않습니다.
+     *
+     * @throws IllegalArgumentException chatRoomId가 null 혹은 0을 포함한 음수일 때 발생합니다. 사용자 세션 정보를 찾을 수 없을 때도 발생합니다.
+     */
+    public UserSession updateUserStatus(Long userId, String deviceId, Long chatRoomId) {
+        if (Objects.isNull(chatRoomId) || chatRoomId <= 0) {
+            throw new IllegalArgumentException("채팅방 ID는 null 혹은 0을 포함한 음수를 허용하지 않습니다.");
+        }
+
+        return updateUserStatus(userId, deviceId, chatRoomId, UserStatus.ACTIVE_APP);
     }
 
-    public void delete(Long userId, String hashKey) {
-        userSessionRepository.delete(userId, hashKey);
+    private UserSession updateUserStatus(Long userId, String deviceId, Long chatRoomId, UserStatus status) {
+        UserSession userSession = userSessionRepository.findUserSession(userId, deviceId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 세션을 찾을 수 없습니다."));
+
+        userSession.updateStatus(status, chatRoomId);
+        userSessionRepository.save(userId, deviceId, userSession);
+
+        return userSession;
+    }
+
+    public Long getSessionTtl(Long userId, String deviceId) {
+        return userSessionRepository.getSessionTtl(userId, deviceId);
+    }
+
+    public void resetSessionTtl(Long userId, String deviceId) {
+        userSessionRepository.resetSessionTtl(userId, deviceId);
+    }
+
+    public void delete(Long userId, String deviceId) {
+        userSessionRepository.delete(userId, deviceId);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -48,11 +47,7 @@ public class UserSessionService {
      * @throws IllegalArgumentException chatRoomId가 null 혹은 0을 포함한 음수일 때 발생합니다. 사용자 세션 정보를 찾을 수 없을 때도 발생합니다.
      */
     public UserSession updateUserStatus(Long userId, String deviceId, Long chatRoomId) {
-        if (Objects.isNull(chatRoomId) || chatRoomId <= 0) {
-            throw new IllegalArgumentException("채팅방 ID는 null 혹은 0을 포함한 음수를 허용하지 않습니다.");
-        }
-
-        return updateUserStatus(userId, deviceId, chatRoomId, UserStatus.ACTIVE_APP);
+        return updateUserStatus(userId, deviceId, chatRoomId, UserStatus.ACTIVE_CHAT_ROOM);
     }
 
     private UserSession updateUserStatus(Long userId, String deviceId, Long chatRoomId, UserStatus status) {
@@ -70,6 +65,12 @@ public class UserSessionService {
     }
 
     public void resetSessionTtl(Long userId, String deviceId) {
+        UserSession userSession = userSessionRepository.findUserSession(userId, deviceId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 세션을 찾을 수 없습니다."));
+
+        userSession.updateLastActiveAt();
+        userSessionRepository.save(userId, deviceId, userSession);
+
         userSessionRepository.resetSessionTtl(userId, deviceId);
     }
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionService.java
@@ -1,6 +1,5 @@
 package kr.co.pennyway.domain.common.redis.session;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import kr.co.pennyway.common.annotation.DomainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,16 +13,22 @@ import java.util.Optional;
 public class UserSessionService {
     private final UserSessionRepository userSessionRepository;
 
-    public void create(Long userId, String hashKey, UserSession value) {
-        userSessionRepository.save(userId, hashKey, value);
+    public void create(Long userId, String domainId, UserSession value) {
+        userSessionRepository.save(userId, domainId, value);
     }
 
-    public Optional<UserSession> read(Long userId, String hashKey) throws JsonProcessingException {
-        return userSessionRepository.findUserSession(userId, hashKey);
+    public Optional<UserSession> read(Long userId, String domainId) {
+        return userSessionRepository.findUserSession(userId, domainId);
     }
 
-    public Map<String, UserSession> readAll(Long userId) throws JsonProcessingException {
+    public Map<String, UserSession> readAll(Long userId) {
         return userSessionRepository.findAllUserSessions(userId);
+    }
+
+    public boolean isExists(Long userId, String domainId) {
+        Optional<UserSession> userSession = userSessionRepository.findUserSession(userId, domainId);
+
+        return userSession.isPresent();
     }
 
     public Long getSessionTtl(Long userId, String hashKey) {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionService.java
@@ -56,6 +56,7 @@ public class UserSessionService {
 
         userSession.updateStatus(status, chatRoomId);
         userSessionRepository.save(userId, deviceId, userSession);
+        userSessionRepository.resetSessionTtl(userId, deviceId);
 
         return userSession;
     }
@@ -70,7 +71,6 @@ public class UserSessionService {
 
         userSession.updateLastActiveAt();
         userSessionRepository.save(userId, deviceId, userSession);
-
         userSessionRepository.resetSessionTtl(userId, deviceId);
     }
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserSessionService.java
@@ -1,0 +1,40 @@
+package kr.co.pennyway.domain.common.redis.session;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import kr.co.pennyway.common.annotation.DomainService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@DomainService
+@RequiredArgsConstructor
+public class UserSessionService {
+    private final UserSessionRepository userSessionRepository;
+
+    public void create(Long userId, String hashKey, UserSession value) {
+        userSessionRepository.save(userId, hashKey, value);
+    }
+
+    public Optional<UserSession> read(Long userId, String hashKey) throws JsonProcessingException {
+        return userSessionRepository.findUserSession(userId, hashKey);
+    }
+
+    public Map<String, UserSession> readAll(Long userId) throws JsonProcessingException {
+        return userSessionRepository.findAllUserSessions(userId);
+    }
+
+    public Long getSessionTtl(Long userId, String hashKey) {
+        return userSessionRepository.getSessionTtl(userId, hashKey);
+    }
+
+    public void resetSessionTtl(Long userId, String hashKey) {
+        userSessionRepository.resetSessionTtl(userId, hashKey);
+    }
+
+    public void delete(Long userId, String hashKey) {
+        userSessionRepository.delete(userId, hashKey);
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserStatus.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserStatus.java
@@ -1,4 +1,4 @@
-package kr.co.pennyway.domain.common.redis.status;
+package kr.co.pennyway.domain.common.redis.session;
 
 import kr.co.pennyway.domain.common.converter.LegacyCommonType;
 import lombok.RequiredArgsConstructor;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserStatus.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/session/UserStatus.java
@@ -1,0 +1,27 @@
+package kr.co.pennyway.domain.common.redis.status;
+
+import kr.co.pennyway.domain.common.converter.LegacyCommonType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum UserStatus implements LegacyCommonType {
+    ACTIVE_APP("1", "앱 활성화"),
+    ACTIVE_CHAT_ROOM_LIST("2", "채팅방 리스트 뷰"),
+    ACTIVE_CHAT_ROOM("3", "채팅방 뷰"),
+    BACKGROUND("4", "백그라운드"),
+    INACTIVE("5", "비활성화"),
+    ;
+
+    private final String code;
+    private final String type;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String toString() {
+        return type;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/config/RedisConfig.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package kr.co.pennyway.domain.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import kr.co.pennyway.domain.common.annotation.DomainRedisCacheManager;
 import kr.co.pennyway.domain.common.annotation.DomainRedisConnectionFactory;
 import kr.co.pennyway.domain.common.annotation.DomainRedisTemplate;
@@ -31,6 +34,7 @@ public class RedisConfig {
     private final int port;
     private final String password;
 
+
     public RedisConfig(
             @Value("${spring.data.redis.host}") String host,
             @Value("${spring.data.redis.port}") int port,
@@ -53,13 +57,13 @@ public class RedisConfig {
     @Bean
     @Primary
     @DomainRedisTemplate
-    public RedisTemplate<String, ?> redisTemplate() {
+    public RedisTemplate<String, ?> redisTemplate(ObjectMapper redisObjectMapper) {
         RedisTemplate<String, ?> template = new RedisTemplate<>();
 
         template.setConnectionFactory(redisConnectionFactory());
 
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper));
         return template;
     }
 
@@ -79,5 +83,14 @@ public class RedisConfig {
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
                 .cacheDefaults(redisCacheConfiguration)
                 .build();
+    }
+
+    @Bean
+    public ObjectMapper redisObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
+        objectMapper.registerModule(new JavaTimeModule());
+
+        return objectMapper;
     }
 }

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/session/UserSessionCustomRepositoryTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/session/UserSessionCustomRepositoryTest.java
@@ -95,6 +95,27 @@ public class UserSessionCustomRepositoryTest extends ContainerRedisTestConfig {
     }
 
     @Test
+    void existsTest() {
+        // Given
+        Long userId = 1L;
+        String hashKey = "testDevice";
+        UserSession session = UserSession.of(hashKey);
+        userSessionRepository.save(userId, hashKey, session);
+
+        // When
+        boolean exists = userSessionRepository.exists(userId, hashKey);
+
+        // Then
+        assertTrue(exists);
+
+        // When
+        boolean notExists = userSessionRepository.exists(userId, "nonExistentDevice");
+
+        // Then
+        assertFalse(notExists);
+    }
+
+    @Test
     @DisplayName("사용자 세션 삭제 테스트")
     void deleteUserSessionTest() throws JsonProcessingException {
         // given
@@ -110,7 +131,7 @@ public class UserSessionCustomRepositoryTest extends ContainerRedisTestConfig {
 
     @Test
     @DisplayName("사용자 세션 상태 업데이트 테스트 (채팅방으로 이동)")
-    void updateUserSessionStatusTest() throws JsonProcessingException {
+    void updateUserSessionStatusTest() {
         // given
         userSessionRepository.save(userId, deviceId, userSession);
 

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/session/UserSessionCustomRepositoryTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/session/UserSessionCustomRepositoryTest.java
@@ -37,13 +37,14 @@ public class UserSessionCustomRepositoryTest extends ContainerRedisTestConfig {
         userId = 1L;
         deviceId = "123456789";
         deviceName = "TestDevice";
-        userSession = UserSession.of(deviceName);
+        userSession = UserSession.of(deviceId, deviceName);
     }
 
     @Test
     @DisplayName("사용자 세션 저장 및 조회 테스트")
     void saveAndFindUserSessionTest() throws JsonProcessingException {
         // given
+        log.debug("userSession: {}", userSession);
         userSessionRepository.save(userId, deviceId, userSession);
 
         // when
@@ -62,7 +63,7 @@ public class UserSessionCustomRepositoryTest extends ContainerRedisTestConfig {
         // given
         String deviceId2 = "987654321";
         String deviceName2 = "TestDevice2";
-        UserSession userSession2 = UserSession.of(deviceName2);
+        UserSession userSession2 = UserSession.of(deviceId2, deviceName2);
         userSessionRepository.save(userId, deviceId, userSession);
         userSessionRepository.save(userId, deviceId2, userSession2);
 

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/session/UserSessionCustomRepositoryTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/session/UserSessionCustomRepositoryTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import kr.co.pennyway.domain.config.ContainerRedisTestConfig;
 import kr.co.pennyway.domain.config.RedisConfig;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -95,15 +96,13 @@ public class UserSessionCustomRepositoryTest extends ContainerRedisTestConfig {
     }
 
     @Test
+    @DisplayName("사용자 세션 존재 여부 조회 테스트")
     void existsTest() {
         // Given
-        Long userId = 1L;
-        String hashKey = "testDevice";
-        UserSession session = UserSession.of(hashKey);
-        userSessionRepository.save(userId, hashKey, session);
+        userSessionRepository.save(userId, deviceId, userSession);
 
         // When
-        boolean exists = userSessionRepository.exists(userId, hashKey);
+        boolean exists = userSessionRepository.exists(userId, deviceId);
 
         // Then
         assertTrue(exists);
@@ -163,5 +162,10 @@ public class UserSessionCustomRepositoryTest extends ContainerRedisTestConfig {
         // then
         UserSession foundSession = userSessionRepository.findUserSession(userId, deviceId).get();
         assertTrue(foundSession.getLastActiveAt().isAfter(initialLastActiveAt));
+    }
+
+    @AfterEach
+    void tearDown() {
+        userSessionRepository.delete(userId, deviceId);
     }
 }

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/session/UserSessionCustomRepositoryTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/session/UserSessionCustomRepositoryTest.java
@@ -1,0 +1,146 @@
+package kr.co.pennyway.domain.common.redis.session;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import kr.co.pennyway.domain.config.ContainerRedisTestConfig;
+import kr.co.pennyway.domain.config.RedisConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@DisplayName("사용자 세션 Redis 저장소 테스트")
+@SpringBootTest(classes = {UserSessionRepositoryImpl.class, RedisConfig.class})
+@ActiveProfiles("test")
+public class UserSessionCustomRepositoryTest extends ContainerRedisTestConfig {
+    @Autowired
+    private UserSessionRepository userSessionRepository;
+
+    private Long userId;
+    private String deviceId;
+    private String deviceName;
+    private UserSession userSession;
+
+    @BeforeEach
+    void setUp() {
+        userId = 1L;
+        deviceId = "123456789";
+        deviceName = "TestDevice";
+        userSession = UserSession.of(deviceName);
+    }
+
+    @Test
+    @DisplayName("사용자 세션 저장 및 조회 테스트")
+    void saveAndFindUserSessionTest() throws JsonProcessingException {
+        // given
+        userSessionRepository.save(userId, deviceId, userSession);
+
+        // when
+        Optional<UserSession> foundSession = userSessionRepository.findUserSession(userId, deviceId);
+
+        // then
+        log.debug("foundSession: {}", foundSession);
+        assertTrue(foundSession.isPresent());
+        assertEquals(deviceName, foundSession.get().getDeviceName());
+        assertEquals(UserStatus.ACTIVE_APP, foundSession.get().getStatus());
+    }
+
+    @Test
+    @DisplayName("모든 사용자 세션 조회 테스트")
+    void findAllUserSessionsTest() throws JsonProcessingException {
+        // given
+        String deviceId2 = "987654321";
+        String deviceName2 = "TestDevice2";
+        UserSession userSession2 = UserSession.of(deviceName2);
+        userSessionRepository.save(userId, deviceId, userSession);
+        userSessionRepository.save(userId, deviceId2, userSession2);
+
+        // when
+        Map<String, UserSession> allSessions = userSessionRepository.findAllUserSessions(userId);
+
+        // then
+        log.debug("allSessions: {}", allSessions);
+        assertThat(allSessions).hasSize(2);
+        assertTrue(allSessions.containsKey(deviceId));
+        assertTrue(allSessions.containsKey(deviceId2));
+    }
+
+    @Test
+    @DisplayName("세션 TTL 조회 및 업데이트 테스트")
+    void sessionTtlTest() throws Exception {
+        // given
+        userSessionRepository.save(userId, deviceId, userSession);
+
+        // when
+        Thread.sleep(1000); // 1초 대기
+        Long initialTtl = userSessionRepository.getSessionTtl(userId, deviceId);
+        userSessionRepository.resetSessionTtl(userId, deviceId); // 세션 초기화
+        Long updatedTtl = userSessionRepository.getSessionTtl(userId, deviceId);
+
+        // then
+        log.debug("initialTtl: {}, updatedTtl: {}", initialTtl, updatedTtl);
+        assertNotNull(initialTtl);
+        assertNotNull(updatedTtl);
+        assertTrue(updatedTtl > initialTtl); // 약간의 오차 허용
+    }
+
+    @Test
+    @DisplayName("사용자 세션 삭제 테스트")
+    void deleteUserSessionTest() throws JsonProcessingException {
+        // given
+        userSessionRepository.save(userId, deviceId, userSession);
+
+        // when
+        userSessionRepository.delete(userId, deviceId);
+
+        // then
+        Optional<UserSession> deletedSession = userSessionRepository.findUserSession(userId, deviceId);
+        assertFalse(deletedSession.isPresent());
+    }
+
+    @Test
+    @DisplayName("사용자 세션 상태 업데이트 테스트 (채팅방으로 이동)")
+    void updateUserSessionStatusTest() throws JsonProcessingException {
+        // given
+        userSessionRepository.save(userId, deviceId, userSession);
+
+        // when
+        UserSession updatedSession = userSessionRepository.findUserSession(userId, deviceId).get();
+        updatedSession.updateStatus(UserStatus.ACTIVE_CHAT_ROOM, 123L);
+        userSessionRepository.save(userId, deviceId, updatedSession);
+
+        // then
+        log.debug("updatedSession: {} to {}", userSession, updatedSession);
+        UserSession foundSession = userSessionRepository.findUserSession(userId, deviceId).get();
+        assertEquals(UserStatus.ACTIVE_CHAT_ROOM, foundSession.getStatus());
+        assertEquals(123L, foundSession.getCurrentChatRoomId());
+    }
+
+    @Test
+    @DisplayName("사용자 세션 마지막 활동 시간 업데이트 테스트")
+    void updateLastActiveAtTest() throws Exception {
+        // given
+        userSessionRepository.save(userId, deviceId, userSession);
+        LocalDateTime initialLastActiveAt = userSession.getLastActiveAt();
+
+        // when
+        Thread.sleep(1000); // 1초 대기
+        UserSession updatedSession = userSessionRepository.findUserSession(userId, deviceId).get();
+        updatedSession.updateLastActiveAt();
+        userSessionRepository.save(userId, deviceId, updatedSession);
+
+        // then
+        UserSession foundSession = userSessionRepository.findUserSession(userId, deviceId).get();
+        assertTrue(foundSession.getLastActiveAt().isAfter(initialLastActiveAt));
+    }
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/config/ContainerDBTestConfig.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/config/ContainerDBTestConfig.java
@@ -11,7 +11,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 @ActiveProfiles("test")
 public class ContainerDBTestConfig {
-    private static final String REDIS_CONTAINER_IMAGE = "redis:7.2.4-alpine";
+    private static final String REDIS_CONTAINER_IMAGE = "redis:7.4";
     private static final String MYSQL_CONTAINER_IMAGE = "mysql:8.0.26";
 
     private static final RedisContainer REDIS_CONTAINER;

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/config/ContainerRedisTestConfig.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/config/ContainerRedisTestConfig.java
@@ -8,7 +8,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @DisplayName("Container Redis 설정")
 public abstract class ContainerRedisTestConfig {
-    private static final String REDIS_CONTAINER_NAME = "redis:7.2.4-alpine";
+    private static final String REDIS_CONTAINER_NAME = "redis:7.4";
     private static final GenericContainer<?> REDIS_CONTAINER;
 
     static {

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/contants/StompNativeHeaderFields.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/contants/StompNativeHeaderFields.java
@@ -1,0 +1,17 @@
+package kr.co.pennyway.socket.common.contants;
+
+public enum StompNativeHeaderFields {
+    DEVICE_ID("device-id"),
+    DEVICE_NAME("device-name"),
+    ;
+
+    private final String value;
+
+    StompNativeHeaderFields(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/dto/StatusMessage.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/dto/StatusMessage.java
@@ -1,0 +1,22 @@
+package kr.co.pennyway.socket.common.dto;
+
+import kr.co.pennyway.domain.common.redis.session.UserStatus;
+
+import java.util.Objects;
+
+public record StatusMessage(
+        UserStatus status,
+        Long chatRoomId
+) {
+    public StatusMessage {
+        Objects.requireNonNull(status, "status must not be null");
+
+        if (status.equals(UserStatus.ACTIVE_CHAT_ROOM)) {
+            Objects.requireNonNull(chatRoomId, "chatRoomId must not be null");
+        }
+    }
+
+    public boolean isChatRoomStatus() {
+        return status.equals(UserStatus.ACTIVE_CHAT_ROOM);
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/dto/StatusMessage.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/dto/StatusMessage.java
@@ -1,6 +1,8 @@
 package kr.co.pennyway.socket.common.dto;
 
 import kr.co.pennyway.domain.common.redis.session.UserStatus;
+import kr.co.pennyway.socket.common.exception.MessageErrorCode;
+import kr.co.pennyway.socket.common.exception.MessageErrorException;
 
 import java.util.Objects;
 
@@ -9,10 +11,12 @@ public record StatusMessage(
         Long chatRoomId
 ) {
     public StatusMessage {
-        Objects.requireNonNull(status, "status must not be null");
+        if (Objects.isNull(status)) {
+            throw new MessageErrorException(MessageErrorCode.MALFORMED_MESSAGE_BODY);
+        }
 
-        if (status.equals(UserStatus.ACTIVE_CHAT_ROOM)) {
-            Objects.requireNonNull(chatRoomId, "chatRoomId must not be null");
+        if (status.equals(UserStatus.ACTIVE_CHAT_ROOM) && Objects.isNull(chatRoomId)) {
+            throw new MessageErrorException(MessageErrorCode.MALFORMED_MESSAGE_BODY);
         }
     }
 

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/event/ReceiptEvent.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/event/ReceiptEvent.java
@@ -4,16 +4,16 @@ import kr.co.pennyway.socket.common.dto.ServerSideMessage;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.messaging.Message;
 
-public class RefreshEvent<T extends ServerSideMessage> extends ApplicationEvent {
+public class ReceiptEvent<T extends ServerSideMessage> extends ApplicationEvent {
     private final Message<T> message;
 
-    private RefreshEvent(Message<T> message) {
+    private ReceiptEvent(Message<T> message) {
         super(message);
         this.message = message;
     }
 
-    public static <T extends ServerSideMessage> RefreshEvent<T> of(Message<T> message) {
-        return new RefreshEvent<>(message);
+    public static <T extends ServerSideMessage> ReceiptEvent<T> of(Message<T> message) {
+        return new ReceiptEvent<>(message);
     }
 
     public Message<T> getMessage() {

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/event/ReceiptEventHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/event/ReceiptEventHandler.java
@@ -25,7 +25,7 @@ public class ReceiptEventHandler {
 
     @Bean
     @Async
-    public CompletableFuture<ApplicationListener<RefreshEvent<ServerSideMessage>>> principalRefreshEventListener(final AbstractSubscribableChannel clientOutboundChannel) {
+    public CompletableFuture<ApplicationListener<ReceiptEvent<ServerSideMessage>>> principalRefreshEventListener(final AbstractSubscribableChannel clientOutboundChannel) {
         return CompletableFuture.completedFuture(event -> {
             Message<ServerSideMessage> message = event.getMessage();
             StompHeaderAccessor accessor = StompHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/InterceptorErrorCode.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/InterceptorErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.messaging.simp.stomp.StompCommand;
 public enum InterceptorErrorCode implements BaseErrorCode {
     // 400
     INVALID_DESTINATION(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "유효하지 않은 목적지입니다", StompCommand.SEND, StompCommand.SUBSCRIBE, StompCommand.UNSUBSCRIBE),
+    INAVLID_HEADER(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST_SYNTAX, "유효하지 않은 헤더입니다", StompCommand.CONNECT),
 
     // 403
     UNAUTHORIZED_TO_SUBSCRIBE(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "해당 주제에 대한 구독 권한이 없습니다", StompCommand.SUBSCRIBE, StompCommand.UNSUBSCRIBE),

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/MessageErrorCode.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/MessageErrorCode.java
@@ -1,0 +1,31 @@
+package kr.co.pennyway.socket.common.exception;
+
+import kr.co.pennyway.common.exception.BaseErrorCode;
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.ReasonCode;
+import kr.co.pennyway.common.exception.StatusCode;
+
+public enum MessageErrorCode implements BaseErrorCode {
+    MALFORMED_MESSAGE_BODY(StatusCode.BAD_REQUEST, ReasonCode.MALFORMED_REQUEST_BODY, "잘못된 메시지 형식입니다"),
+    ;
+
+    private final StatusCode statusCode;
+    private final ReasonCode reasonCode;
+    private final String message;
+
+    MessageErrorCode(StatusCode statusCode, ReasonCode reasonCode, String message) {
+        this.statusCode = statusCode;
+        this.reasonCode = reasonCode;
+        this.message = message;
+    }
+
+    @Override
+    public CausedBy causedBy() {
+        return CausedBy.of(statusCode, reasonCode);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldError {
+        return message;
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/MessageErrorException.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/MessageErrorException.java
@@ -1,0 +1,21 @@
+package kr.co.pennyway.socket.common.exception;
+
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.GlobalErrorException;
+
+public class MessageErrorException extends GlobalErrorException {
+    private final MessageErrorCode errorCode;
+
+    public MessageErrorException(MessageErrorCode baseErrorCode) {
+        super(baseErrorCode);
+        this.errorCode = baseErrorCode;
+    }
+
+    public CausedBy causedBy() {
+        return errorCode.causedBy();
+    }
+
+    public MessageErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/handler/inbound/ConnectAuthenticateHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/handler/inbound/ConnectAuthenticateHandler.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.socket.common.interceptor.handler.inbound;
 
 import kr.co.pennyway.domain.common.redis.session.UserSession;
 import kr.co.pennyway.domain.common.redis.session.UserSessionService;
+import kr.co.pennyway.domain.common.redis.session.UserStatus;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.service.UserService;
 import kr.co.pennyway.infra.common.exception.JwtErrorCode;
@@ -82,6 +83,12 @@ public class ConnectAuthenticateHandler implements ConnectCommandHandler {
             throw new InterceptorErrorException(InterceptorErrorCode.INAVLID_HEADER);
         }
 
-        userSessionService.create(userId, deviceId, UserSession.of(deviceName));
+        if (userSessionService.isExists(userId, deviceId)) {
+            log.info("[인증 핸들러] 사용자 세션을 업데이트합니다. userId: {}, deviceId: {}", userId, deviceId);
+            userSessionService.updateUserStatus(userId, deviceId, UserStatus.ACTIVE_APP);
+        } else {
+            log.info("[인증 핸들러] 사용자 세션을 생성합니다. userId: {}, deviceId: {}", userId, deviceId);
+            userSessionService.create(userId, deviceId, UserSession.of(deviceName));
+        }
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/handler/inbound/ConnectAuthenticateHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/handler/inbound/ConnectAuthenticateHandler.java
@@ -102,7 +102,7 @@ public class ConnectAuthenticateHandler implements ConnectCommandHandler {
             userSessionService.updateUserStatus(userId, deviceId, UserStatus.ACTIVE_APP);
         } else {
             log.info("[인증 핸들러] 사용자 세션을 생성합니다. userId: {}, deviceId: {}", userId, deviceId);
-            userSessionService.create(userId, deviceId, UserSession.of(deviceName));
+            userSessionService.create(userId, deviceId, UserSession.of(deviceId, deviceName));
         }
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/handler/inbound/DisconnectHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/handler/inbound/DisconnectHandler.java
@@ -1,0 +1,31 @@
+package kr.co.pennyway.socket.common.interceptor.handler.inbound;
+
+import kr.co.pennyway.domain.common.redis.session.UserSessionService;
+import kr.co.pennyway.domain.common.redis.session.UserStatus;
+import kr.co.pennyway.socket.common.interceptor.marker.DisconnectCommandHandler;
+import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DisconnectHandler implements DisconnectCommandHandler {
+    private final UserSessionService userSessionService;
+
+    @Override
+    public boolean isSupport(StompCommand command) {
+        return StompCommand.DISCONNECT.equals(command);
+    }
+
+    @Override
+    public void handle(Message<?> message, StompHeaderAccessor accessor) {
+        UserPrincipal principal = (UserPrincipal) accessor.getUser();
+
+        userSessionService.updateUserStatus(principal.getUserId(), principal.getDeviceId(), UserStatus.INACTIVE);
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/marker/DisconnectCommandHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/marker/DisconnectCommandHandler.java
@@ -1,0 +1,4 @@
+package kr.co.pennyway.socket.common.interceptor.marker;
+
+public interface DisconnectCommandHandler extends StompCommandHandler {
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/authenticate/UserPrincipal.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/security/authenticate/UserPrincipal.java
@@ -16,18 +16,22 @@ public class UserPrincipal implements Principal {
     private Role role;
     private boolean isChatNotify;
     private LocalDateTime expiresAt;
+    private String deviceId;
+    private String deviceName;
 
     @Builder
-    private UserPrincipal(Long userId, String name, String username, Role role, boolean isChatNotify, LocalDateTime expiresAt) {
+    private UserPrincipal(Long userId, String name, String username, Role role, boolean isChatNotify, LocalDateTime expiresAt, String deviceId, String deviceName) {
         this.userId = userId;
         this.name = name;
         this.username = username;
         this.role = role;
         this.isChatNotify = isChatNotify;
         this.expiresAt = expiresAt;
+        this.deviceId = deviceId;
+        this.deviceName = deviceName;
     }
 
-    public static UserPrincipal from(User user, LocalDateTime expiresAt) {
+    public static UserPrincipal of(User user, LocalDateTime expiresAt, String deviceId, String deviceName) {
         return UserPrincipal.builder()
                 .userId(user.getId())
                 .name(user.getName())
@@ -35,6 +39,8 @@ public class UserPrincipal implements Principal {
                 .role(user.getRole())
                 .isChatNotify(user.getNotifySetting().isChatNotify())
                 .expiresAt(expiresAt)
+                .deviceId(deviceId)
+                .deviceName(deviceName)
                 .build();
     }
 
@@ -83,7 +89,9 @@ public class UserPrincipal implements Principal {
                 ", username='" + username + '\'' +
                 ", role=" + role + '\'' +
                 ", isChatNotify=" + isChatNotify + '\'' +
-                ", expiresAt=" + expiresAt +
+                ", expiresAt=" + expiresAt + '\'' +
+                ", deviceId='" + deviceId + '\'' +
+                ", deviceName='" + deviceName + '\'' +
                 '}';
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/WebSocketMessageBrokerConfig.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/WebSocketMessageBrokerConfig.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -68,7 +69,7 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
     public void configureClientOutboundChannel(ChannelRegistration registration) {
         registration.interceptors(new ChannelInterceptor() {
             @Override
-            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+            public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
                 StompHeaderAccessor accessor = StompHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
                 log.info("Outbound message: {}", accessor);
                 return message;

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/StatusController.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/StatusController.java
@@ -1,0 +1,23 @@
+package kr.co.pennyway.socket.controller;
+
+import kr.co.pennyway.socket.common.annotation.PreAuthorize;
+import kr.co.pennyway.socket.common.dto.StatusMessage;
+import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal;
+import kr.co.pennyway.socket.service.StatusService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class StatusController {
+    private final StatusService statusService;
+
+    @MessageMapping("status.me")
+    @PreAuthorize("#isAuthenticated(#principal)")
+    public void updateStatus(UserPrincipal principal, StatusMessage message) {
+        statusService.updateStatus(principal.getUserId(), principal.getDeviceId(), message);
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/StatusController.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/StatusController.java
@@ -7,6 +7,7 @@ import kr.co.pennyway.socket.service.StatusService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
 @Slf4j
@@ -17,7 +18,7 @@ public class StatusController {
 
     @MessageMapping("status.me")
     @PreAuthorize("#isAuthenticated(#principal)")
-    public void updateStatus(UserPrincipal principal, StatusMessage message) {
-        statusService.updateStatus(principal.getUserId(), principal.getDeviceId(), message);
+    public void updateStatus(UserPrincipal principal, StatusMessage message, StompHeaderAccessor accessor) {
+        statusService.updateStatus(principal.getUserId(), principal.getDeviceId(), message, accessor);
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/AuthService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/AuthService.java
@@ -2,7 +2,7 @@ package kr.co.pennyway.socket.service;
 
 import kr.co.pennyway.infra.common.exception.JwtErrorException;
 import kr.co.pennyway.socket.common.dto.ServerSideMessage;
-import kr.co.pennyway.socket.common.event.RefreshEvent;
+import kr.co.pennyway.socket.common.event.ReceiptEvent;
 import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal;
 import kr.co.pennyway.socket.common.security.jwt.AccessTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +38,6 @@ public class AuthService {
             message = MessageBuilder.createMessage(payload, accessor.getMessageHeaders());
         }
 
-        eventPublisher.publishEvent(RefreshEvent.of(message));
+        eventPublisher.publishEvent(ReceiptEvent.of(message));
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/StatusService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/StatusService.java
@@ -32,6 +32,6 @@ public class StatusService {
         ServerSideMessage payload = ServerSideMessage.of("2000", "OK");
         Message<ServerSideMessage> response = MessageBuilder.createMessage(payload, accessor.getMessageHeaders());
 
-        publisher.publishEvent(ReceiptEvent.of(response));
+        publisher.publishEvent(ReceiptEvent.of(response)); // @FIXME: Refresh Event와 달리 Receipt가 성공적으로 처리되지 않음.
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/StatusService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/StatusService.java
@@ -1,0 +1,25 @@
+package kr.co.pennyway.socket.service;
+
+import kr.co.pennyway.domain.common.redis.session.UserSession;
+import kr.co.pennyway.domain.common.redis.session.UserSessionService;
+import kr.co.pennyway.socket.common.dto.StatusMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StatusService {
+    private final UserSessionService userSessionService;
+
+    public void updateStatus(Long userId, String deviceId, StatusMessage message) {
+        if (message.isChatRoomStatus()) {
+            UserSession session = userSessionService.updateUserStatus(userId, deviceId, message.chatRoomId());
+            log.debug("사용자 상태 변경: {}", session);
+        } else {
+            UserSession session = userSessionService.updateUserStatus(userId, deviceId, message.status());
+            log.debug("사용자 상태 변경: {}", session);
+        }
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/StatusService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/StatusService.java
@@ -2,9 +2,15 @@ package kr.co.pennyway.socket.service;
 
 import kr.co.pennyway.domain.common.redis.session.UserSession;
 import kr.co.pennyway.domain.common.redis.session.UserSessionService;
+import kr.co.pennyway.socket.common.dto.ServerSideMessage;
 import kr.co.pennyway.socket.common.dto.StatusMessage;
+import kr.co.pennyway.socket.common.event.ReceiptEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -12,8 +18,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StatusService {
     private final UserSessionService userSessionService;
+    private final ApplicationEventPublisher publisher;
 
-    public void updateStatus(Long userId, String deviceId, StatusMessage message) {
+    public void updateStatus(Long userId, String deviceId, StatusMessage message, StompHeaderAccessor accessor) {
         if (message.isChatRoomStatus()) {
             UserSession session = userSessionService.updateUserStatus(userId, deviceId, message.chatRoomId());
             log.debug("사용자 상태 변경: {}", session);
@@ -21,5 +28,10 @@ public class StatusService {
             UserSession session = userSessionService.updateUserStatus(userId, deviceId, message.status());
             log.debug("사용자 상태 변경: {}", session);
         }
+
+        ServerSideMessage payload = ServerSideMessage.of("2000", "OK");
+        Message<ServerSideMessage> response = MessageBuilder.createMessage(payload, accessor.getMessageHeaders());
+
+        publisher.publishEvent(ReceiptEvent.of(response));
     }
 }


### PR DESCRIPTION
## 작업 이유
- 클라이언트의 세션 상태를 다음과 같이 구분합니다.
- 자세한 내용은 [블로그](https://jaeseo0519.tistory.com/418)에 작성

| **상황** | **상태** | **처리** |
| --- | --- | --- |
| 사용자가 앱을 실행 중이지만, 채팅 관련 뷰(내가 가입한 채팅방 리스트 뷰 or 임의의 채팅방 뷰)를 보고 있지 않음. | ACTIVE\_APP | • 푸시 알림 |
| 사용자가 앱을 실행 중이며, 내가 가입한 채팅 리스트 뷰를 보고 있음. | ACTIVE\_CHAT\_ROOM\_LIST | • 메시지 전달 |
| 사용자가 앱을 실행 중이며, 임의의 채팅방 뷰를 보고 있음. | ACTIVE\_CHAT\_ROOM\_{chat\_room\_id} | • 메시지 전달   • 다른 채팅방 메시지는 푸시 알림 |
| 사용자가 앱을 백그라운드로 실행함.   (앱을 종료하지 않고 나가거나, 화면을 끄거나, 메뉴 화면으로 이동) | BACKGROUND | • 푸시 알림 |
| 사용자가 앱을 종료함. | INACTIVE | • 푸시 알림 |
| 사용자가 절전 모드(방해 금지 모드)를 사용함. |   | 중요 알림에 대해서는 기기 설정을 무시하고 보내거나, 배터리 잔량에 따라 동작을 조정할 필요가 있다면...?   너무 복잡한 기능이라 일단 제외 |
| 일정 시간 내 ping을 수신하지 못 함. | INACTIVE | • 푸시 알림 |
| 사용자가 로그아웃을 함. | INACTIVE | • X |
| 사용자가 회원탈퇴를 함. | 사용자 상태 제거 | • X |
| 사용자가 앱을 삭제함. | offline 유지 | • X |


<br/>

## 작업 사항
### 1️⃣ User Status
```java
@RequiredArgsConstructor
public enum UserStatus implements LegacyCommonType {
    ACTIVE_APP("1", "앱 활성화"),
    ACTIVE_CHAT_ROOM_LIST("2", "채팅방 리스트 뷰"),
    ACTIVE_CHAT_ROOM("3", "채팅방 뷰"),
    BACKGROUND("4", "백그라운드"),
    INACTIVE("5", "비활성화"),
    ;

    ...
}
```
- 사용자 상태는 총 5개로 구분합니다.  


<br/>

### 2️⃣ 사용자 세션
```java
public class UserSession implements Serializable {
    @Serial
    private static final long serialVersionUID = 1L;

    private String deviceId;
    private String deviceName;
    @Convert(converter = UserStatusConverter.class)
    private UserStatus status;
    private Long currentChatRoomId;
    private LocalDateTime lastActiveAt;

    ...
}
```
- redis에 저장되는 사용자 세션 정보는 다음과 같습니다.
   - `deviceId`, `deviceName`: 나중에 사용자 기기 FCM 토큰 식별을 위해 필요한 값.
   - `status`: 사용자의 현재 상태
   - `currentChatRoomId`: 사용자가 채팅방 뷰를 보고 있을 때, 해당 채팅방 아이디
   - `lastActiveAt`: 사용자의 메시지(박동 검사 포함)를 수신할 때마다 업데이트되는 값. 

사실 `deviceId`는 필요없을 수 있습니다.  
어차피 socket-relay에서 채팅방에 가입한 `user_id` 리스트를 통해, 각 유저의 `deviceId`를 불러올테니까요.  
그런데 UserSession에 사용자 식별 가능한 값이 하나도 없어, 일단 불안하여 추가했습니다.  

<br/>

### 3️⃣ 사용자 상태 활성화
- Connect 프레임 수신 시, 사용자의 상태를 `ACTIVE_APP`으로 전환합니다.


<br/>

###  4️⃣ 사용자 뷰 상태 추적
```java
@Slf4j
@Controller
@RequiredArgsConstructor
public class StatusController {
    private final StatusService statusService;

    @MessageMapping("status.me")
    @PreAuthorize("#isAuthenticated(#principal)")
    public void updateStatus(UserPrincipal principal, StatusMessage message, StompHeaderAccessor accessor) {
        statusService.updateStatus(principal.getUserId(), principal.getDeviceId(), message, accessor);
    }
}
```
- 사용자가 SEND 프레임을 `status.me` path로 전송하여, 상태를 변경합니다.

<br/>

### 5️⃣ 사용자 상태 비활성화
- Disconnect 프레임 수신 시, 사용자의 상태를 `INACTIVE`로 전환합니다.


<br/>

### 6️⃣ 사용자 활동 시간 업데이트
필요가 없다고 판단하여, 박동 검사에 대해 사용자 활성 시간을 갱신하는 로직은 추가하지 않았습니다.  
이유는 제 블로그에서 발췌한 고찰로 퉁치겠습니다.  

```
이 내용을 작성하다가, 생각해보니 정말 필요할까 싶어서 제외해버렸다.
 
요지는 사용자가 포그라운드에서 아무것도 안 하고, 가만히 있는 경우에 발생한다.
어떠한 뷰 이동도 없으니, 사용자의 마지막 활동 시간은 변하지 않을 것이다.
처음에는 이게 문제가 된다고 생각해서, 박동 검사를 할 때마다 활동 시간을 업데이트 하려는 interceptor를 추가하려 했다.
 
그러나 Spring WebSocket은 IEFT 권장 사항에 따라, 박동 검사 interval을 25초로 잡고 있으며
이는 모든 사용자 세션마다 25초 주기로 redis에 부하를 줘야 한다는 이야기가 된다.
 
그래서 이 시점에서 한 번 다시 생각해보게 되었는데, 사용자가 아무런 액션을 취하지 않을 때 마지막 활동 시간을 업데이트 해줘야 할 이유가 존재할까?
서비스 정책마다 다를 수 있겠지만, 내 서비스 같은 경우엔 이게 전혀 의미가 없는 행위였다.
그리고 애초에 포그라운드로 계속 냅둔다고 한들, 어쨌든 한 번이라도 백그라운드로 전환하면 상태는 알아서 바뀔 것이고, 앱을 종료해도 마찬가지.
아무런 액션도 취하지 않는 사용자의 "활동 시간을 갱신한다"라는 전제부터가 잘못 되었다고 생각하게 되었다.
 
의미도 없는데 애꿎은 redis만 괴롭힐 뻔..
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 사용자 상태를 관리하는 접근법이 적절하다고 보는지?

<br/>

## 발견한 이슈
- receipt 헤더가 존재하면, 언제나 응답을 돌려줘야 하는데, 이게 안 됨.
   - interceptor에서 clientOutboundChannel 의존성을 주입해서 해결하려 했으나, 순환 참조에 걸려서 실패......
- redis를 반드시 7.4로 업그레이드 해야합니다.
   - hash로 user session을 저장하는데, 7.4의 `HEXPIRE` 명령어가 있어야만 필드 별로 ttl을 걸 수 있습니다.
   - Lettuce에서 `HEXPIRE` 명령어를 사용할 수 있는 메서드를 제공해주지 않아, 네이티브로 처리하려고 했으나 이상한 에러가 발생합니다. 그래서 일단 Lua Script를 이용해서 처리했습니다. 
