### PR TITLE
Socket: ✨ Send Chat Message Usecase

### DIFF
--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/domain/ChatMessage.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/domain/ChatMessage.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
  * Redis에 저장되는 채팅 메시지의 기본 단위입니다.
  */
 @Getter
-@RedisHash
+@RedisHash(value = "chatroom")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage {
     /**
@@ -36,7 +36,7 @@ public class ChatMessage {
     private Long sender;
 
     protected ChatMessage(ChatMessageBuilder builder) {
-        this.id = "chatroom:" + builder.getChatRoomId() + ":message:" + builder.getChatId();
+        this.id = builder.getChatRoomId() + ":message:" + builder.getChatId();
         this.content = builder.getContent();
         this.contentType = builder.getContentType();
         this.categoryType = builder.getCategoryType();

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/domain/ChatMessage.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/domain/ChatMessage.java
@@ -46,11 +46,11 @@ public class ChatMessage {
     }
 
     public Long getChatRoomId() {
-        return Long.parseLong(id.split(":")[1]);
+        return Long.parseLong(id.split(":")[0]);
     }
 
     public Long getChatId() {
-        return Long.parseLong(id.split(":")[3]);
+        return Long.parseLong(id.split(":")[2]);
     }
 
     @Override

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryTest.java
@@ -56,7 +56,7 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
         log.info("Saved message: {}", savedMessage);
         assertAll(
                 () -> assertNotNull(savedMessage, "저장된 메시지는 null이 아니어야 합니다"),
-                () -> assertTrue(savedMessage.getId().matches("chatroom:\\d+:message:\\d+"), "ID는 'chatroom:{roomId}:message:{messageId}' 형태여야 합니다"),
+                () -> assertTrue(savedMessage.getId().matches("\\d+:message:\\d+"), "ID는 'chatroom:{roomId}:message:{messageId}' 형태여야 합니다 ('chatroom:'은 hash key로 제외)"),
                 () -> assertEquals(chatMessage.getId(), savedMessage.getId(), "저장 전후의 ID가 동일해야 합니다")
         );
     }

--- a/pennyway-socket/build.gradle
+++ b/pennyway-socket/build.gradle
@@ -28,4 +28,6 @@ dependencies {
 
     /* jackson */
     implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.2.3'
 }

