### PR TITLE
Api: ✨ Implementing Chatroom Join API: A Bounded Context Approach

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -1,0 +1,38 @@
+package kr.co.pennyway.api.apis.chat.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.apis.chat.dto.ChatMemberReq;
+import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
+import kr.co.pennyway.api.common.annotation.ApiExceptionExplanation;
+import kr.co.pennyway.api.common.annotation.ApiResponseExplanations;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "[채팅방 멤버 API]")
+public interface ChatMemberApi {
+    @Operation(summary = "채팅방 멤버 가입", method = "POST", description = "채팅방에 멤버로 가입한다.")
+    @ApiResponse(responseCode = "200", description = "채팅방 멤버 가입 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRoom", schema = @Schema(implementation = ChatRoomRes.Detail.class))))
+    @ApiResponseExplanations(errors = {
+            @ApiExceptionExplanation(value = ChatRoomErrorCode.class, constant = "INVALID_PASSWORD", summary = "비밀번호가 일치하지 않음", description = "비밀번호가 일치하지 않아 채팅방 멤버 가입에 실패했습니다."),
+            @ApiExceptionExplanation(value = ChatRoomErrorCode.class, constant = "NOT_FOUND_CHAT_ROOM", summary = "채팅방을 찾을 수 없음", description = "채팅방을 찾을 수 없어 채팅방 멤버 가입에 실패했습니다."),
+            @ApiExceptionExplanation(value = ChatRoomErrorCode.class, constant = "FULL_CHAT_ROOM", summary = "채팅방이 가득 참", description = "채팅방이 가득 차서 채팅방 멤버 가입에 실패했습니다."),
+            @ApiExceptionExplanation(value = ChatMemberErrorCode.class, constant = "BANNED", summary = "차단된 사용자", description = "차단된 사용자로 채팅방 멤버 가입에 실패했습니다."),
+            @ApiExceptionExplanation(value = ChatMemberErrorCode.class, constant = "ALREADY_JOINED", summary = "이미 가입한 사용자", description = "이미 가입한 사용자로 채팅방 멤버 가입에 실패했습니다.")
+    })
+    ResponseEntity<?> joinChatRoom(
+            @PathVariable("chatRoomId") Long chatRoomId,
+            @Validated @RequestBody ChatMemberReq.Join payload,
+            @AuthenticationPrincipal SecurityUserDetails user
+    );
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -1,6 +1,9 @@
 package kr.co.pennyway.api.apis.chat.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.SchemaProperty;
