### PR TITLE
Api: ✏️ Modify the format of chat search api

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
@@ -26,7 +26,7 @@ public interface ChatRoomApi {
     @ApiResponse(responseCode = "200", description = "가입한 채팅방 목록 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRooms", array = @ArraySchema(schema = @Schema(implementation = ChatRoomRes.Detail.class)))))
     ResponseEntity<?> getMyChatRooms(@AuthenticationPrincipal SecurityUserDetails user);
 
-    @Operation(summary = "채팅방 검색", method = "GET", description = "사용자가 가입한 채팅방 중 검색어에 일치하는 채팅방 목록을 조회한다. 검색 결과는 무한 스크롤 응답으로 반환되며, 정렬 순서는 정확도가 높은 순으로 반환된다. content 필드는 List<ChatRoomRes.Detail> 타입으로, '가입한 채팅방 목록 조회' API 응답과 동일하다.")
+    @Operation(summary = "채팅방 검색", method = "GET", description = "사용자가 가입한 채팅방 중 검색어에 일치하는 채팅방 목록을 조회한다. 검색 결과는 무한 스크롤 응답으로 반환되며, 정렬 순서는 정확도가 높은 순으로 반환된다. contents 필드는 List<ChatRoomRes.Detail> 타입으로, '가입한 채팅방 목록 조회' API 응답과 동일하다.")
     @ApiResponse(responseCode = "200", description = "채팅방 검색 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRooms", schema = @Schema(implementation = SliceResponseTemplate.class))))
     ResponseEntity<?> searchChatRooms(@Validated ChatRoomReq.SearchQuery query, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
@@ -1,6 +1,8 @@
 package kr.co.pennyway.api.apis.chat.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -27,6 +29,12 @@ public interface ChatRoomApi {
     ResponseEntity<?> getMyChatRooms(@AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "채팅방 검색", method = "GET", description = "사용자가 가입한 채팅방 중 검색어에 일치하는 채팅방 목록을 조회한다. 검색 결과는 무한 스크롤 응답으로 반환되며, 정렬 순서는 정확도가 높은 순으로 반환된다. contents 필드는 List<ChatRoomRes.Detail> 타입으로, '가입한 채팅방 목록 조회' API 응답과 동일하다.")
+    @Parameters({
+            @Parameter(name = "target", description = "검색 대상. 채팅방 제목 혹은 설명을 검색한다. 최소한 2자 이상의 문자열이어야 한다.", example = "페니웨이", required = true),
+            @Parameter(name = "page", description = "페이지 번호. 0부터 시작한다.", example = "0", required = true),
+            @Parameter(name = "size", description = "페이지 크기. 한 페이지 당 반환되는 채팅방 개수이다. 기본값으로 10개씩 반환한다."),
+            @Parameter(name = "query", hidden = true)
+    })
     @ApiResponse(responseCode = "200", description = "채팅방 검색 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRooms", schema = @Schema(implementation = SliceResponseTemplate.class))))
     ResponseEntity<?> searchChatRooms(@Validated ChatRoomReq.SearchQuery query, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomController.java
@@ -43,6 +43,6 @@ public class ChatRoomController implements ChatRoomApi {
     public ResponseEntity<?> searchChatRooms(@Validated ChatRoomReq.SearchQuery query, @AuthenticationPrincipal SecurityUserDetails user) {
         Pageable pageable = Pageable.ofSize(query.size()).withPage(query.page());
 
-        return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOMS, chatRoomUseCase.searchChatRooms(user.getUserId(), query.target(), pageable)));
+        return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOM, chatRoomUseCase.searchChatRooms(user.getUserId(), query.target(), pageable)));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomReq.java
@@ -42,8 +42,13 @@ public final class ChatRoomReq {
             String target,
             @Schema(description = "페이지 번호. 0부터 시작한다.", example = "0")
             int page,
-            @Schema(description = "페이지 크기. 한 페이지 당 반환되는 채팅방 개수이다.", example = "10")
-            int size
+            @Schema(description = "페이지 크기. 한 페이지 당 반환되는 채팅방 개수이다. 기본값으로 10개씩 반환한다.", example = "10")
+            Integer size
     ) {
+        public SearchQuery {
+            if (size == null) {
+                size = 10;
+            }
+        }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomReq.java
@@ -36,13 +36,10 @@ public final class ChatRoomReq {
     }
 
     public record SearchQuery(
-            @Schema(description = "검색 대상. 채팅방 제목 혹은 설명을 검색한다. 최소한 2자 이상의 문자열이어야 한다.", example = "페니웨이")
             @NotNull(message = "검색 대상은 NULL이 될 수 없습니다.")
             @Size(min = 2)
             String target,
-            @Schema(description = "페이지 번호. 0부터 시작한다.", example = "0")
             int page,
-            @Schema(description = "페이지 크기. 한 페이지 당 반환되는 채팅방 개수이다. 기본값으로 10개씩 반환한다.", example = "10")
             Integer size
     ) {
         public SearchQuery {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/SliceResponseTemplate.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/response/SliceResponseTemplate.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Schema(description = "페이징된 무한 스크롤 응답")
 public record SliceResponseTemplate<E>(
         @Schema(description = "응답 컨텐츠 내용")
-        List<E> content,
+        List<E> contents,
         @Schema(description = "현재 페이지 번호")
         int currentPageNumber,
         @Schema(description = "페이지 크기")
@@ -19,7 +19,7 @@ public record SliceResponseTemplate<E>(
         @Schema(description = "다음 페이지 존재 여부")
         boolean hasNext
 ) {
-    public static <E> SliceResponseTemplate<E> of(@NonNull List<E> content, @NonNull Pageable pageable, int numberOfElements, boolean hasNext) {
-        return new SliceResponseTemplate<>(content, pageable.getPageNumber(), pageable.getPageSize(), numberOfElements, hasNext);
+    public static <E> SliceResponseTemplate<E> of(@NonNull List<E> contents, @NonNull Pageable pageable, int numberOfElements, boolean hasNext) {
+        return new SliceResponseTemplate<>(contents, pageable.getPageNumber(), pageable.getPageSize(), numberOfElements, hasNext);
     }
 }


### PR DESCRIPTION
## 작업 이유
- JSend 프로토콜에 맞추어 Slice 응답 템플릿 수정
- Swagger 수정
- Sql Injection Defense  

<br/>

## 작업 사항
### 1️⃣ Slice 응답 포맷
```json
{
    "code": "",
    "data": {
        "domain": { // 복수 명사에서 단수 명사로 수정
            "contents": [ // 단수 명사에서 복수 명사로 수정

            ],
            // ... 이하 동일
        }
    }
}
```
- 새벽에 웹 프론트 팀과 이야기하다 보니, 단수/복수 명칭을 혼용하고 있는 것 같아 SliceResponseTemplate를 수정했습니다.
- 단, 해당 Template는 최근에 개발한 #181 에만 반영하고, 이전의 무한 스크롤 API들에는 반영되어 있지 않습니다. (수정하면 iOS팀에서 모두 바꿔줘야 함.)

<br/>

### 2️⃣ SQL Injection Defense
JPA는 기본적으로 SQL Injection 공격을 방어해주긴 하지만,  
JPA와 JPASQLQuery를 혼용하고 있기 때문에 혹시나 싶은 상황에 대비하여 몇 가지 키워드를 target parameter로 전달해보았습니다.  

- `;delete from chat_room where id=4;`
- `;drop table chat_room;`
- `;delete from user;`

머쓱할 정도로 잘 막아주더라구요. 허허.  
SQLQueryFactory를 사용하지 않아서, Hibernate 기반의 SQL을 실행할 수 있기 때문에 괜찮다고 판단하였습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 없음.

<br/>

## 발견한 이슈
- 없음.