--- a/pennyway-socket/build.gradle
+++ b/pennyway-socket/build.gradle
@@ -25,4 +25,7 @@ dependencies {
 
     /* RabbitMQ (for listener) */
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-amqp', version: '3.3.4'
+
+    /* jackson */
+    implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/command/SendMessageCommand.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/command/SendMessageCommand.java
@@ -8,11 +8,11 @@ import kr.co.pennyway.socket.common.constants.SystemMessageConstants;
  * 채팅 메시지 전송을 위한 Command 클래스
  */
 public record SendMessageCommand(
-        long chatRoomId, // 채팅방 아이디는 음수일 수 없다.
-        String content, // 메시지 내용은 5000자를 초과할 수 없다.
-        MessageContentType contentType, // 메시지 타입은 NULL일 수 없다.
-        MessageCategoryType categoryType, // 메시지 카테고리는 NULL일 수 없다.
-        long senderId // 발신자 아이디는 음수일 수 없다.
+        long chatRoomId,
+        String content,
+        MessageContentType contentType,
+        MessageCategoryType categoryType,
+        long senderId
 ) {
     public SendMessageCommand {
         if (chatRoomId <= 0) {

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/command/SendMessageCommand.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/command/SendMessageCommand.java
@@ -1,4 +1,4 @@
-package kr.co.pennyway.socket.dto;
+package kr.co.pennyway.socket.command;
 
 import kr.co.pennyway.domain.common.redis.message.type.MessageCategoryType;
 import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.java
@@ -20,7 +20,7 @@ public class ChatMessageController {
 
     @MessageMapping("chat.message.{chatRoomId}")
     @PreAuthorize("#isAuthenticated(#principal) and @chatRoomAccessChecker.hasPermission(#chatRoomId, #principal)")
-    public void sendMessage(@DestinationVariable Long chatRoomId, @Validated ChatMessageDto payload, UserPrincipal principal) {
+    public void sendMessage(@DestinationVariable Long chatRoomId, @Validated ChatMessageDto.Request payload, UserPrincipal principal) {
         chatMessageSendService.execute(SendMessageCommand.createUserMessage(chatRoomId, payload.content(), payload.contentType(), principal.getUserId()));
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.java
@@ -1,0 +1,26 @@
+package kr.co.pennyway.socket.controller;
+
+import kr.co.pennyway.socket.command.SendMessageCommand;
+import kr.co.pennyway.socket.common.annotation.PreAuthorize;
+import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal;
+import kr.co.pennyway.socket.dto.ChatMessageDto;
+import kr.co.pennyway.socket.service.ChatMessageSendService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+    private final ChatMessageSendService chatMessageSendService;
+
+    @MessageMapping("chat.message.{chatRoomId}")
+    @PreAuthorize("#isAuthenticated(#principal) and @chatRoomAccessChecker.hasPermission(#chatRoomId, #principal)")
+    public void sendMessage(@DestinationVariable Long chatRoomId, @Validated ChatMessageDto payload, UserPrincipal principal) {
+        chatMessageSendService.execute(SendMessageCommand.createUserMessage(chatRoomId, payload.content(), payload.contentType(), principal.getUserId()));
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/dto/ChatMessageDto.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/dto/ChatMessageDto.java
@@ -1,14 +1,47 @@
 package kr.co.pennyway.socket.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
+import kr.co.pennyway.domain.common.redis.message.type.MessageCategoryType;
 import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;
 
-public record ChatMessageDto(
-        @NotNull(message = "메시지 내용은 null을 허용하지 않습니다.")
-        @Size(min = 1, max = 1000, message = "메시지 내용은 1자 이상 1000자 이하로 입력해주세요.")
-        String content,
-        @NotNull(message = "메시지 타입은 null을 허용하지 않습니다.")
-        MessageContentType contentType
-) {
+import java.time.LocalDateTime;
+
+public final class ChatMessageDto {
+    public record Request(
+            @NotNull(message = "메시지 내용은 null을 허용하지 않습니다.")
+            @Size(min = 1, max = 1000, message = "메시지 내용은 1자 이상 1000자 이하로 입력해주세요.")
+            String content,
+            @NotNull(message = "메시지 타입은 null을 허용하지 않습니다.")
+            MessageContentType contentType
+    ) {
+    }
+
+    public record Response(
+            Long chatRoomId,
+            Long chatId,
+            String content,
+            MessageContentType contentType,
+            MessageCategoryType categoryType,
+            @JsonSerialize(using = LocalDateTimeSerializer.class)
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt,
+            Long senderId
+    ) {
+        public static Response from(ChatMessage message) {
+            return new Response(
+                    message.getChatRoomId(),
+                    message.getChatId(),
+                    message.getContent(),
+                    message.getContentType(),
+                    message.getCategoryType(),
+                    message.getCreatedAt(),
+                    message.getSender()
+            );
+        }
+    }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/dto/ChatMessageDto.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/dto/ChatMessageDto.java
@@ -1,0 +1,9 @@
+package kr.co.pennyway.socket.dto;
+
+import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;
+
+public record ChatMessageDto(
+        String content,
+        MessageContentType contentType
+) {
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/dto/ChatMessageDto.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/dto/ChatMessageDto.java
@@ -1,9 +1,14 @@
 package kr.co.pennyway.socket.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;
 
 public record ChatMessageDto(
+        @NotNull(message = "메시지 내용은 null을 허용하지 않습니다.")
+        @Size(min = 1, max = 1000, message = "메시지 내용은 1자 이상 1000자 이하로 입력해주세요.")
         String content,
+        @NotNull(message = "메시지 타입은 null을 허용하지 않습니다.")
         MessageContentType contentType
 ) {
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/relay/ChatJoinEventListener.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/relay/ChatJoinEventListener.java
@@ -27,7 +27,7 @@ public class ChatJoinEventListener {
             containerFactory = "simpleRabbitListenerContainerFactory",
             bindings = @QueueBinding(
                     value = @Queue("${pennyway.rabbitmq.chat-join-event.queue}"),
-                    exchange = @Exchange(value = "${pennyway.rabbitmq.chat.exchange}"),
+                    exchange = @Exchange(value = "${pennyway.rabbitmq.chat.exchange}", type = "topic"),
                     key = "${pennyway.rabbitmq.chat-join-event.routing-key}"
             )
     )

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/relay/ChatJoinEventListener.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/relay/ChatJoinEventListener.java
@@ -19,8 +19,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @EnableConfigurationProperties({ChatExchangeProperties.class})
 public class ChatJoinEventListener {
-    private static final String JOIN_MESSAGE_SUFFIX = "님이 입장하셨습니다.";
-
     private final ChatMessageSendService chatMessageSendService;
 
     @RabbitListener(

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/relay/ChatJoinEventListener.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/relay/ChatJoinEventListener.java
@@ -2,8 +2,8 @@ package kr.co.pennyway.socket.relay;
 
 import kr.co.pennyway.infra.common.event.ChatRoomJoinEvent;
 import kr.co.pennyway.infra.common.properties.ChatExchangeProperties;
+import kr.co.pennyway.socket.command.SendMessageCommand;
 import kr.co.pennyway.socket.common.constants.SystemMessageTemplate;
-import kr.co.pennyway.socket.dto.SendMessageCommand;
 import kr.co.pennyway.socket.service.ChatMessageSendService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.java
@@ -6,7 +6,7 @@ import kr.co.pennyway.domain.common.redis.message.service.ChatMessageService;
 import kr.co.pennyway.infra.client.broker.MessageBrokerAdapter;
 import kr.co.pennyway.infra.client.guid.IdGenerator;
 import kr.co.pennyway.infra.common.properties.ChatExchangeProperties;
-import kr.co.pennyway.socket.dto.SendMessageCommand;
+import kr.co.pennyway.socket.command.SendMessageCommand;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.java
@@ -7,6 +7,7 @@ import kr.co.pennyway.infra.client.broker.MessageBrokerAdapter;
 import kr.co.pennyway.infra.client.guid.IdGenerator;
 import kr.co.pennyway.infra.common.properties.ChatExchangeProperties;
 import kr.co.pennyway.socket.command.SendMessageCommand;
+import kr.co.pennyway.socket.dto.ChatMessageDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -37,13 +38,13 @@ public class ChatMessageSendService {
                 .categoryType(command.categoryType())
                 .sender(command.senderId())
                 .build();
-
-        chatMessageService.save(message);
+        
+        ChatMessageDto.Response response = ChatMessageDto.Response.from(chatMessageService.save(message));
 
         messageBrokerAdapter.convertAndSend(
                 chatExchangeProperties.getExchange(),
                 "chat.room." + command.chatRoomId(),
-                message
+                response
         );
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.java
@@ -38,8 +38,9 @@ public class ChatMessageSendService {
                 .categoryType(command.categoryType())
                 .sender(command.senderId())
                 .build();
+        message = chatMessageService.save(message);
         
-        ChatMessageDto.Response response = ChatMessageDto.Response.from(chatMessageService.save(message));
+        ChatMessageDto.Response response = ChatMessageDto.Response.from(message);
 
         messageBrokerAdapter.convertAndSend(
                 chatExchangeProperties.getExchange(),


### PR DESCRIPTION
## 작업 이유
- Authenticated user can send message using Socket API

<br/>

## 작업 사항
### 1️⃣ Chat Message Sending Flow
```json
{
   "content": "" // Required; max length: 5,000 characters
   "contentType": "" // Must match `MessageContentType` capitalization
}
```
- `SEND /pub/chat.message.{chatRoomId}`

<br/>

### 2️⃣ Fix `chat_message` Redis Key Format

![image](https://github.com/user-attachments/assets/73b73bfa-aac3-4518-a55b-9c50b41cc329)

- Intended format: `chatroom:{chatroom_id}:message:{message_id}`, but was saved with `{classpath}:` prefix.
- Cause: `@RedisHash` lacked a specified value, defaulting to the classpath.

![image](https://github.com/user-attachments/assets/2b816fd0-ed62-4a55-bb09-a9de602449b0)

- Update successfully validated.

<br/>

### 3️⃣ Refactor response message type to external message brocker
- Switched from entity to DTO for RabbitMQ serialization convenience.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- When Socket application is running, output `Shutdown Signal: channel error; protocol method: #method<channel.close>(reply-code=406, reply-text=PRECONDITION_FAILED - inequivalent arg 'type' for exchange 'chat.exchange' in vhost '/': received 'direct' but current is 'topic', class-id=40, method-id=10)` logs.
   - This results from an unassigned exchange type in `@RabbitListener.` 😅 (It's fixed now)

<br/>

## 발견한 이슈
- Not thing.

