### PR TITLE
Ignore: ✨ Fetch Summary of Chatrooms Joined by User

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "[채팅방 API]")
 public interface ChatRoomApi {
@@ -25,8 +26,9 @@ public interface ChatRoomApi {
     ResponseEntity<?> createChatRoom(@RequestBody ChatRoomReq.Create request, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "가입한 채팅방 목록 조회", method = "GET", description = "사용자가 가입한 채팅방 목록을 조회하며, 정렬 순서는 보장하지 않는다. 최근 활성화된 채팅방의 순서를 지정할 방법에 대해 추가 개선이 필요한 API이므로, 추후 기능이 일부 수정될 수도 있다.")
+    @Parameter(name = "summary", description = "채팅방 요약 정보 조회 여부. true로 설정하면 채팅방의 상세 정보가 chatRoomIds 필드만 반환된다. (default=false)", example = "false")
     @ApiResponse(responseCode = "200", description = "가입한 채팅방 목록 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRooms", array = @ArraySchema(schema = @Schema(implementation = ChatRoomRes.Detail.class)))))
-    ResponseEntity<?> getMyChatRooms(@AuthenticationPrincipal SecurityUserDetails user);
+    ResponseEntity<?> getMyChatRooms(@RequestParam(name = "summary", required = false, defaultValue = "false") boolean query, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "채팅방 검색", method = "GET", description = "사용자가 가입한 채팅방 중 검색어에 일치하는 채팅방 목록을 조회한다. 검색 결과는 무한 스크롤 응답으로 반환되며, 정렬 순서는 정확도가 높은 순으로 반환된다. contents 필드는 List<ChatRoomRes.Detail> 타입으로, '가입한 채팅방 목록 조회' API 응답과 동일하다.")
     @Parameters({

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomController.java
@@ -35,7 +35,7 @@ public class ChatRoomController implements ChatRoomApi {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getMyChatRooms(@RequestParam(name = "summary", required = false, defaultValue = "false") boolean isSummary, @AuthenticationPrincipal SecurityUserDetails user) {
         if (isSummary) {
-            return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOMS, chatRoomUseCase.readJoinedChatRoomIds(user.getUserId())));
+            return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOM, chatRoomUseCase.readJoinedChatRoomIds(user.getUserId())));
         }
 
         return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOMS, chatRoomUseCase.getChatRooms(user.getUserId())));

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomController.java
@@ -33,7 +33,11 @@ public class ChatRoomController implements ChatRoomApi {
     @Override
     @GetMapping("/me")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> getMyChatRooms(@AuthenticationPrincipal SecurityUserDetails user) {
+    public ResponseEntity<?> getMyChatRooms(@RequestParam(name = "summary", required = false, defaultValue = "false") boolean isSummary, @AuthenticationPrincipal SecurityUserDetails user) {
+        if (isSummary) {
+            return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOMS, chatRoomUseCase.readJoinedChatRoomIds(user.getUserId())));
+        }
+
         return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOMS, chatRoomUseCase.getChatRooms(user.getUserId())));
     }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -8,6 +8,7 @@ import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.Set;
 
 public final class ChatRoomRes {
     @Schema(description = "채팅방 상세 정보")
@@ -54,5 +55,12 @@ public final class ChatRoomRes {
                     chatRoom.getCreatedAt()
             );
         }