@@ -22,6 +25,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "[채팅방 멤버 API]")
 public interface ChatMemberApi {
     @Operation(summary = "채팅방 멤버 가입", method = "POST", description = "채팅방에 멤버로 가입한다.")
+    @Parameters({
+            @Parameter(name = "chatRoomId", description = "채팅방 ID", required = true, in = ParameterIn.PATH),
+            @Parameter(name = "payload", description = "채팅방 멤버 가입 요청 DTO", required = true, in = ParameterIn.DEFAULT, schema = @Schema(implementation = ChatMemberReq.Join.class))
+    })
     @ApiResponse(responseCode = "200", description = "채팅방 멤버 가입 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRoom", schema = @Schema(implementation = ChatRoomRes.Detail.class))))
     @ApiResponseExplanations(errors = {
             @ApiExceptionExplanation(value = ChatRoomErrorCode.class, constant = "INVALID_PASSWORD", summary = "비밀번호가 일치하지 않음", description = "비밀번호가 일치하지 않아 채팅방 멤버 가입에 실패했습니다."),

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.api.apis.chat.controller;
 
+import kr.co.pennyway.api.apis.chat.api.ChatMemberApi;
 import kr.co.pennyway.api.apis.chat.dto.ChatMemberReq;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
 import kr.co.pennyway.api.apis.chat.usecase.ChatMemberUseCase;
@@ -17,10 +18,11 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v2/chat-rooms/{chatRoomId}/chat-members")
-public class ChatMemberController {
+public class ChatMemberController implements ChatMemberApi {
     private static final String CHAT_ROOM = "chatRoom";
     private final ChatMemberUseCase chatMemberUseCase;
 
+    @Override
     @PostMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> joinChatRoom(

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -1,0 +1,35 @@
+package kr.co.pennyway.api.apis.chat.controller;
+
+import kr.co.pennyway.api.apis.chat.dto.ChatMemberReq;
+import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
+import kr.co.pennyway.api.apis.chat.usecase.ChatMemberUseCase;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/chat-rooms/{chatRoomId}/chat-members")
+public class ChatMemberController {
+    private static final String CHAT_ROOM = "chatRoom";
+    private final ChatMemberUseCase chatMemberUseCase;
+
+    @PostMapping("")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> joinChatRoom(
+            @PathVariable("chatRoomId") Long chatRoomId,
+            @Validated @RequestBody ChatMemberReq.Join payload,
+            @AuthenticationPrincipal SecurityUserDetails user
+    ) {
+        ChatRoomRes.Detail detail = chatMemberUseCase.joinChatRoom(user.getUserId(), chatRoomId, payload.password());
+
+        return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOM, detail));
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberReq.java
@@ -10,6 +10,9 @@ public final class ChatMemberReq {
         @Pattern(regexp = "^[0-9]{6}$", message = "채팅방 비밀번호는 6자리 정수여야 합니다.")
         private String password;
 
+        protected Join() {
+        }
+
         public Join(String password) {
             this.password = password;
         }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberReq.java
@@ -1,0 +1,17 @@
+package kr.co.pennyway.api.apis.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+
+public final class ChatMemberReq {
+    @Schema(title = "채팅방 멤버 가입 요청 DTO")
+    public static class Join {
+        @Schema(description = "채팅방 비밀번호. NULL을 허용한다. 비밀번호는 6자리 정수만 허용", example = "123456")
+        @Pattern(regexp = "^[0-9]{6}$", message = "채팅방 비밀번호는 6자리 정수여야 합니다.")
+        private String password;
+
+        public Integer password() {
+            return password != null ? Integer.valueOf(password) : null;
+        }
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberReq.java
@@ -10,6 +10,10 @@ public final class ChatMemberReq {
         @Pattern(regexp = "^[0-9]{6}$", message = "채팅방 비밀번호는 6자리 정수여야 합니다.")
         private String password;
 
+        public Join(String password) {
+            this.password = password;
+        }
+
         // 메서드 표현 일관성을 유지하고, password를 Integer로 변환하여 반환하는 getter
         public Integer password() {
             return password != null ? Integer.valueOf(password) : null;

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberReq.java
@@ -10,8 +10,14 @@ public final class ChatMemberReq {
         @Pattern(regexp = "^[0-9]{6}$", message = "채팅방 비밀번호는 6자리 정수여야 합니다.")
         private String password;
 
+        // 메서드 표현 일관성을 유지하고, password를 Integer로 변환하여 반환하는 getter
         public Integer password() {
             return password != null ? Integer.valueOf(password) : null;
+        }
+
+        // Swagger UI에서 표현하기 위한 getter
+        public String getPassword() {
+            return password;
         }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
@@ -5,11 +5,13 @@ import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorCode;
 import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorException;
 import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomService;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
 import kr.co.pennyway.domain.domains.user.service.UserService;
+import kr.co.pennyway.infra.common.event.ChatRoomJoinEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -40,8 +42,9 @@ public class ChatMemberJoinService {
         }
 
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
+        ChatMember member = chatMemberService.createMember(user, chatRoom);
 
-        chatMemberService.createMember(user, chatRoom);
+        eventPublisher.publishEvent(ChatRoomJoinEvent.of(chatRoomId, member.getName()));
     }
 
     private boolean isFullRoom(Long chatRoomId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
@@ -1,0 +1,50 @@
+package kr.co.pennyway.api.apis.chat.service;
+
+import kr.co.pennyway.domain.common.redisson.DistributedLock;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorCode;
+import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorException;
+import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomService;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMemberJoinService {
+    private static final long MAX_MEMBER_COUNT = 300;
+
+    private final UserService userService;
+    private final ChatRoomService chatRoomService;
+    private final ChatMemberService chatMemberService;
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @DistributedLock(key = "chatRoom.join.#chatRoomId")
+    public void execute(Long userId, Long chatRoomId, Integer password) {
+        ChatRoom chatRoom = chatRoomService.readChatRoom(chatRoomId).orElseThrow(() -> new ChatRoomErrorException(ChatRoomErrorCode.NOT_FOUND_CHAT_ROOM));
+
+        if (isFullRoom(chatRoomId)) {
+            throw new ChatRoomErrorException(ChatRoomErrorCode.FULL_CHAT_ROOM);
+        }
+
+        if (chatRoom.isPrivateRoom() && !chatRoom.matchPassword(password)) {
+            throw new ChatRoomErrorException(ChatRoomErrorCode.INVALID_PASSWORD);
+        }
+
+        User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
+
+        chatMemberService.createMember(user, chatRoom);
+    }
+
+    private boolean isFullRoom(Long chatRoomId) {
+        return chatMemberService.countActiveMembers(chatRoomId) >= MAX_MEMBER_COUNT;
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
@@ -39,7 +39,7 @@ public class ChatMemberJoinService {
      * @param password   Integer : 비공개 채팅방의 경우 비밀번호 정보를 입력받으며, 채팅방에 비밀번호가 없을 경우 null
      * @return Pair<ChatRoom, Integer> - 채팅방 정보와 현재 가입한 회원 수
      */
-    @DistributedLock(key = "chatRoom.join.#chatRoomId")
+    @DistributedLock(key = "'chat-room-join-' + #chatRoomId")
     public Pair<ChatRoom, Integer> execute(Long userId, Long chatRoomId, Integer password) {
         ChatRoom chatRoom = chatRoomService.readChatRoom(chatRoomId).orElseThrow(() -> new ChatRoomErrorException(ChatRoomErrorCode.NOT_FOUND_CHAT_ROOM));
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
@@ -57,7 +57,7 @@ public class ChatMemberJoinService {
 
         eventPublisher.publishEvent(ChatRoomJoinEvent.of(chatRoomId, member.getName()));
 
-        return Pair.of(chatRoom, currentMemberCount.intValue());
+        return Pair.of(chatRoom, currentMemberCount.intValue() + 1);
     }
 
     private boolean isFullRoom(Long currentMemberCount) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
@@ -45,10 +45,12 @@ public class ChatMemberJoinService {
 
         Long currentMemberCount = chatMemberService.countActiveMembers(chatRoomId);
         if (isFullRoom(currentMemberCount)) {
+            log.warn("채팅방이 가득 찼습니다. chatRoomId: {}", chatRoomId);
             throw new ChatRoomErrorException(ChatRoomErrorCode.FULL_CHAT_ROOM);
         }
 
         if (chatRoom.isPrivateRoom() && !chatRoom.matchPassword(password)) {
+            log.warn("채팅방 비밀번호가 일치하지 않습니다. chatRoomId: {}", chatRoomId);
             throw new ChatRoomErrorException(ChatRoomErrorCode.INVALID_PASSWORD);
         }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSaveService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSaveService.java
@@ -38,7 +38,7 @@ public class ChatRoomSaveService {
         ChatRoom chatRoom = chatRoomService.create(request.toEntity(chatRoomId, originImageUrl));
 
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
-        chatMemberService.createAdmin(user.getName(), user, chatRoom);
+        chatMemberService.createAdmin(user, chatRoom);
 
         return chatRoom;
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSaveService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSaveService.java
@@ -4,9 +4,7 @@ import kr.co.pennyway.api.apis.chat.dto.ChatRoomReq;
 import kr.co.pennyway.api.common.storage.AwsS3Adapter;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomService;
-import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
-import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
@@ -40,9 +38,7 @@ public class ChatRoomSaveService {
         ChatRoom chatRoom = chatRoomService.create(request.toEntity(chatRoomId, originImageUrl));
 
         User user = userService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
-        ChatMember member = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.ADMIN);
-
-        chatMemberService.create(member);
+        chatMemberService.createAdmin(user.getName(), user, chatRoom);
 
         return chatRoom;
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -1,0 +1,23 @@
+package kr.co.pennyway.api.apis.chat.usecase;
+
+import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
+import kr.co.pennyway.api.apis.chat.mapper.ChatRoomMapper;
+import kr.co.pennyway.api.apis.chat.service.ChatMemberJoinService;
+import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class ChatMemberUseCase {
+    private final ChatMemberJoinService chatMemberJoinService;
+
+    public ChatRoomRes.Detail joinChatRoom(Long userId, Long chatRoomId, Integer password) {
+        Pair<ChatRoom, Integer> chatRoom = chatMemberJoinService.execute(userId, chatRoomId, password);
+
+        return ChatRoomMapper.toChatRoomResDetail(chatRoom.getLeft(), false, chatRoom.getRight());
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/InfraConfig.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/config/InfraConfig.java
@@ -19,7 +19,8 @@ import org.springframework.context.annotation.Configuration;
 @EnablePennywayInfraConfig({
         PennywayInfraConfigGroup.FCM,
         PennywayInfraConfigGroup.DISTRIBUTED_COORDINATION_CONFIG,
-        PennywayInfraConfigGroup.GUID_GENERATOR_CONFIG
+        PennywayInfraConfigGroup.GUID_GENERATOR_CONFIG,
+        PennywayInfraConfigGroup.MESSAGE_BROKER_CONFIG
 })
 public class InfraConfig {
 }

--- a/pennyway-app-external-api/src/main/resources/application.yml
+++ b/pennyway-app-external-api/src/main/resources/application.yml
@@ -13,6 +13,10 @@ jwt:
     access-token: ${JWT_ACCESS_EXPIRATION_TIME:1800000} # 30m (30 * 60 * 1000)
     refresh-token: ${JWT_REFRESH_EXPIRATION_TIME:604800000} # 7d (7 * 24 * 60 * 60 * 1000)
 
+pennyway:
+  rabbitmq:
+    validate-connection: true
+
 ---
 spring:
   config:

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomSaveControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomSaveControllerUnitTest.java
@@ -50,7 +50,7 @@ public class ChatRoomSaveControllerUnitTest {
     @WithSecurityMockUser
     void createChatRoomSuccess() throws Exception {
         // given
-        ChatRoom fixture = ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity();
+        ChatRoom fixture = ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity(1L);
         ChatRoomReq.Create request = ChatRoomFixture.PRIVATE_CHAT_ROOM.toCreateRequest();
         given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.from(fixture, true, 1));
 
@@ -67,7 +67,7 @@ public class ChatRoomSaveControllerUnitTest {
     @WithSecurityMockUser
     void createChatRoomSuccessWithNullBackgroundImageUrl() throws Exception {
         // given
-        ChatRoom fixture = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity();
+        ChatRoom fixture = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(1L);
         ChatRoomReq.Create request = ChatRoomFixture.PUBLIC_CHAT_ROOM.toCreateRequest();
 
         given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.from(fixture, true, 1));

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatMemberJoinIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatMemberJoinIntegrationTest.java
@@ -1,0 +1,286 @@
+package kr.co.pennyway.api.apis.chat.integration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.chat.dto.ChatMemberReq;
+import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
+import kr.co.pennyway.api.common.response.ErrorResponse;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
+import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
+import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
+import kr.co.pennyway.api.config.fixture.ChatMemberFixture;
+import kr.co.pennyway.api.config.fixture.ChatRoomFixture;
+import kr.co.pennyway.api.config.fixture.UserFixture;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorCode;
+import kr.co.pennyway.domain.domains.chatroom.repository.ChatRoomRepository;
+import kr.co.pennyway.domain.domains.member.repository.ChatMemberRepository;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.repository.UserRepository;
+import kr.co.pennyway.infra.client.guid.IdGenerator;
+import kr.co.pennyway.infra.common.event.ChatRoomJoinEvent;
+import kr.co.pennyway.infra.common.event.ChatRoomJoinEventHandler;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@Slf4j
+@ExternalApiIntegrationTest
+@RecordApplicationEvents
+public class ChatMemberJoinIntegrationTest extends ExternalApiDBTestConfig {
+    private static final String BASE_URL = "/v2/chat-rooms/{chatRoomId}/chat-members";
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private ChatMemberRepository chatMemberRepository;
+
+    @Autowired
+    private JwtProvider accessTokenProvider;
+
+    @Autowired
+    private IdGenerator<Long> idGenerator;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ApplicationEvents events;
+
+    @MockBean
+    private ChatRoomJoinEventHandler chatRoomJoinEventHandler;
+
+    @LocalServerPort
+    private int port;
+
+    private String url;
+
+    @BeforeEach
+    void setUp() {
+        url = "http://localhost:" + port + BASE_URL;
+    }
+
+    @Test
+    @DisplayName("Happy Path: 공개 채팅방 가입 성공")
+    void successJoinPublicRoom() {
+        // given
+        User admin = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(idGenerator.generate()));
+        chatMemberRepository.save(ChatMemberFixture.ADMIN.toEntity(admin, chatRoom));
+
+        User user = userRepository.save(UserFixture.GENERAL_USER.toUser());
+
+        ArgumentCaptor<ChatRoomJoinEvent> eventCaptor = ArgumentCaptor.forClass(ChatRoomJoinEvent.class);
+
+        // when
+        ResponseEntity<?> response = postJoining(user, chatRoom.getId(), new ChatMemberReq.Join(null));
+
+        // then
+        assertAll(
+                () -> assertEquals(HttpStatus.OK, response.getStatusCode()),
+                () -> assertTrue(chatMemberRepository.existsByChatRoomIdAndUserId(chatRoom.getId(), user.getId())),
+                () -> verify(chatRoomJoinEventHandler).handle(eventCaptor.capture()),
+                () -> {
+                    ChatRoomJoinEvent capturedEvent = eventCaptor.getValue();
+                    assertEquals(chatRoom.getId(), capturedEvent.chatRoomId());
+                    assertEquals(user.getName(), capturedEvent.userName());
+                }
+        );
+    }
+
+    @Test
+    @DisplayName("동시에 350명의 사용자가 가입을 시도하면 정원 초과로 인해, 299명만 가입에 성공한다")
+    void concurrentJoinRequests() throws InterruptedException {
+        // given
+        User admin = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(idGenerator.generate()));
+        chatMemberRepository.save(ChatMemberFixture.ADMIN.toEntity(admin, chatRoom));
+
+        List<User> users = IntStream.range(0, 350)
+                .mapToObj(i -> userRepository.save(UserFixture.GENERAL_USER.toUser()))
+                .toList();
+
+        // when
+        CountDownLatch latch = new CountDownLatch(users.size());
+        List<CompletableFuture<JoinResult>> futures = users.stream()
+                .map(user -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        return JoinResult.from(
+                                postJoining(user, chatRoom.getId(), new ChatMemberReq.Join(null))
+                        );
+                    } finally {
+                        latch.countDown();
+                    }
+                }))
+                .toList();
+
+        latch.await();
+
+        List<JoinResult> results = futures.stream()
+                .map(CompletableFuture::join)
+                .toList();
+
+        // then
+        assertAll(
+                () -> assertEquals(299, results.stream().filter(JoinResult::isSuccess).count()),
+                () -> assertEquals(51, results.stream().filter(JoinResult::isFullRoomError).count()),
+                () -> assertEquals(300, chatMemberRepository.countByChatRoomIdAndActive(chatRoom.getId()))
+        );
+    }
+
+    @Test
+    @DisplayName("트랜잭션 롤백: 이벤트 발행 실패 시 가입도 롤백된다")
+    void rollbackWhenEventPublishFails() {
+        // given
+        User admin = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(idGenerator.generate()));
+        chatMemberRepository.save(ChatMemberFixture.ADMIN.toEntity(admin, chatRoom));
+
+        User user = userRepository.save(UserFixture.GENERAL_USER.toUser());
+
+        doThrow(new RuntimeException("Event publish failed")).when(chatRoomJoinEventHandler).handle(any(ChatRoomJoinEvent.class));
+
+        // when
+        ResponseEntity<?> response = postJoining(user, chatRoom.getId(), new ChatMemberReq.Join(null));
+
+        // then
+        assertAll(
+                () -> assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode()),
+                () -> assertFalse(chatMemberRepository.existsByChatRoomIdAndUserId(chatRoom.getId(), user.getId()))
+        );
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 가입할 수 없다")
+    void failWhenUserNotAuthenticated() {
+        // given
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(idGenerator.generate()));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // when
+        ResponseEntity<ErrorResponse> response = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                new HttpEntity<>(new ChatMemberReq.Join(null), headers),
+                new ParameterizedTypeReference<>() {
+                },
+                chatRoom.getId()
+        );
+
+        // then
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("비공개 채팅방 가입 시 올바른 비밀번호로 가입할 수 있다")
+    void successJoinPrivateRoomWithValidPassword() {
+        // given
+        User admin = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(idGenerator.generate()));
+        chatMemberRepository.save(ChatMemberFixture.ADMIN.toEntity(admin, chatRoom));
+
+        User user = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        Integer expectedPassword = ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity(idGenerator.generate()).getPassword();
+
+        // when
+        ResponseEntity<?> response = postJoining(user, chatRoom.getId(), new ChatMemberReq.Join(expectedPassword.toString()));
+
+        // then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    }
+
+    private ResponseEntity<?> postJoining(User user, Long chatRoomId, ChatMemberReq.Join request) {
+        ResponseEntity<Object> response = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                createHttpEntity(user, request),
+                Object.class,
+                chatRoomId
+        );
+
+        Object body = response.getBody();
+        if (body == null) {
+            throw new IllegalStateException("예상치 못한 반환 타입입니다. : " + response);
+        }
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            return ResponseEntity
+                    .status(response.getStatusCode())
+                    .headers(response.getHeaders())
+                    .body(objectMapper.convertValue(body, new TypeReference<SuccessResponse<Map<String, ChatRoomRes.Detail>>>() {
+                    }));
+        } else {
+            return ResponseEntity
+                    .status(response.getStatusCode())
+                    .headers(response.getHeaders())
+                    .body(objectMapper.convertValue(body, new TypeReference<ErrorResponse>() {
+                    }));
+        }
+    }
+
+    private HttpEntity<?> createHttpEntity(User user, ChatMemberReq.Join request) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessTokenProvider.generateToken(AccessTokenClaim.of(user.getId(), user.getRole().name())));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new HttpEntity<>(request, headers);
+    }
+
+    @Getter
+    private static class JoinResult {
+        private final HttpStatusCode status;
+        private final Object body;
+        private final boolean isSuccess;
+
+        private JoinResult(ResponseEntity<?> response) {
+            this.status = response.getStatusCode();
+            this.body = response.getBody();
+            this.isSuccess = status == HttpStatus.OK;
+        }
+
+        public static JoinResult from(ResponseEntity<?> response) {
+            return new JoinResult(response);
+        }
+
+        public boolean isFullRoomError() {
+            if (!isSuccess && body instanceof ErrorResponse errorResponse) {
+                return errorResponse.getCode().equals(ChatRoomErrorCode.FULL_CHAT_ROOM.causedBy().getCode());
+            }
+            return false;
+        }
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinServiceTest.java
@@ -1,6 +1,5 @@
-package kr.co.pennyway.api.apis.chat.usecase;
+package kr.co.pennyway.api.apis.chat.service;
 
-import kr.co.pennyway.api.apis.chat.service.ChatMemberJoinService;
 import kr.co.pennyway.api.config.fixture.ChatMemberFixture;
 import kr.co.pennyway.api.config.fixture.ChatRoomFixture;
 import kr.co.pennyway.api.config.fixture.UserFixture;

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberJoinServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberJoinServiceTest.java
@@ -210,11 +210,11 @@ public class ChatMemberJoinServiceTest {
     }
 
     private ChatRoom createPublicRoom() {
-        return ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity();
+        return ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(1L);
     }
 
     private ChatRoom createPrivateRoom() {
-        return ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity();
+        return ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity(1L);
     }
 
     private User createUser() {

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberJoinServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberJoinServiceTest.java
@@ -8,8 +8,10 @@ import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorCode;
 import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorException;
 import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomService;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
 import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
 import kr.co.pennyway.domain.domains.user.service.UserService;
 import kr.co.pennyway.infra.common.event.ChatRoomJoinEvent;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +20,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
@@ -31,20 +35,17 @@ import static org.mockito.Mockito.*;
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 public class ChatMemberJoinServiceTest {
+    private static final long FULL_ROOM_CAPACITY = 300L;
+    private static final long AVAILABLE_CAPACITY = 299L;
     private ChatMemberJoinService chatMemberJoinService;
-
     @Mock
     private UserService userService;
-
     @Mock
     private ChatRoomService chatRoomService;
-
     @Mock
     private ChatMemberService chatMemberService;
-
     @Mock
     private ApplicationEventPublisher eventPublisher;
-
     private Long userId = 1L;
     private Long chatRoomId = 1L;
 
@@ -57,8 +58,8 @@ public class ChatMemberJoinServiceTest {
     @DisplayName("채팅방이 가득 찼을 때 (정원 300명) 가입에 실패한다.")
     void failWhenChatRoomIsFull() {
         // given
-        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity()));
-        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(300L);
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(createPublicRoom()));
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(FULL_ROOM_CAPACITY);
 
         // when
         ChatRoomErrorException exception = assertThrows(ChatRoomErrorException.class, () -> chatMemberJoinService.execute(userId, chatRoomId, null));
@@ -72,8 +73,8 @@ public class ChatMemberJoinServiceTest {
     void failWhenPasswordIsNotMatch() {
         // given
         Integer invalidPassword = 134679;
-        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity()));
-        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(299L);
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(createPrivateRoom()));
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(AVAILABLE_CAPACITY);
 
         // when
         ChatRoomErrorException exception = assertThrows(ChatRoomErrorException.class, () -> chatMemberJoinService.execute(userId, chatRoomId, invalidPassword));
@@ -86,12 +87,12 @@ public class ChatMemberJoinServiceTest {
     @DisplayName("채팅방 수용 인원이 남아있고, 공개 채팅방이라면 비밀번호 검증을 수행하지 않는다.")
     void successWhenChatRoomIsNotFullAndPublic() {
         // given
-        ChatRoom expectedChatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity();
+        ChatRoom expectedChatRoom = createPublicRoom();
+        User expectedUser = createUser();
 
         given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(expectedChatRoom));
-        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(299L);
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(AVAILABLE_CAPACITY);
 
-        User expectedUser = UserFixture.GENERAL_USER.toUser();
         given(userService.readUser(userId)).willReturn(Optional.of(expectedUser));
         given(chatMemberService.createMember(expectedUser, expectedChatRoom)).willReturn(ChatMemberFixture.MEMBER.toEntity(expectedUser, expectedChatRoom));
 
@@ -103,23 +104,120 @@ public class ChatMemberJoinServiceTest {
     }
 
     @Test
-    @DisplayName("채팅방 수용 인원이 남이있고, 비밀번호가 일치할 때 가입에 성공한다. 이 때, 가입에 성공한 경우 채팅방 정보와 현재 가입한 회원 수를 반환한다.")
+    @DisplayName("채팅방 수용 인원이 남아있고, 비밀번호가 일치할 때 가입에 성공한다. 이 때, 가입에 성공한 경우 채팅방 정보와 현재 가입한 회원 수를 반환한다.")
     void successWhenChatRoomIsNotFullAndPasswordIsMatch() {
         // given
-        ChatRoom expectedChatRoom = ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity();
+        ChatRoom expectedChatRoom = createPrivateRoom();
+        User expectedUser = createUser();
+        ChatMember expectedMember = ChatMemberFixture.MEMBER.toEntity(expectedUser, expectedChatRoom);
         Integer validPassword = expectedChatRoom.getPassword();
-        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(expectedChatRoom));
-        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(299L);
 
-        User expectedUser = UserFixture.GENERAL_USER.toUser();
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(expectedChatRoom));
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(AVAILABLE_CAPACITY);
+
         given(userService.readUser(userId)).willReturn(Optional.of(expectedUser));
-        given(chatMemberService.createMember(expectedUser, expectedChatRoom)).willReturn(ChatMemberFixture.MEMBER.toEntity(expectedUser, expectedChatRoom));
+        given(chatMemberService.createMember(expectedUser, expectedChatRoom)).willReturn(expectedMember);
 
         // when
         Pair<ChatRoom, Integer> result = chatMemberJoinService.execute(userId, chatRoomId, validPassword);
 
         // then
-        assertNotNull(result.getLeft());
-        assertEquals(300, result.getRight());
+        assertAll(
+                () -> assertEquals(expectedChatRoom, result.getLeft()),
+                () -> assertEquals(FULL_ROOM_CAPACITY, result.getRight().longValue()),
+                () -> verify(eventPublisher, times(1)).publishEvent(any(ChatRoomJoinEvent.class))
+        );
+    }
+
+    @Test
+    @DisplayName("가입 성공 시 정확한 이벤트가 발행된다")
+    void explicitEventPublishedWhenJoinSuccess() {
+        // given
+        ChatRoom expectedChatRoom = createPrivateRoom();
+        User expectedUser = createUser();
+        ChatMember expectedMember = ChatMemberFixture.MEMBER.toEntity(expectedUser, expectedChatRoom);
+        Integer validPassword = expectedChatRoom.getPassword();
+
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(expectedChatRoom));
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(AVAILABLE_CAPACITY);
+
+        given(userService.readUser(userId)).willReturn(Optional.of(expectedUser));
+        given(chatMemberService.createMember(expectedUser, expectedChatRoom)).willReturn(expectedMember);
+
+        // when
+        chatMemberJoinService.execute(userId, chatRoomId, validPassword);
+
+        // then
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+        Object capturedEvent = eventCaptor.getValue();
+        assertInstanceOf(ChatRoomJoinEvent.class, capturedEvent);
+        ChatRoomJoinEvent joinEvent = (ChatRoomJoinEvent) capturedEvent;
+
+        assertAll(
+                () -> assertEquals(chatRoomId, joinEvent.chatRoomId()),
+                () -> assertEquals(expectedUser.getName(), joinEvent.userName())
+        );
+    }
+
+    @Test
+    @DisplayName("채팅방 가입 시 정해진 순서대로 검증이 수행된다")
+    void verifyValidationOrder() {
+        // given
+        InOrder inOrder = inOrder(chatRoomService, chatMemberService, userService);
+
+        ChatRoom expectedChatRoom = createPrivateRoom();
+        User expectedUser = createUser();
+        ChatMember expectedMember = ChatMemberFixture.MEMBER.toEntity(expectedUser, expectedChatRoom);
+        Integer validPassword = expectedChatRoom.getPassword();
+
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(expectedChatRoom));
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(AVAILABLE_CAPACITY);
+
+        given(userService.readUser(userId)).willReturn(Optional.of(expectedUser));
+        given(chatMemberService.createMember(expectedUser, expectedChatRoom)).willReturn(expectedMember);
+
+        // when
+        chatMemberJoinService.execute(userId, chatRoomId, validPassword);
+
+        // then
+        inOrder.verify(chatRoomService).readChatRoom(chatRoomId);
+        inOrder.verify(chatMemberService).countActiveMembers(chatRoomId);
+        inOrder.verify(userService).readUser(userId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 채팅방에 가입을 시도하면 실패한다")
+    void failWhenChatRoomNotFound() {
+        // given
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.empty());
+
+        // when - then
+        assertThrows(ChatRoomErrorException.class, () -> chatMemberJoinService.execute(userId, chatRoomId, null));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자가 가입을 시도하면 실패한다")
+    void failWhenUserNotFound() {
+        // given
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(createPublicRoom()));
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(AVAILABLE_CAPACITY);
+        given(userService.readUser(userId)).willReturn(Optional.empty());
+
+        // when - then
+        assertThrows(UserErrorException.class, () -> chatMemberJoinService.execute(userId, chatRoomId, null));
+    }
+
+    private ChatRoom createPublicRoom() {
+        return ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity();
+    }
+
+    private ChatRoom createPrivateRoom() {
+        return ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity();
+    }
+
+    private User createUser() {
+        return UserFixture.GENERAL_USER.toUser();
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberJoinServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberJoinServiceTest.java
@@ -1,0 +1,125 @@
+package kr.co.pennyway.api.apis.chat.usecase;
+
+import kr.co.pennyway.api.apis.chat.service.ChatMemberJoinService;
+import kr.co.pennyway.api.config.fixture.ChatMemberFixture;
+import kr.co.pennyway.api.config.fixture.ChatRoomFixture;
+import kr.co.pennyway.api.config.fixture.UserFixture;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorCode;
+import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorException;
+import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomService;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import kr.co.pennyway.infra.common.event.ChatRoomJoinEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+public class ChatMemberJoinServiceTest {
+    private ChatMemberJoinService chatMemberJoinService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private ChatRoomService chatRoomService;
+
+    @Mock
+    private ChatMemberService chatMemberService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private Long userId = 1L;
+    private Long chatRoomId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        chatMemberJoinService = new ChatMemberJoinService(userService, chatRoomService, chatMemberService, eventPublisher);
+    }
+
+    @Test
+    @DisplayName("채팅방이 가득 찼을 때 (정원 300명) 가입에 실패한다.")
+    void failWhenChatRoomIsFull() {
+        // given
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity()));
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(300L);
+
+        // when
+        ChatRoomErrorException exception = assertThrows(ChatRoomErrorException.class, () -> chatMemberJoinService.execute(userId, chatRoomId, null));
+
+        // then
+        assertEquals(ChatRoomErrorCode.FULL_CHAT_ROOM, exception.getBaseErrorCode());
+    }
+
+    @Test
+    @DisplayName("비공개 채팅방의 비밀번호가 일치하지 않을 때 가입에 실패한다.")
+    void failWhenPasswordIsNotMatch() {
+        // given
+        Integer invalidPassword = 134679;
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity()));
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(299L);
+
+        // when
+        ChatRoomErrorException exception = assertThrows(ChatRoomErrorException.class, () -> chatMemberJoinService.execute(userId, chatRoomId, invalidPassword));
+
+        // then
+        assertEquals(ChatRoomErrorCode.INVALID_PASSWORD, exception.getBaseErrorCode());
+    }
+
+    @Test
+    @DisplayName("채팅방 수용 인원이 남아있고, 공개 채팅방이라면 비밀번호 검증을 수행하지 않는다.")
+    void successWhenChatRoomIsNotFullAndPublic() {
+        // given
+        ChatRoom expectedChatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity();
+
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(expectedChatRoom));
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(299L);
+
+        User expectedUser = UserFixture.GENERAL_USER.toUser();
+        given(userService.readUser(userId)).willReturn(Optional.of(expectedUser));
+        given(chatMemberService.createMember(expectedUser, expectedChatRoom)).willReturn(ChatMemberFixture.MEMBER.toEntity(expectedUser, expectedChatRoom));
+
+        // when
+        chatMemberJoinService.execute(userId, chatRoomId, null);
+
+        // then
+        verify(eventPublisher, times(1)).publishEvent(any(ChatRoomJoinEvent.class));
+    }
+
+    @Test
+    @DisplayName("채팅방 수용 인원이 남이있고, 비밀번호가 일치할 때 가입에 성공한다. 이 때, 가입에 성공한 경우 채팅방 정보와 현재 가입한 회원 수를 반환한다.")
+    void successWhenChatRoomIsNotFullAndPasswordIsMatch() {
+        // given
+        ChatRoom expectedChatRoom = ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity();
+        Integer validPassword = expectedChatRoom.getPassword();
+        given(chatRoomService.readChatRoom(chatRoomId)).willReturn(Optional.of(expectedChatRoom));
+        given(chatMemberService.countActiveMembers(chatRoomId)).willReturn(299L);
+
+        User expectedUser = UserFixture.GENERAL_USER.toUser();
+        given(userService.readUser(userId)).willReturn(Optional.of(expectedUser));
+        given(chatMemberService.createMember(expectedUser, expectedChatRoom)).willReturn(ChatMemberFixture.MEMBER.toEntity(expectedUser, expectedChatRoom));
+
+        // when
+        Pair<ChatRoom, Integer> result = chatMemberJoinService.execute(userId, chatRoomId, validPassword);
+
+        // then
+        assertNotNull(result.getLeft());
+        assertEquals(300, result.getRight());
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/ChatMemberFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/ChatMemberFixture.java
@@ -1,0 +1,22 @@
+package kr.co.pennyway.api.config.fixture;
+
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import kr.co.pennyway.domain.domains.user.domain.User;
+
+public enum ChatMemberFixture {
+    ADMIN(ChatMemberRole.ADMIN),
+    MEMBER(ChatMemberRole.MEMBER),
+    ;
+
+    private final ChatMemberRole role;
+
+    ChatMemberFixture(ChatMemberRole role) {
+        this.role = role;
+    }
+
+    public ChatMember toEntity(User user, ChatRoom chatRoom) {
+        return ChatMember.of(user, chatRoom, this.role);
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/ChatRoomFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/ChatRoomFixture.java
@@ -19,9 +19,9 @@ public enum ChatRoomFixture {
         this.password = password;
     }
 
-    public ChatRoom toEntity() {
+    public ChatRoom toEntity(Long id) {
         return ChatRoom.builder()
-                .id(1L)
+                .id(id)
                 .title(title)
                 .description(description)
                 .backgroundImageUrl(backgroundImageUrl)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatroom/domain/ChatRoom.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatroom/domain/ChatRoom.java
@@ -76,6 +76,14 @@ public class ChatRoom extends DateAuditable {
         }
     }
 
+    public boolean isPrivateRoom() {
+        return password != null;
+    }
+
+    public boolean matchPassword(Integer password) {
+        return this.password.equals(password);
+    }
+
     @Override
     public String toString() {
         return "ChatRoom{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatroom/exception/ChatRoomErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatroom/exception/ChatRoomErrorCode.java
@@ -11,6 +11,9 @@ public enum ChatRoomErrorCode implements BaseErrorCode {
     /* 400 Bad Request */
     INVALID_PASSWORD(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "비밀번호가 일치하지 않습니다."),
 
+    /* 404 Not Found */
+    NOT_FOUND_CHAT_ROOM(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "채팅방을 찾을 수 없습니다."),
+
     /* 409 Conflict */
     FULL_CHAT_ROOM(StatusCode.CONFLICT, ReasonCode.REQUESTED_RESPONSE_FORMAT_NOT_SUPPORTED, "채팅방 인원이 가득 찼습니다."),
     ;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatroom/exception/ChatRoomErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatroom/exception/ChatRoomErrorCode.java
@@ -1,0 +1,31 @@
+package kr.co.pennyway.domain.domains.chatroom.exception;
+
+import kr.co.pennyway.common.exception.BaseErrorCode;
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.ReasonCode;
+import kr.co.pennyway.common.exception.StatusCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ChatRoomErrorCode implements BaseErrorCode {
+    /* 400 Bad Request */
+    INVALID_PASSWORD(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "비밀번호가 일치하지 않습니다."),
+
+    /* 409 Conflict */
+    FULL_CHAT_ROOM(StatusCode.CONFLICT, ReasonCode.REQUESTED_RESPONSE_FORMAT_NOT_SUPPORTED, "채팅방 인원이 가득 찼습니다."),
+    ;
+
+    private final StatusCode statusCode;
+    private final ReasonCode reasonCode;
+    private final String message;
+
+    @Override
+    public CausedBy causedBy() {
+        return CausedBy.of(statusCode, reasonCode);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldError {
+        return message;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatroom/exception/ChatRoomErrorException.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatroom/exception/ChatRoomErrorException.java
@@ -1,0 +1,21 @@
+package kr.co.pennyway.domain.domains.chatroom.exception;
+
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.GlobalErrorException;
+
+public class ChatRoomErrorException extends GlobalErrorException {
+    private final ChatRoomErrorCode chatRoomErrorCode;
+
+    public ChatRoomErrorException(ChatRoomErrorCode baseErrorCode) {
+        super(baseErrorCode);
+        this.chatRoomErrorCode = baseErrorCode;
+    }
+
+    public CausedBy causedBy() {
+        return chatRoomErrorCode.causedBy();
+    }
+
+    public String getExplainError() {
+        return chatRoomErrorCode.getExplainError();
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatroom/service/ChatRoomService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatroom/service/ChatRoomService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @DomainService
@@ -21,6 +22,11 @@ public class ChatRoomService {
     @Transactional
     public ChatRoom create(ChatRoom chatRoom) {
         return chatRoomRepository.save(chatRoom);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ChatRoom> readChatRoom(Long chatRoomId) {
+        return chatRoomRepository.findById(chatRoomId);
     }
 
     @Transactional(readOnly = true)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -79,6 +79,24 @@ public class ChatMember extends DateAuditable {
         Objects.requireNonNull(role, "role은 null이 될 수 없습니다.");
     }
 
+    /**
+     * 사용자 데이터가 삭제되었는지 확인한다.
+     *
+     * @return 삭제된 데이터가 아니면 true, 삭제된 데이터이면 false
+     */
+    public boolean isActive() {
+        return deletedAt == null;
+    }
+
+    /**
+     * 사용자 추방된 이력이 있는 지 확인한다.
+     *
+     * @return 추방된 이력이 있으면 true, 없으면 false
+     */
+    public boolean isBannedMember() {
+        return deletedAt != null && banned;
+    }
+
     @Override
     public String toString() {
         return "ChatMember{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
@@ -24,7 +23,6 @@ import java.util.Objects;
 @Table(name = "chat_member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
-@SQLRestriction("deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE chat_member SET deleted_at = NOW() WHERE id = ?")
 public class ChatMember extends DateAuditable {
     @Id

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -51,7 +51,7 @@ public class ChatMember extends DateAuditable {
     private ChatRoom chatRoom;
 
     @Builder
-    public ChatMember(String name, User user, ChatRoom chatRoom, ChatMemberRole role) {
+    protected ChatMember(String name, User user, ChatRoom chatRoom, ChatMemberRole role) {
         validate(name, user, chatRoom, role);
 
         this.name = name;
@@ -60,9 +60,9 @@ public class ChatMember extends DateAuditable {
         this.role = role;
     }
 
-    public static ChatMember of(String name, User user, ChatRoom chatRoom, ChatMemberRole role) {
+    public static ChatMember of(User user, ChatRoom chatRoom, ChatMemberRole role) {
         return ChatMember.builder()
-                .name(name)
+                .name(user.getName())
                 .user(user)
                 .chatRoom(chatRoom)
                 .role(role)

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -97,6 +97,11 @@ public class ChatMember extends DateAuditable {
         return deletedAt != null && banned;
     }
 
+    public void ban() {
+        this.banned = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
     @Override
     public String toString() {
         return "ChatMember{" +

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/exception/ChatMemberErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/exception/ChatMemberErrorCode.java
@@ -1,0 +1,31 @@
+package kr.co.pennyway.domain.domains.member.exception;
+
+import kr.co.pennyway.common.exception.BaseErrorCode;
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.ReasonCode;
+import kr.co.pennyway.common.exception.StatusCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ChatMemberErrorCode implements BaseErrorCode {
+    /* 403 FORBIDDEN */
+    BANNED(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "차단된 회원입니다."),
+
+    /* 409 Conflict */
+    ALREADY_JOINED(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 가입한 회원입니다."),
+    ;
+
+    private final StatusCode statusCode;
+    private final ReasonCode reasonCode;
+    private final String message;
+
+    @Override
+    public CausedBy causedBy() {
+        return CausedBy.of(statusCode, reasonCode);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldError {
+        return message;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/exception/ChatMemberErrorException.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/exception/ChatMemberErrorException.java
@@ -1,0 +1,21 @@
+package kr.co.pennyway.domain.domains.member.exception;
+
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.GlobalErrorException;
+
+public class ChatMemberErrorException extends GlobalErrorException {
+    private final ChatMemberErrorCode chatMemberErrorCode;
+
+    public ChatMemberErrorException(ChatMemberErrorCode baseErrorCode) {
+        super(baseErrorCode);
+        this.chatMemberErrorCode = baseErrorCode;
+    }
+
+    public CausedBy causedBy() {
+        return chatMemberErrorCode.causedBy();
+    }
+
+    public String getExplainError() {
+        return chatMemberErrorCode.getExplainError();
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
@@ -3,5 +3,8 @@ package kr.co.pennyway.domain.domains.member.repository;
 import kr.co.pennyway.domain.common.repository.ExtendedRepository;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 
+import java.util.Set;
+
 public interface ChatMemberRepository extends ExtendedRepository<ChatMember, Long>, CustomChatMemberRepository {
+    Set<ChatMember> findByChat_Room_IdAndUser_Id(Long chatRoomId, Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
@@ -2,9 +2,15 @@ package kr.co.pennyway.domain.domains.member.repository;
 
 import kr.co.pennyway.domain.common.repository.ExtendedRepository;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Set;
 
 public interface ChatMemberRepository extends ExtendedRepository<ChatMember, Long>, CustomChatMemberRepository {
     Set<ChatMember> findByChat_Room_IdAndUser_Id(Long chatRoomId, Long userId);
+
+    @Transactional(readOnly = true)
+    @Query("SELECT COUNT(*) FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.deletedAt IS NULL")
+    long countByChatRoomIdAndActive(Long chatRoomId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
@@ -8,7 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Set;
 
 public interface ChatMemberRepository extends ExtendedRepository<ChatMember, Long>, CustomChatMemberRepository {
-    Set<ChatMember> findByChat_Room_IdAndUser_Id(Long chatRoomId, Long userId);
+    @Transactional(readOnly = true)
+    Set<ChatMember> findByChatRoom_IdAndUser_Id(Long chatRoomId, Long userId);
 
     @Transactional(readOnly = true)
     @Query("SELECT COUNT(*) FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.deletedAt IS NULL")

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepository.java
@@ -1,5 +1,9 @@
 package kr.co.pennyway.domain.domains.member.repository;
 
 public interface CustomChatMemberRepository {
+    /**
+     * 채팅방에 해당 유저가 존재하는지 확인한다.
+     * 이 때, 삭제된 사용자 데이터는 조회하지 않는다.
+     */
     boolean existsByChatRoomIdAndUserId(Long chatRoomId, Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepositoryImpl.java
@@ -18,7 +18,8 @@ public class CustomChatMemberRepositoryImpl implements CustomChatMemberRepositor
         return queryFactory.select(ConstantImpl.create(1))
                 .from(chatMember)
                 .where(chatMember.chatRoom.id.eq(chatRoomId)
-                        .and(chatMember.user.id.eq(userId)))
+                        .and(chatMember.user.id.eq(userId))
+                        .and(chatMember.deletedAt.isNull()))
                 .fetchFirst() != null;
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -21,14 +21,14 @@ public class ChatMemberService {
     private final ChatMemberRepository chatMemberRepository;
 
     @Transactional
-    public ChatMember createAdmin(String nickname, User user, ChatRoom chatRoom) {
-        ChatMember chatMember = ChatMember.of(nickname, user, chatRoom, ChatMemberRole.ADMIN);
+    public ChatMember createAdmin(User user, ChatRoom chatRoom) {
+        ChatMember chatMember = ChatMember.of(user, chatRoom, ChatMemberRole.ADMIN);
 
         return chatMemberRepository.save(chatMember);
     }
 
     @Transactional
-    public ChatMember createMember(String nickname, User user, ChatRoom chatRoom) {
+    public ChatMember createMember(User user, ChatRoom chatRoom) {
         Set<ChatMember> chatMembers = chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId());
 
         if (chatMembers.stream().anyMatch(ChatMember::isActive)) {
@@ -41,7 +41,7 @@ public class ChatMemberService {
             throw new ChatMemberErrorException(ChatMemberErrorCode.BANNED);
         }
 
-        ChatMember chatMember = ChatMember.of(nickname, user, chatRoom, ChatMemberRole.MEMBER);
+        ChatMember chatMember = ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER);
 
         return chatMemberRepository.save(chatMember);
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -3,12 +3,16 @@ package kr.co.pennyway.domain.domains.member.service;
 import kr.co.pennyway.common.annotation.DomainService;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
 import kr.co.pennyway.domain.domains.member.repository.ChatMemberRepository;
 import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
 
 @Slf4j
 @DomainService
@@ -23,6 +27,29 @@ public class ChatMemberService {
         return chatMemberRepository.save(chatMember);
     }
 
+    @Transactional
+    public ChatMember createMember(String nickname, User user, ChatRoom chatRoom) {
+        Set<ChatMember> chatMembers = chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId());
+
+        if (chatMembers.stream().anyMatch(ChatMember::isActive)) {
+            log.warn("사용자는 이미 채팅방에 가입되어 있습니다. chatRoomId: {}, userId: {}", chatRoom.getId(), user.getId());
+            throw new ChatMemberErrorException(ChatMemberErrorCode.ALREADY_JOINED);
+        }
+
+        if (chatMembers.stream().anyMatch(ChatMember::isBanned)) {
+            log.warn("사용자는 채팅방에서 추방된 이력이 존재합니다. chatRoomId: {}, userId: {}", chatRoom.getId(), user.getId());
+            throw new ChatMemberErrorException(ChatMemberErrorCode.BANNED);
+        }
+
+        ChatMember chatMember = ChatMember.of(nickname, user, chatRoom, ChatMemberRole.MEMBER);
+
+        return chatMemberRepository.save(chatMember);
+    }
+
+    /**
+     * 채팅방에 해당 유저가 존재하는지 확인한다.
+     * 이 때, 삭제된 사용자 데이터는 조회하지 않는다.
+     */
     @Transactional(readOnly = true)
     public boolean isExists(Long chatRoomId, Long userId) {
         return chatMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId);

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -1,8 +1,11 @@
 package kr.co.pennyway.domain.domains.member.service;
 
 import kr.co.pennyway.common.annotation.DomainService;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.repository.ChatMemberRepository;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import kr.co.pennyway.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +17,9 @@ public class ChatMemberService {
     private final ChatMemberRepository chatMemberRepository;
 
     @Transactional
-    public ChatMember create(ChatMember chatMember) {
+    public ChatMember createAdmin(String nickname, User user, ChatRoom chatRoom) {
+        ChatMember chatMember = ChatMember.of(nickname, user, chatRoom, ChatMemberRole.ADMIN);
+
         return chatMemberRepository.save(chatMember);
     }
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -54,4 +54,9 @@ public class ChatMemberService {
     public boolean isExists(Long chatRoomId, Long userId) {
         return chatMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId);
     }
+
+    @Transactional(readOnly = true)
+    public long countActiveMembers(Long chatRoomId) {
+        return chatMemberRepository.countByChatRoomIdAndActive(chatRoomId);
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -29,7 +29,7 @@ public class ChatMemberService {
 
     @Transactional
     public ChatMember createMember(User user, ChatRoom chatRoom) {
-        Set<ChatMember> chatMembers = chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId());
+        Set<ChatMember> chatMembers = chatMemberRepository.findByChatRoom_IdAndUser_Id(chatRoom.getId(), user.getId());
 
         if (chatMembers.stream().anyMatch(ChatMember::isActive)) {
             log.warn("사용자는 이미 채팅방에 가입되어 있습니다. chatRoomId: {}, userId: {}", chatRoom.getId(), user.getId());

--- a/pennyway-domain/src/test/java/kr/co/pennyway/common/fixture/ChatRoomFixture.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/common/fixture/ChatRoomFixture.java
@@ -1,0 +1,30 @@
+package kr.co.pennyway.common.fixture;
+
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+
+public enum ChatRoomFixture {
+    PRIVATE_CHAT_ROOM("페니웨이", "페니웨이 채팅방입니다.", "delete/chatroom/1/fsdflasdfa_12121210.jpg", "123456"),
+    PUBLIC_CHAT_ROOM("페니웨이", "페니웨이 채팅방입니다.", "delete/chatroom/1/fsdflasdfa_12121210.jpg", null);
+
+    private final String title;
+    private final String description;
+    private final String backgroundImageUrl;
+    private final String password;
+
+    ChatRoomFixture(String title, String description, String backgroundImageUrl, String password) {
+        this.title = title;
+        this.description = description;
+        this.backgroundImageUrl = backgroundImageUrl;
+        this.password = password;
+    }
+
+    public ChatRoom toEntity() {
+        return ChatRoom.builder()
+                .id(1L)
+                .title(title)
+                .description(description)
+                .backgroundImageUrl(backgroundImageUrl)
+                .password(password != null ? Integer.valueOf(password) : null)
+                .build();
+    }
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/common/fixture/UserFixture.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/common/fixture/UserFixture.java
@@ -1,0 +1,49 @@
+package kr.co.pennyway.common.fixture;
+
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.type.ProfileVisibility;
+import kr.co.pennyway.domain.domains.user.type.Role;
+import lombok.Getter;
+
+@Getter
+public enum UserFixture {
+    GENERAL_USER(1L, "jayang", "dkssudgktpdy1", "Yang", "010-1111-1111", Role.USER, ProfileVisibility.PUBLIC, NotifySetting.of(true, true, true), false),
+    OAUTH_USER(2L, "only._.o", null, "Only", "010-2222-2222", Role.USER, ProfileVisibility.PUBLIC, NotifySetting.of(true, true, true), false),
+    ;
+
+    private final Long id;
+    private final String username;
+    private final String password;
+    private final String name;
+    private final String phone;
+    private final Role role;
+    private final ProfileVisibility profileVisibility;
+    private final NotifySetting notifySetting;
+    private final Boolean locked;
+
+    UserFixture(Long id, String username, String password, String name, String phone, Role role, ProfileVisibility profileVisibility, NotifySetting notifySetting, Boolean locked) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.role = role;
+        this.profileVisibility = profileVisibility;
+        this.notifySetting = notifySetting;
+        this.locked = locked;
+    }
+
+    public User toUser() {
+        return User.builder()
+                .username(username)
+                .password(password)
+                .name(name)
+                .phone(phone)
+                .role(role)
+                .profileVisibility(profileVisibility)
+                .notifySetting(notifySetting)
+                .locked(locked)
+                .build();
+    }
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/member/service/ChatMemberCreateServiceTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/member/service/ChatMemberCreateServiceTest.java
@@ -1,0 +1,109 @@
+package kr.co.pennyway.domain.domains.member.service;
+
+import kr.co.pennyway.common.fixture.ChatRoomFixture;
+import kr.co.pennyway.common.fixture.UserFixture;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
+import kr.co.pennyway.domain.domains.member.repository.ChatMemberRepository;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+public class ChatMemberCreateServiceTest {
+    @Mock
+    private ChatMemberRepository chatMemberRepository;
+    private ChatMemberService chatMemberService;
+
+    private User user;
+    private ChatRoom chatRoom;
+
+    @BeforeEach
+    void setUp() {
+        chatMemberService = new ChatMemberService(chatMemberRepository);
+        user = UserFixture.GENERAL_USER.toUser();
+        chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity();
+    }
+
+    @Test
+    @DisplayName("이미 가입한 회원은 가입에 실패한다.")
+    void createMemberWhenAlreadyExist() {
+        // given
+        ChatMember chatMember = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.MEMBER);
+        given(chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of(chatMember));
+
+        // when
+        ChatMemberErrorException exception = assertThrows(ChatMemberErrorException.class, () -> chatMemberService.createMember(user.getName(), user, chatRoom));
+
+        // then
+        assertEquals(ChatMemberErrorCode.ALREADY_JOINED, exception.getBaseErrorCode(), "에러 코드는 ALREADY_JOINED 여야 한다.");
+    }
+
+    @Test
+    @DisplayName("추방 당한 이력이 있는 회원은 가입에 실패한다.")
+    void createMemberWhenBanned() {
+        // given
+        ChatMember chatMember = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.MEMBER);
+        chatMember.ban();
+        given(chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of(chatMember));
+
+        // when
+        ChatMemberErrorException exception = assertThrows(ChatMemberErrorException.class, () -> chatMemberService.createMember(user.getName(), user, chatRoom));
+
+        // then
+        assertEquals(ChatMemberErrorCode.BANNED, exception.getBaseErrorCode(), "에러 코드는 BANNED 여야 한다.");
+    }
+
+    @Test
+    @DisplayName("가입한 이력이 없는 사용자는 가입에 성공한다.")
+    void createMemberWhenNotExist() {
+
+        // given
+        given(chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of());
+
+        ChatMember chatMember = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.MEMBER);
+        given(chatMemberRepository.save(any(ChatMember.class))).willReturn(chatMember);
+
+        // when
+        ChatMember result = chatMemberService.createMember(user.getName(), user, chatRoom);
+
+        // then
+        Assertions.assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("탈퇴한 이력이 있지만, 사유가 추방이 아니라면 가입에 성공한다.")
+    void createMemberWhenWithdrawn() {
+        // given
+        ChatMember original = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.MEMBER);
+        ReflectionTestUtils.setField(original, "deletedAt", LocalDateTime.now());
+
+        ChatMember chatMember = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.MEMBER);
+        given(chatMemberRepository.save(any(ChatMember.class))).willReturn(chatMember);
+
+        // when
+        ChatMember result = chatMemberService.createMember(user.getName(), user, chatRoom);
+
+        // then
+        Assertions.assertNotNull(result);
+    }
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/member/service/ChatMemberCreateServiceTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/member/service/ChatMemberCreateServiceTest.java
@@ -49,7 +49,7 @@ public class ChatMemberCreateServiceTest {
     void createMemberWhenAlreadyExist() {
         // given
         ChatMember chatMember = ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER);
-        given(chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of(chatMember));
+        given(chatMemberRepository.findByChatRoom_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of(chatMember));
 
         // when
         ChatMemberErrorException exception = assertThrows(ChatMemberErrorException.class, () -> chatMemberService.createMember(user, chatRoom));
@@ -64,7 +64,7 @@ public class ChatMemberCreateServiceTest {
         // given
         ChatMember chatMember = ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER);
         chatMember.ban();
-        given(chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of(chatMember));
+        given(chatMemberRepository.findByChatRoom_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of(chatMember));
 
         // when
         ChatMemberErrorException exception = assertThrows(ChatMemberErrorException.class, () -> chatMemberService.createMember(user, chatRoom));
@@ -78,7 +78,7 @@ public class ChatMemberCreateServiceTest {
     void createMemberWhenNotExist() {
 
         // given
-        given(chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of());
+        given(chatMemberRepository.findByChatRoom_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of());
 
         ChatMember chatMember = ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER);
         given(chatMemberRepository.save(any(ChatMember.class))).willReturn(chatMember);

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/member/service/ChatMemberCreateServiceTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/member/service/ChatMemberCreateServiceTest.java
@@ -48,11 +48,11 @@ public class ChatMemberCreateServiceTest {
     @DisplayName("이미 가입한 회원은 가입에 실패한다.")
     void createMemberWhenAlreadyExist() {
         // given
-        ChatMember chatMember = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.MEMBER);
+        ChatMember chatMember = ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER);
         given(chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of(chatMember));
 
         // when
-        ChatMemberErrorException exception = assertThrows(ChatMemberErrorException.class, () -> chatMemberService.createMember(user.getName(), user, chatRoom));
+        ChatMemberErrorException exception = assertThrows(ChatMemberErrorException.class, () -> chatMemberService.createMember(user, chatRoom));
 
         // then
         assertEquals(ChatMemberErrorCode.ALREADY_JOINED, exception.getBaseErrorCode(), "에러 코드는 ALREADY_JOINED 여야 한다.");
@@ -62,12 +62,12 @@ public class ChatMemberCreateServiceTest {
     @DisplayName("추방 당한 이력이 있는 회원은 가입에 실패한다.")
     void createMemberWhenBanned() {
         // given
-        ChatMember chatMember = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.MEMBER);
+        ChatMember chatMember = ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER);
         chatMember.ban();
         given(chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of(chatMember));
 
         // when
-        ChatMemberErrorException exception = assertThrows(ChatMemberErrorException.class, () -> chatMemberService.createMember(user.getName(), user, chatRoom));
+        ChatMemberErrorException exception = assertThrows(ChatMemberErrorException.class, () -> chatMemberService.createMember(user, chatRoom));
 
         // then
         assertEquals(ChatMemberErrorCode.BANNED, exception.getBaseErrorCode(), "에러 코드는 BANNED 여야 한다.");
@@ -80,11 +80,11 @@ public class ChatMemberCreateServiceTest {
         // given
         given(chatMemberRepository.findByChat_Room_IdAndUser_Id(chatRoom.getId(), user.getId())).willReturn(Set.of());
 
-        ChatMember chatMember = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.MEMBER);
+        ChatMember chatMember = ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER);
         given(chatMemberRepository.save(any(ChatMember.class))).willReturn(chatMember);
 
         // when
-        ChatMember result = chatMemberService.createMember(user.getName(), user, chatRoom);
+        ChatMember result = chatMemberService.createMember(user, chatRoom);
 
         // then
         Assertions.assertNotNull(result);
@@ -94,14 +94,14 @@ public class ChatMemberCreateServiceTest {
     @DisplayName("탈퇴한 이력이 있지만, 사유가 추방이 아니라면 가입에 성공한다.")
     void createMemberWhenWithdrawn() {
         // given
-        ChatMember original = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.MEMBER);
+        ChatMember original = ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER);
         ReflectionTestUtils.setField(original, "deletedAt", LocalDateTime.now());
 
-        ChatMember chatMember = ChatMember.of(user.getName(), user, chatRoom, ChatMemberRole.MEMBER);
+        ChatMember chatMember = ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER);
         given(chatMemberRepository.save(any(ChatMember.class))).willReturn(chatMember);
 
         // when
-        ChatMember result = chatMemberService.createMember(user.getName(), user, chatRoom);
+        ChatMember result = chatMemberService.createMember(user, chatRoom);
 
         // then
         Assertions.assertNotNull(result);

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/ChatRoomJoinEvent.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/ChatRoomJoinEvent.java
@@ -4,4 +4,7 @@ public record ChatRoomJoinEvent(
         Long chatRoomId,
         String userName
 ) {
+    public static ChatRoomJoinEvent of(Long chatRoomId, String userName) {
+        return new ChatRoomJoinEvent(chatRoomId, userName);
+    }
 }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/ChatRoomJoinEvent.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/ChatRoomJoinEvent.java
@@ -1,0 +1,7 @@
+package kr.co.pennyway.infra.common.event;
+
+public record ChatRoomJoinEvent(
+        Long chatRoomId,
+        String userName
+) {
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/ChatRoomJoinEventHandler.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/ChatRoomJoinEventHandler.java
@@ -1,0 +1,36 @@
+package kr.co.pennyway.infra.common.event;
+
+import kr.co.pennyway.infra.client.broker.MessageBrokerAdapter;
+import kr.co.pennyway.infra.common.properties.ChatExchangeProperties;
+import kr.co.pennyway.infra.common.properties.ChatJoinEventExchangeProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@EnableConfigurationProperties({ChatExchangeProperties.class, ChatJoinEventExchangeProperties.class})
+public class ChatRoomJoinEventHandler {
+    private final MessageBrokerAdapter messageBrokerAdapter;
+    private final ChatExchangeProperties chatExchangeProperties;
+    private final ChatJoinEventExchangeProperties chatJoinEventExchangeProperties;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ChatRoomJoinEvent event) {
+        log.debug("handle: {}", event);
+
+        Message<?> message = MessageBuilder.createMessage(event, null);
+
+        messageBrokerAdapter.send(
+                chatExchangeProperties.getExchange(),
+                chatJoinEventExchangeProperties.getRoutingKey(),
+                message
+        );
+    }
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/ChatRoomJoinEventHandler.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/ChatRoomJoinEventHandler.java
@@ -22,7 +22,7 @@ public class ChatRoomJoinEventHandler {
     private final ChatJoinEventExchangeProperties chatJoinEventExchangeProperties;
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handle(ChatRoomJoinEvent event) {
         log.debug("handle: {}", event);
 

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/ChatRoomJoinEventHandler.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/ChatRoomJoinEventHandler.java
@@ -5,16 +5,17 @@ import kr.co.pennyway.infra.common.properties.ChatExchangeProperties;
 import kr.co.pennyway.infra.common.properties.ChatJoinEventExchangeProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.Map;
+
 @Slf4j
 @RequiredArgsConstructor
-@EnableConfigurationProperties({ChatExchangeProperties.class, ChatJoinEventExchangeProperties.class})
 public class ChatRoomJoinEventHandler {
     private final MessageBrokerAdapter messageBrokerAdapter;
     private final ChatExchangeProperties chatExchangeProperties;
@@ -25,7 +26,7 @@ public class ChatRoomJoinEventHandler {
     public void handle(ChatRoomJoinEvent event) {
         log.debug("handle: {}", event);
 
-        Message<?> message = MessageBuilder.createMessage(event, null);
+        Message<?> message = MessageBuilder.createMessage(event, new MessageHeaders(Map.of()));
 
         messageBrokerAdapter.send(
                 chatExchangeProperties.getExchange(),

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/ChatJoinEventExchangeProperties.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/properties/ChatJoinEventExchangeProperties.java
@@ -1,0 +1,21 @@
+package kr.co.pennyway.infra.common.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "pennyway.rabbitmq.chat-join-event")
+public class ChatJoinEventExchangeProperties {
+    private final String queue;
+    private final String routingKey;
+
+    @Override
+    public String toString() {
+        return "ChatJoinEventExchangeProperties{" +
+                "queue='" + queue + '\'' +
+                ", routingKey='" + routingKey + '\'' +
+                '}';
+    }
+}

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MessageBrokerConfig.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/config/MessageBrokerConfig.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import kr.co.pennyway.infra.client.broker.MessageBrokerAdapter;
+import kr.co.pennyway.infra.common.event.ChatRoomJoinEventHandler;
 import kr.co.pennyway.infra.common.importer.PennywayInfraConfig;
 import kr.co.pennyway.infra.common.properties.ChatExchangeProperties;
 import kr.co.pennyway.infra.common.properties.ChatJoinEventExchangeProperties;
@@ -135,5 +136,10 @@ public class MessageBrokerConfig implements PennywayInfraConfig {
     @Bean
     public MessageBrokerAdapter messageBrokerAdapter(RabbitMessagingTemplate rabbitMessagingTemplate) {
         return new MessageBrokerAdapter(rabbitMessagingTemplate);
+    }
+
+    @Bean
+    public ChatRoomJoinEventHandler chatRoomJoinEventHandler(MessageBrokerAdapter messageBrokerAdapter, ChatExchangeProperties chatExchangeProperties, ChatJoinEventExchangeProperties chatJoinEventExchangeProperties) {
+        return new ChatRoomJoinEventHandler(messageBrokerAdapter, chatExchangeProperties, chatJoinEventExchangeProperties);
     }
 }

--- a/pennyway-infra/src/main/resources/application-infra.yml
+++ b/pennyway-infra/src/main/resources/application-infra.yml
@@ -60,6 +60,9 @@ pennyway:
       queue: ${RABBITMQ_CHAT_QUEUE:chat.queue}
       exchange: ${RABBITMQ_CHAT_EXCHANGE:chat.exchange}
       routing-key: ${RABBITMQ_CHAT_ROUTING:chat.room.*}
+    chat-join-event:
+      queue: ${RABBITMQ_CHAT_JOIN_QUEUE:chat.join.queue}
+      routing-key: ${RABBITMQ_CHAT_JOIN_ROUTING:chat.join.*}
 
 oauth2:
   client:

--- a/pennyway-socket/src/main/resources/application.yml
+++ b/pennyway-socket/src/main/resources/application.yml
@@ -12,6 +12,8 @@ pennyway:
     chat:
       endpoint: ${SOCKET_CHAT_ENDPOINT:/ws}
       allowed-origin-patterns: ${ALLOWED_ORIGIN_PATTERNS:*}
+  rabbitmq:
+    validate-connection: true
 
 message-broker:
   external:


### PR DESCRIPTION
## 작업 이유
- Authenticated User can join chatroom

<br/>

## 작업 사항
### 1️⃣ Domain Business Rule
- Domain Aspect
   - Password Requirements (Controller Layer): Password must be a six-digit integer. Null values are allowed for public rooms.
   - User Authentication (Security Layer): User must be authenticated.
   - Chatroom Capacity (Application Layer): Chatroom can accommodate up to 300 users
   - Password Match (Application Layer): Chatroom's password must match for entry.
   - User Validation (Domain Layer): User shouldn't be currently a member or have a ban history in the chatroom.
   - Immutability Check (Domain Layer): Fields like name and role in chat members are immutable.
   - New Join Handling (Application Layer): At the end of the service, handle the new join message within the chatroom.
   - When a user joins the chatroom, a new join message is implicitly handled within the chatroom.
- Infrastructure Aspect
   - Concurrent Join Handling: If 350 users try to join simultaneously, only the first 299 will succeed (requires Distributed Lock).
   - If the chatroom resource is committed, a message must be sent to the queue at least once. (requires transaction rollback & message broker)

<br/>

### 2️⃣ Refined Chatroom Join API with Bounded-Context Design
> If you want more details, read [my blog](https://jaeseo0519.tistory.com/420)

![image](https://github.com/user-attachments/assets/282d6585-963c-415b-b09b-c327eb119605)
- We can implement this feature in two way
   1. Implement all feature in the socket application
   2. Separate HTTP requests from socket requests.
- Choosing the first approach may violate principles of separation of concerns and bounded-context:
   - WebSocket’s role should focus on real-time message routing.
   - The creation of chat-member resources, however, is better managed through REST API.
- Consequently, Chat-member context should be handled via HTTP API, while message context should remain within the socket.

<br/>

### 3️⃣ Unit Test
- Verify Business Rules:
   - Confirm chatroom capacity limits are enforced (e.g., chatroom is full).
   - Validate the provided password is correct.
   - Ensure events are published as expected.
- Exceptional Cases:
   - Handle cases where the chatroom does not exist.
   - Address scenarios with missing user data.
   - Manage cases with incorrect passwords.

<br/>

### 4️⃣ Integration Test
- Distributed Lock Verification
   - Simultaneous room join scenario.
   - Confirm correct lock acquisition and release.
- Transaction Verification
   - Test rollback functionality.
   - Ensure data consistency.
- Flow Verification
   - Test happy path scenarios.
   - Verify real data is saved and received as expected.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
![image](https://github.com/user-attachments/assets/8cb629cb-a6d9-4c6f-aece-645ab452bdf9)
![image](https://github.com/user-attachments/assets/ca5f23eb-8d05-45b2-9333-8b41a18d6abe)

- I mapped out a design as though we have a socket-relay module, but it’s purely conceptual at this point.
   - This is because our server lacks sufficient memory for a full implementation. 😂
   - Therefore, I’ll proceed by implementing this feature within the socket application itself.
- The remaining, unrelated tasks will be deferred to the next stage for completion (ex. socket-relay module)

<br/>

## 발견한 이슈
- When testing `ApplicationEventPublisher` and `EventHandler` using mocks in an integration test, `@RecordingEvents` and `verify()` cannot be used directly.
   - This is because `ApplicationEventPublishe`r is part of the Spring context itself, meaning `@MockBean` won’t work in this instance.
   - Therefore, `ApplicationEventPublisher` cannot act as a mock instance.
   - Additionally, when you mock event handlers, `ApplicationEvents` will not accurately capture event counts.
   - Instead, an alternative approach should be used for event capture.
      ```java
        ArgumentCaptor<ChatRoomJoinEvent> eventCaptor = ArgumentCaptor.forClass(ChatRoomJoinEvent.class);

        // when
        ResponseEntity<?> response = postJoining(user, chatRoom.getId(), new ChatMemberReq.Join(null));

        // then
        assertAll(
                () -> assertEquals(HttpStatus.OK, response.getStatusCode()),
                () -> assertTrue(chatMemberRepository.existsByChatRoomIdAndUserId(chatRoom.getId(), user.getId())),
                () -> verify(chatRoomJoinEventHandler).handle(eventCaptor.capture()),
                () -> {
                    ChatRoomJoinEvent capturedEvent = eventCaptor.getValue();
                    assertEquals(chatRoom.getId(), capturedEvent.chatRoomId());
                    assertEquals(user.getName(), capturedEvent.userName());
                }
        );
      ```

