### PR TITLE
Socket: 🐛 hash key 인자 전달 휴먼 에러 수정

### DIFF
--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/handler/inbound/ConnectAuthenticateHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/interceptor/handler/inbound/ConnectAuthenticateHandler.java
@@ -97,11 +97,13 @@ public class ConnectAuthenticateHandler implements ConnectCommandHandler {
 
     private void activateUserSession(UserPrincipal principal) {
         if (userSessionService.isExists(principal.getUserId(), principal.getDeviceId())) {
-            log.info("[인증 핸들러] 사용자 세션을 업데이트합니다. userId: {}, deviceId: {}", principal.getUserId(), principal.getDeviceId());
-            userSessionService.updateUserStatus(principal.getUserId(), principal.getDeviceName(), UserStatus.ACTIVE_APP);
+            log.info("[인증 핸들러] 사용자 세션을 갱신합니다. userId: {}, deviceId: {}", principal.getUserId(), principal.getDeviceId());
+            userSessionService.updateUserStatus(principal.getUserId(), principal.getDeviceId(), UserStatus.ACTIVE_APP);
+            log.info("[인증 핸들러] 사용자 세션을 갱신했습니다. userId: {}, deviceId: {}", principal.getUserId(), principal.getDeviceId());
         } else {
             log.info("[인증 핸들러] 사용자 세션을 생성합니다. userId: {}, deviceId: {}", principal.getUserId(), principal.getDeviceId());
             userSessionService.create(principal.getUserId(), principal.getDeviceId(), UserSession.of(principal.getDeviceId(), principal.getDeviceName()));
+            log.info("[인증 핸들러] 사용자 세션을 생성했습니다. userId: {}, deviceId: {}", principal.getUserId(), principal.getDeviceId());
         }
     }
 }


### PR DESCRIPTION
## 작업 이유
- 잘못된 인자를 전달하여, redis 쿼리 실행 오류

<br/>

## 작업 사항
- `ConnectAuthenticateHandler` 내부 `activateUserSession`에서 `deviceName`을 전달하던 것을 `deviceId`로 수정

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음

<br/>

## 발견한 이슈
- 없음