+    }
+
+    @Schema(description = "채팅방 요약 정보")
+    public record Summary(
+            @Schema(description = "채팅방 ID 목록. 빈 목록일 경우 빈 배열이 반환된다. 각 요소는 long 타입이다.")
+            Set<Long> chatRoomIds
+    ) {
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberSearchService.java
@@ -1,0 +1,19 @@
+package kr.co.pennyway.api.apis.chat.service;
+
+import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMemberSearchService {
+    private final ChatMemberService chatMemberService;
+
+    public Set<Long> readJoinedChatRoomIds(Long userId) {
+        return chatMemberService.readChatRoomIdsByUserId(userId);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.api.apis.chat.usecase;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomReq;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
 import kr.co.pennyway.api.apis.chat.mapper.ChatRoomMapper;
+import kr.co.pennyway.api.apis.chat.service.ChatMemberSearchService;
 import kr.co.pennyway.api.apis.chat.service.ChatRoomSaveService;
 import kr.co.pennyway.api.apis.chat.service.ChatRoomSearchService;
 import kr.co.pennyway.api.common.response.SliceResponseTemplate;
@@ -14,12 +15,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
+import java.util.Set;
 
 @UseCase
 @RequiredArgsConstructor
 public class ChatRoomUseCase {
     private final ChatRoomSaveService chatRoomSaveService;
     private final ChatRoomSearchService chatRoomSearchService;
+
+    private final ChatMemberSearchService chatMemberSearchService;
 
     public ChatRoomRes.Detail createChatRoom(ChatRoomReq.Create request, Long userId) {
         ChatRoom chatRoom = chatRoomSaveService.createChatRoom(request, userId);
@@ -31,6 +35,12 @@ public class ChatRoomUseCase {
         List<ChatRoomDetail> chatRooms = chatRoomSearchService.readChatRooms(userId);
 
         return ChatRoomMapper.toChatRoomResDetails(chatRooms);
+    }
+
+    public ChatRoomRes.Summary readJoinedChatRoomIds(Long userId) {
+        Set<Long> chatRoomIds = chatMemberSearchService.readJoinedChatRoomIds(userId);
+
+        return new ChatRoomRes.Summary(chatRoomIds);
     }
 
     public SliceResponseTemplate<ChatRoomRes.Detail> searchChatRooms(Long userId, String target, Pageable pageable) {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
@@ -14,4 +14,8 @@ public interface ChatMemberRepository extends ExtendedRepository<ChatMember, Lon
     @Transactional(readOnly = true)
     @Query("SELECT COUNT(*) FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.deletedAt IS NULL")
     long countByChatRoomIdAndActive(Long chatRoomId);
+
+    @Transactional(readOnly = true)
+    @Query("SELECT cm.chatRoom.id FROM ChatMember cm WHERE cm.user.id = :userId AND cm.deletedAt IS NULL")
+    Set<Long> findChatRoomIdsByUserId(Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -46,6 +46,11 @@ public class ChatMemberService {
         return chatMemberRepository.save(chatMember);
     }
 
+    @Transactional
+    public Set<Long> findChatRoomIdsByUserId(Long userId) {
+        return chatMemberRepository.findChatRoomIdsByUserId(userId);
+    }
+
     /**
      * 채팅방에 해당 유저가 존재하는지 확인한다.
      * 이 때, 삭제된 사용자 데이터는 조회하지 않는다.

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -47,7 +47,7 @@ public class ChatMemberService {
     }
 
     @Transactional
-    public Set<Long> findChatRoomIdsByUserId(Long userId) {
+    public Set<Long> readChatRoomIdsByUserId(Long userId) {
         return chatMemberRepository.findChatRoomIdsByUserId(userId);
     }
 


### PR DESCRIPTION
## 작업 이유
- When user starts application, It's helping for client to subscribe chatrooms

<br/>

## 작업 사항
### Specification Of Request And Response
- url: `GET /v2/chatrooms?summary=true`
   - pre-condition: authenticated user
- response
   ```json
  {
      "code": "2000",
      "data": {
           "chatRoom": {
                "chatRoomIds": [
                      1, 2, 3, ...
                ]
           }
      }
  }
   ```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- Reason for Implementing Joined Chatroom IDs in ChatMemberSearchService:
   - Placing this feature in `ChatRoomSearchService` would introduce dependencies impacting unit tests negatively.
   - Alternatively, using a class like `ChatRoomsSummarySearchService` would add unnecessary complexity.
- SRP Justification:
   - Fetching chatroom summaries relates directly to searching `chat_member` data, thus aligning with `ChatMember` responsibilities.
   - This approach simplifies dependencies and enhances testability.
- Considerations:
   - Low Domain cohesion
   - Consistency in abstraction level

<br/>

## 발견한 이슈
- None.

