### PR TITLE
Ignore: ✨ Receive Chatroom Detail Informations

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
@@ -16,6 +16,7 @@ import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -39,4 +40,9 @@ public interface ChatRoomApi {
     })
     @ApiResponse(responseCode = "200", description = "채팅방 검색 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRooms", schema = @Schema(implementation = SliceResponseTemplate.class))))
     ResponseEntity<?> searchChatRooms(@Validated ChatRoomReq.SearchQuery query, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "채팅방 조회", method = "GET", description = "사용자가 가입한 채팅방 중 특정 채팅방의 상세 정보를 조회한다. 채팅방의 상세 정보에는 채팅방의 참여자 목록과 최근 채팅 메시지 목록 등이 포함된다.")
+    @Parameter(name = "chatRoomId", description = "조회할 채팅방의 식별자", example = "1", required = true)
+    @ApiResponse(responseCode = "200", description = "채팅방 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRoom", schema = @Schema(implementation = ChatRoomRes.RoomWithParticipants.class))))
+    ResponseEntity<?> getChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomController.java
@@ -49,4 +49,10 @@ public class ChatRoomController implements ChatRoomApi {
 
         return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOM, chatRoomUseCase.searchChatRooms(user.getUserId(), query.target(), pageable)));
     }
+
+    @GetMapping("/{chatRoomId}")
+    @PreAuthorize("isAuthenticated() and @chatRoomManager.hasPermission(#user.getUserId(), #chatRoomId)")
+    public ResponseEntity<?> getChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @AuthenticationPrincipal SecurityUserDetails user) {
+        return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOM, chatRoomUseCase.getChatRoomWithParticipants(user.getUserId(), chatRoomId)));
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberRes.java
@@ -1,9 +1,14 @@
 package kr.co.pennyway.api.apis.chat.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+
+import java.time.LocalDateTime;
 
 public final class ChatMemberRes {
     @Schema(description = "채팅방 참여자 상세 정보")
@@ -16,14 +21,19 @@ public final class ChatMemberRes {
             ChatMemberRole role,
             @Schema(description = "채팅방 참여자 알림 설정 여부. 내 정보를 조회할 때만 포함됩니다.")
             @JsonInclude(JsonInclude.Include.NON_NULL)
-            Boolean notifyEnabled
+            Boolean notifyEnabled,
+            @Schema(description = "채팅방 가입일")
+            @JsonSerialize(using = LocalDateTimeSerializer.class)
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt
     ) {
         public static Detail from(ChatMember chatMember, boolean isContainNotifyEnabled) {
             return new Detail(
                     chatMember.getId(),
                     chatMember.getName(),
                     chatMember.getRole(),
-                    isContainNotifyEnabled ? chatMember.isNotifyEnabled() : null
+                    isContainNotifyEnabled ? chatMember.isNotifyEnabled() : null,
+                    chatMember.getCreatedAt()
             );
         }
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberRes.java
@@ -1,0 +1,30 @@
+package kr.co.pennyway.api.apis.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+
+public final class ChatMemberRes {
+    @Schema(description = "채팅방 참여자 상세 정보")
+    public record Detail(
+            @Schema(description = "채팅방 참여자 ID", type = "long")
+            Long id,
+            @Schema(description = "채팅방 참여자 이름")
+            String name,
+            @Schema(description = "채팅방 참여자 역할")
+            ChatMemberRole role,
+            @Schema(description = "채팅방 참여자 알림 설정 여부. 내 정보를 조회할 때만 포함됩니다.")
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Boolean notifyEnabled
+    ) {
+        public static Detail from(ChatMember chatMember, boolean isContainNotifyEnabled) {
+            return new Detail(
+                    chatMember.getId(),
+                    chatMember.getName(),
+                    chatMember.getRole(),
+                    isContainNotifyEnabled ? chatMember.isNotifyEnabled() : null
+            );
+        }
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRes.java
@@ -1,0 +1,45 @@
+package kr.co.pennyway.api.apis.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
+import kr.co.pennyway.domain.common.redis.message.type.MessageCategoryType;
+import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;
+
+import java.time.LocalDateTime;
+
+public final class ChatRes {
+    @Schema(description = "채팅 메시지 상세 정보")
+    public record Detail(
+            @Schema(description = "채팅방 ID", type = "long")
+            Long chatRoomId,
+            @Schema(description = "채팅 ID", type = "long")
+            Long chatId,
+            @Schema(description = "채팅 내용")
+            String content,
+            @Schema(description = "채팅 내용 타입")
+            MessageContentType contentType,
+            @Schema(description = "채팅 메시지 카테고리 타입")
+            MessageCategoryType categoryType,
+            @Schema(description = "채팅 생성일")
+            @JsonSerialize(using = LocalDateTimeSerializer.class)
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt,
+            @Schema(description = "채팅 보낸 사람 ID", type = "long")
+            Long senderId
+    ) {
+        public static Detail from(ChatMessage message) {
+            return new Detail(
+                    message.getChatRoomId(),
+                    message.getChatId(),
+                    message.getContent(),
+                    message.getContentType(),
+                    message.getCategoryType(),
+                    message.getCreatedAt(),
+                    message.getSender()
+            );
+        }
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -62,5 +64,20 @@ public final class ChatRoomRes {
             @Schema(description = "채팅방 ID 목록. 빈 목록일 경우 빈 배열이 반환된다. 각 요소는 long 타입이다.")
             Set<Long> chatRoomIds
     ) {
+    }
+
+    @Schema(description = "채팅방 참여자 정보 (방의 참여자 + 최근 메시지)")
+    @Builder
+    public record RoomWithParticipants(
+            @Schema(description = "채팅방에서 내 정보")
+            ChatMemberRes.Detail myInfo,
+            @Schema(description = "최근에 채팅 메시지를 보낸 참여자의 상세 정보 목록")
+            List<ChatMemberRes.Detail> recentParticipants,
+            @Schema(description = "채팅방에서 내 정보와 최근 활동자를 제외한 참여자 ID 목록")
+            List<Long> otherParticipantIds,
+            @Schema(description = "최근 채팅 이력")
+            List<ChatRes.Detail> recentMessages
+    ) {
+
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -75,7 +75,7 @@ public final class ChatRoomRes {
             List<ChatMemberRes.Detail> recentParticipants,
             @Schema(description = "채팅방에서 내 정보와 최근 활동자를 제외한 참여자 ID 목록")
             List<Long> otherParticipantIds,
-            @Schema(description = "최근 채팅 이력")
+            @Schema(description = "최근 채팅 이력. 메시지는 최신순으로 정렬되어 반환.")
             List<ChatRes.Detail> recentMessages
     ) {
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
@@ -1,10 +1,14 @@
 package kr.co.pennyway.api.apis.chat.mapper;
 
+import kr.co.pennyway.api.apis.chat.dto.ChatMemberRes;
+import kr.co.pennyway.api.apis.chat.dto.ChatRes;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
 import kr.co.pennyway.api.common.response.SliceResponseTemplate;
 import kr.co.pennyway.common.annotation.Mapper;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.chatroom.dto.ChatRoomDetail;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -44,5 +48,22 @@ public final class ChatRoomMapper {
 
     public static ChatRoomRes.Detail toChatRoomResDetail(ChatRoom chatRoom, boolean isAdmin, int participantCount) {
         return ChatRoomRes.Detail.from(chatRoom, isAdmin, participantCount);
+    }
+
+    public static ChatRoomRes.RoomWithParticipants toChatRoomResRoomWithParticipants(ChatMember myInfo, List<ChatMember> recentParticipants, List<Long> otherMemberIds, List<ChatMessage> chatMessages) {
+        List<ChatMemberRes.Detail> recentParticipantsRes = recentParticipants.stream()
+                .map(participant -> ChatMemberRes.Detail.from(participant, false))
+                .toList();
+
+        List<ChatRes.Detail> chatMessagesRes = chatMessages.stream()
+                .map(ChatRes.Detail::from)
+                .toList();
+
+        return ChatRoomRes.RoomWithParticipants.builder()
+                .myInfo(ChatMemberRes.Detail.from(myInfo, true))
+                .recentParticipants(recentParticipantsRes)
+                .otherParticipantIds(otherMemberIds)
+                .recentMessages(chatMessagesRes)
+                .build();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
@@ -1,0 +1,50 @@
+package kr.co.pennyway.api.apis.chat.service;
+
+import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
+import kr.co.pennyway.api.apis.chat.mapper.ChatRoomMapper;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
+import kr.co.pennyway.domain.common.redis.message.service.ChatMessageService;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRoomWithParticipantsSearchService {
+    private final ChatMemberService chatMemberService;
+    private final ChatMessageService chatMessageService;
+
+    @Transactional(readOnly = true)
+    public ChatRoomRes.RoomWithParticipants execute(Long userId, Long chatRoomId) {
+        // (1) myInfo: 내 정보 조회 - MySQL
+        ChatMember myInfo = chatMemberService.readChatMember(userId, chatRoomId)
+                .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
+
+        // (2) recentChats: 최근 채팅 조회 - Redis (key: `chatroom:{chatroom_id}:message:{message_id}`)
+        List<ChatMessage> chatMessages = chatMessageService.readRecentMessages(chatRoomId, 15);
+
+        // (3) recentParticipantIds: 최근 채팅 참여자 정보 상세 조회 - MySQL
+        Set<Long> recentParticipantIds = chatMessages.stream()
+                .map(ChatMessage::getSender)
+                .filter(sender -> !sender.equals(userId))
+                .collect(Collectors.toSet());
+
+        List<ChatMember> recentParticipants = chatMemberService.readChatMembersByMemberIdIn(chatRoomId, recentParticipantIds);
+
+        // (4) otherMemberIds: 나머지 멤버 ID 조회 - MySQL
+        recentParticipantIds.add(userId);
+        List<Long> otherMemberIds = chatMemberService.readChatMemberIdsByMemberIdNotIn(chatRoomId, recentParticipantIds);
+
+        return ChatRoomMapper.toChatRoomResRoomWithParticipants(myInfo, recentParticipants, otherMemberIds, chatMessages);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
@@ -6,6 +6,7 @@ import kr.co.pennyway.api.apis.chat.mapper.ChatRoomMapper;
 import kr.co.pennyway.api.apis.chat.service.ChatMemberSearchService;
 import kr.co.pennyway.api.apis.chat.service.ChatRoomSaveService;
 import kr.co.pennyway.api.apis.chat.service.ChatRoomSearchService;
+import kr.co.pennyway.api.apis.chat.service.ChatRoomWithParticipantsSearchService;
 import kr.co.pennyway.api.common.response.SliceResponseTemplate;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
@@ -22,6 +23,7 @@ import java.util.Set;
 public class ChatRoomUseCase {
     private final ChatRoomSaveService chatRoomSaveService;
     private final ChatRoomSearchService chatRoomSearchService;
+    private final ChatRoomWithParticipantsSearchService chatRoomWithParticipantsSearchService;
 
     private final ChatMemberSearchService chatMemberSearchService;
 
@@ -35,6 +37,10 @@ public class ChatRoomUseCase {
         List<ChatRoomDetail> chatRooms = chatRoomSearchService.readChatRooms(userId);
 
         return ChatRoomMapper.toChatRoomResDetails(chatRooms);
+    }
+
+    public ChatRoomRes.RoomWithParticipants getChatRoomWithParticipants(Long userId, Long chatRoomId) {
+        return chatRoomWithParticipantsSearchService.execute(userId, chatRoomId);
     }
 
     public ChatRoomRes.Summary readJoinedChatRoomIds(Long userId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/ChatRoomManager.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/ChatRoomManager.java
@@ -1,0 +1,22 @@
+package kr.co.pennyway.api.common.security.authorization;
+
+import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component("chatRoomManager")
+@RequiredArgsConstructor
+public class ChatRoomManager {
+    private final ChatMemberService chatMemberService;
+
+    /**
+     * 사용자가 채팅방에 대한 접근 권한이 있는지 확인한다.
+     */
+    @Transactional(readOnly = true)
+    public boolean hasPermission(Long userId, Long chatRoomId) {
+        return chatMemberService.isExists(chatRoomId, userId);
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatRoomDetailIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatRoomDetailIntegrationTest.java
@@ -1,0 +1,228 @@
+package kr.co.pennyway.api.apis.chat.integration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import kr.co.pennyway.api.common.util.ApiTestHelper;
+import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
+import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
+import kr.co.pennyway.api.config.fixture.ChatRoomFixture;
+import kr.co.pennyway.api.config.fixture.UserFixture;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessageBuilder;
+import kr.co.pennyway.domain.common.redis.message.repository.ChatMessageRepositoryImpl;
+import kr.co.pennyway.domain.common.redis.message.type.MessageCategoryType;
+import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomService;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.repository.ChatMemberRepository;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@ExternalApiIntegrationTest
+public class ChatRoomDetailIntegrationTest extends ExternalApiDBTestConfig {
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private JwtProvider accessTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private ChatMemberRepository chatMemberRepository;
+
+    @Autowired
+    private ChatRoomService chatRoomService;
+
+    @Autowired
+    private ChatMemberService chatMemberService;
+
+    @Autowired
+    private ChatMessageRepositoryImpl chatMessageRepository;
+
+    private ApiTestHelper apiTestHelper;
+
+    @LocalServerPort
+    private int port;
+
+    private User owner;
+    private ChatRoom chatRoom;
+    private ChatMember ownerMember;
+
+    @BeforeEach
+    void setUp() {
+        apiTestHelper = new ApiTestHelper(restTemplate, objectMapper, accessTokenProvider);
+
+        owner = userService.createUser(UserFixture.GENERAL_USER.toUser());
+        chatRoom = chatRoomService.create(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(1L));
+        ownerMember = chatMemberService.createAdmin(owner, chatRoom);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Set<String> keys = redisTemplate.keys("chatroom:*:message");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+
+        chatMemberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Happy Path: 사용자는 채팅방 상세 정보를 조회할 수 있다.")
+    void successGetChatRoomDetail() {
+        // given
+        User member = userService.createUser(UserFixture.GENERAL_USER.toUser());
+        ChatMember participant = chatMemberService.createMember(member, chatRoom);
+
+        int expectedRecentParticipantCount = 1; // 나 자신은 제외
+        int expectedMessageCount = 5;
+
+        for (int i = 1; i <= 5; i++) {
+            chatMessageRepository.save(createTestMessage(chatRoom.getId(), (long) i, i % 2 == 0 ? owner.getId() : participant.getId()));
+        }
+
+        // when
+        ResponseEntity<?> response = performApi(owner, chatRoom.getId());
+
+        // then
+        assertAll(
+                () -> assertEquals(HttpStatus.OK, response.getStatusCode()),
+                () -> {
+                    SuccessResponse<Map<String, ChatRoomRes.RoomWithParticipants>> result = (SuccessResponse<Map<String, ChatRoomRes.RoomWithParticipants>>) response.getBody();
+                    ChatRoomRes.RoomWithParticipants payload = result.getData().get("chatRoom");
+
+                    assertNotNull(result);
+                    assertEquals(owner.getId(), payload.myInfo().id(), "내 ID가 일치해야 한다");
+                    assertEquals(ownerMember.getRole(), ChatMemberRole.ADMIN, "나는 방장 권한이어야 한다");
+                    assertEquals(expectedRecentParticipantCount, payload.recentParticipants().size(), "최근 참여자 개수가 일치해야 한다");
+                    assertEquals(expectedMessageCount, payload.recentMessages().size(), "최근 메시지 개수가 일치해야 한다");
+                    assertTrue(payload.otherParticipantIds().isEmpty(), "다른 참여자가 없어야 한다");
+                }
+        );
+    }
+
+    @Test
+    @DisplayName("채팅방 멤버가 아닌 사용자는 조회할 수 없다")
+    void failGetChatRoomDetailWhenNotMember() {
+        // given
+        User nonMember = userService.createUser(UserFixture.GENERAL_USER.toUser());
+
+        // when
+        ResponseEntity<?> response = performApi(nonMember, chatRoom.getId());
+
+        // then
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(), "채팅방 멤버가 아닌 사용자는 조회할 수 없어야 한다");
+    }
+
+    @Test
+    @DisplayName("최근 메시지가 없는 채팅방도 정상적으로 조회된다")
+    void successGetChatRoomDetailWithoutMessages() {
+        // given
+        User member = userService.createUser(UserFixture.GENERAL_USER.toUser());
+        ChatMember participant = chatMemberService.createMember(member, chatRoom);
+
+        // when
+        ResponseEntity<?> response = performApi(member, chatRoom.getId());
+
+        // then
+        SuccessResponse<Map<String, ChatRoomRes.RoomWithParticipants>> result = (SuccessResponse<Map<String, ChatRoomRes.RoomWithParticipants>>) response.getBody();
+        ChatRoomRes.RoomWithParticipants payload = result.getData().get("chatRoom");
+
+        assertNotNull(result);
+        assertTrue(payload.recentMessages().isEmpty(), "최근 메시지가 없어야 한다");
+    }
+
+    @Test
+    @DisplayName("채팅방에 다수의 참여자가 있는 경우 정상적으로 조회된다")
+    void successGetChatRoomDetailWithManyParticipants() {
+        // given
+        int expectedParticipantCount = 10;
+        List<User> participants = createMultipleParticipants(expectedParticipantCount);
+
+        chatMessageRepository.save(createTestMessage(chatRoom.getId(), 1L, owner.getId()));
+        chatMessageRepository.save(createTestMessage(chatRoom.getId(), 2L, participants.get(0).getId()));
+        chatMessageRepository.save(createTestMessage(chatRoom.getId(), 3L, participants.get(1).getId()));
+
+        // when
+        ResponseEntity<?> response = performApi(owner, chatRoom.getId());
+
+        // then
+        SuccessResponse<Map<String, ChatRoomRes.RoomWithParticipants>> result = (SuccessResponse<Map<String, ChatRoomRes.RoomWithParticipants>>) response.getBody();
+        ChatRoomRes.RoomWithParticipants payload = result.getData().get("chatRoom");
+
+        assertAll(
+                () -> assertNotNull(payload),
+                () -> assertEquals(payload.recentParticipants().size(), 2, "최근 참여자 개수가 일치해야 한다."),
+                () -> assertEquals(payload.otherParticipantIds().size(), expectedParticipantCount - 2, "다른 참여자 개수가 일치해야 한다.")
+        );
+    }
+
+    private ChatMessage createTestMessage(Long chatRoomId, Long chatId, Long senderId) {
+        return ChatMessageBuilder.builder()
+                .chatRoomId(chatRoomId)
+                .chatId(chatId)
+                .content("Test message " + chatId)
+                .contentType(MessageContentType.TEXT)
+                .categoryType(MessageCategoryType.NORMAL)
+                .sender(senderId)
+                .build();
+    }
+
+    private List<User> createMultipleParticipants(int count) {
+        List<User> participants = new ArrayList<>();
+
+        for (int i = 0; i < count; ++i) {
+            User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
+            chatMemberService.createMember(user, chatRoom);
+            participants.add(user);
+        }
+
+        return participants;
+    }
+
+    private ResponseEntity<?> performApi(User user, Long roomId) {
+        return apiTestHelper.callApi(
+                "http://localhost:" + port + "/v2/chat-rooms/{roomId}",
+                HttpMethod.GET,
+                user,
+                null,
+                new TypeReference<SuccessResponse<Map<String, ChatRoomRes.RoomWithParticipants>>>() {
+                },
+                roomId
+        );
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchServiceTest.java
@@ -1,0 +1,145 @@
+package kr.co.pennyway.api.apis.chat.service;
+
+import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
+import kr.co.pennyway.api.config.fixture.ChatMemberFixture;
+import kr.co.pennyway.api.config.fixture.ChatRoomFixture;
+import kr.co.pennyway.api.config.fixture.UserFixture;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessageBuilder;
+import kr.co.pennyway.domain.common.redis.message.service.ChatMessageService;
+import kr.co.pennyway.domain.common.redis.message.type.MessageCategoryType;
+import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+public class ChatRoomWithParticipantsSearchServiceTest {
+    private final Long userId = 1L;
+    private ChatRoom chatRoom;
+
+    @InjectMocks
+    private ChatRoomWithParticipantsSearchService service;
+    @Mock
+    private ChatMemberService chatMemberService;
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    @BeforeEach
+    void setUp() {
+        chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(1L);
+    }
+
+    @Test
+    @DisplayName("채팅방 참여자 정보와 최근 메시지를 성공적으로 조회한다")
+    public void successToRetrieveChatRoomWithParticipantsAndRecentMessages() {
+        // given
+        ChatMember myInfo = createChatMember(userId, UserFixture.GENERAL_USER.toUser(), chatRoom, ChatMemberRole.ADMIN);
+        List<ChatMessage> recentMessages = createRecentMessages();
+        List<ChatMember> recentParticipants = createRecentParticipants();
+        List<Long> otherMemberIds = List.of(5L, 6L);
+
+        given(chatMemberService.readChatMember(userId, chatRoom.getId())).willReturn(Optional.of(myInfo));
+        given(chatMessageService.readRecentMessages(eq(chatRoom.getId()), anyInt())).willReturn(recentMessages);
+        given(chatMemberService.readChatMembersByMemberIdIn(eq(chatRoom.getId()), anySet())).willReturn(recentParticipants);
+        given(chatMemberService.readChatMemberIdsByMemberIdNotIn(eq(chatRoom.getId()), anySet())).willReturn(otherMemberIds);
+
+        // when
+        ChatRoomRes.RoomWithParticipants result = service.execute(userId, chatRoom.getId());
+
+        // then
+        log.debug("result: {}", result);
+
+        assertAll(
+                () -> assertEquals(userId, result.myInfo().id()),
+                () -> assertEquals(2, result.recentParticipants().size()),
+                () -> assertEquals(2, result.otherParticipantIds().size()),
+                () -> assertEquals(3, result.recentMessages().size())
+        );
+
+        // verify
+        verify(chatMemberService).readChatMember(userId, chatRoom.getId());
+        verify(chatMessageService).readRecentMessages(eq(chatRoom.getId()), anyInt());
+        verify(chatMemberService).readChatMembersByMemberIdIn(eq(chatRoom.getId()), anySet());
+        verify(chatMemberService).readChatMemberIdsByMemberIdNotIn(eq(chatRoom.getId()), anySet());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 채팅방 멤버 조회 시 예외가 발생한다")
+    void throwExceptionWhenChatMemberNotFound() {
+        // given
+        given(chatMemberService.readChatMember(userId, chatRoom.getId())).willReturn(Optional.empty());
+
+        // when
+        ChatMemberErrorException exception = assertThrows(ChatMemberErrorException.class,
+                () -> service.execute(userId, chatRoom.getId()));
+
+        // then
+        assertEquals(ChatMemberErrorCode.NOT_FOUND, exception.getBaseErrorCode());
+
+        verify(chatMemberService).readChatMember(userId, chatRoom.getId());
+        verifyNoMoreInteractions(chatMemberService, chatMessageService);
+    }
+
+    private List<ChatMember> createRecentParticipants() {
+        return List.of(
+                createChatMember(2L, UserFixture.GENERAL_USER.toUser(), chatRoom, ChatMemberRole.MEMBER),
+                createChatMember(3L, UserFixture.GENERAL_USER.toUser(), chatRoom, ChatMemberRole.MEMBER)
+        );
+    }
+
+    private ChatMember createChatMember(Long userId, User user, ChatRoom chatRoom, ChatMemberRole role) {
+        ChatMember member;
+
+        switch (role) {
+            case ADMIN -> member = ChatMemberFixture.ADMIN.toEntity(user, chatRoom);
+            case MEMBER -> member = ChatMemberFixture.MEMBER.toEntity(user, chatRoom);
+            default -> throw new IllegalArgumentException("Unexpected role: " + role);
+        }
+
+        ReflectionTestUtils.setField(member, "id", userId);
+        return member;
+    }
+
+    private List<ChatMessage> createRecentMessages() {
+        return List.of(
+                createChatMessage(3L, "Message 3", 1L),
+                createChatMessage(2L, "Message 2", 2L),
+                createChatMessage(1L, "Message 1", 3L)
+        );
+    }
+
+    private ChatMessage createChatMessage(Long chatId, String content, Long senderId) {
+        return ChatMessageBuilder.builder()
+                .chatRoomId(chatRoom.getId())
+                .chatId(chatId)
+                .content(content)
+                .contentType(MessageContentType.TEXT)
+                .categoryType(MessageCategoryType.NORMAL)
+                .sender(senderId)
+                .build();
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/common/util/ApiTestHelper.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/common/util/ApiTestHelper.java
@@ -1,0 +1,108 @@
+package kr.co.pennyway.api.common.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.common.response.ErrorResponse;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import kr.co.pennyway.api.common.security.jwt.access.AccessTokenClaim;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+
+public final class ApiTestHelper {
+    private final TestRestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final JwtProvider accessTokenProvider;
+
+    public ApiTestHelper(TestRestTemplate restTemplate, ObjectMapper objectMapper, JwtProvider accessTokenProvider) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+        this.accessTokenProvider = accessTokenProvider;
+    }
+
+    /**
+     * API 요청을 보내고 응답을 처리하는 일반화된 메서드
+     *
+     * @param url                 API 엔드포인트 URL
+     * @param method              HTTP 메서드
+     * @param user                요청하는 사용자
+     * @param request             요청 바디 (없을 경우 null)
+     * @param successResponseType 성공 응답 타입
+     * @param uriVariables        URL 변수들
+     * @return ResponseEntity
+     */
+    public <T, R> ResponseEntity<?> callApi(
+            String url,
+            HttpMethod method,
+            User user,
+            T request,
+            TypeReference<SuccessResponse<R>> successResponseType,
+            Object... uriVariables) {
+
+        ResponseEntity<Object> response = restTemplate.exchange(
+                url,
+                method,
+                createHttpEntity(user, request),
+                Object.class,
+                uriVariables
+        );
+
+        Object body = response.getBody();
+        if (body == null) {
+            throw new IllegalStateException("예상치 못한 반환 타입입니다. : " + response);
+        }
+
+        return response.getStatusCode().is2xxSuccessful()
+                ? createSuccessResponse(response, body, successResponseType)
+                : createErrorResponse(response, body);
+    }
+
+    /**
+     * HTTP 요청 엔티티 생성
+     */
+    private <T> HttpEntity<?> createHttpEntity(User user, T request) {
+        HttpHeaders headers = new HttpHeaders();
+        if (user != null) {
+            headers.set("Authorization", "Bearer " + generateToken(user));
+        }
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new HttpEntity<>(request, headers);
+    }
+
+    /**
+     * 사용자 토큰 생성
+     */
+    private String generateToken(User user) {
+        return accessTokenProvider.generateToken(
+                AccessTokenClaim.of(user.getId(), user.getRole().name())
+        );
+    }
+
+    /**
+     * 성공 응답 생성
+     */
+    private <R> ResponseEntity<SuccessResponse<R>> createSuccessResponse(
+            ResponseEntity<Object> response,
+            Object body,
+            TypeReference<SuccessResponse<R>> successResponseType) {
+        return ResponseEntity
+                .status(response.getStatusCode())
+                .headers(response.getHeaders())
+                .body(objectMapper.convertValue(body, successResponseType));
+    }
+
+    /**
+     * 에러 응답 생성
+     */
+    private ResponseEntity<ErrorResponse> createErrorResponse(
+            ResponseEntity<Object> response,
+            Object body) {
+        return ResponseEntity
+                .status(response.getStatusCode())
+                .headers(response.getHeaders())
+                .body(objectMapper.convertValue(body, new TypeReference<ErrorResponse>() {
+                }));
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/domain/ChatMessage.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/domain/ChatMessage.java
@@ -9,7 +9,6 @@ import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.redis.core.RedisHash;
 
 import java.time.LocalDateTime;
 
@@ -18,7 +17,6 @@ import java.time.LocalDateTime;
  * Redis에 저장되는 채팅 메시지의 기본 단위입니다.
  */
 @Getter
-@RedisHash(value = "chatroom")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage {
     /**
@@ -36,7 +34,7 @@ public class ChatMessage {
     private Long sender;
 
     protected ChatMessage(ChatMessageBuilder builder) {
-        this.id = builder.getChatRoomId() + ":message:" + builder.getChatId();
+        this.id = createId(builder.getChatRoomId(), builder.getChatId());
         this.content = builder.getContent();
         this.contentType = builder.getContentType();
         this.categoryType = builder.getCategoryType();
@@ -51,6 +49,10 @@ public class ChatMessage {
 
     public Long getChatId() {
         return Long.parseLong(id.split(":")[2]);
+    }
+
+    private String createId(long chatRoomId, long chatId) {
+        return "chatroom:" + chatRoomId + ":message:" + chatId;
     }
 
     @Override

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/domain/ChatMessage.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/domain/ChatMessage.java
@@ -1,7 +1,6 @@
 package kr.co.pennyway.domain.common.redis.message.domain;
 
 import jakarta.persistence.Convert;
-import jakarta.persistence.Id;
 import kr.co.pennyway.domain.common.converter.MessageCategoryTypeConverter;
 import kr.co.pennyway.domain.common.converter.MessageContentTypeConverter;
 import kr.co.pennyway.domain.common.redis.message.type.MessageCategoryType;
@@ -9,6 +8,7 @@ import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
 
 import java.time.LocalDateTime;
 
@@ -17,13 +17,11 @@ import java.time.LocalDateTime;
  * Redis에 저장되는 채팅 메시지의 기본 단위입니다.
  */
 @Getter
+@RedisHash(value = "chatroom")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage {
-    /**
-     * 채팅 메시지 ID는 "chatroom:{roomId}:message:{messageId}" 형태로 생성한다.
-     */
-    @Id
-    private String id;
+    private Long chatRoomId;
+    private Long chatId;
     private String content;
     @Convert(converter = MessageContentTypeConverter.class)
     private MessageContentType contentType;
@@ -34,7 +32,8 @@ public class ChatMessage {
     private Long sender;
 
     protected ChatMessage(ChatMessageBuilder builder) {
-        this.id = createId(builder.getChatRoomId(), builder.getChatId());
+        this.chatRoomId = builder.getChatRoomId();
+        this.chatId = builder.getChatId();
         this.content = builder.getContent();
         this.contentType = builder.getContentType();
         this.categoryType = builder.getCategoryType();
@@ -43,28 +42,18 @@ public class ChatMessage {
         this.sender = builder.getSender();
     }
 
-    public Long getChatRoomId() {
-        return Long.parseLong(id.split(":")[0]);
-    }
-
-    public Long getChatId() {
-        return Long.parseLong(id.split(":")[2]);
-    }
-
-    private String createId(long chatRoomId, long chatId) {
-        return "chatroom:" + chatRoomId + ":message:" + chatId;
-    }
 
     @Override
     public String toString() {
         return "ChatMessage{" +
-                "id='" + id + '\'' +
+                "chatRoomId='" + chatRoomId + '\'' +
+                ", chatId='" + chatId + '\'' +
                 ", content='" + content + '\'' +
-                ", contentType=" + contentType +
-                ", categoryType=" + categoryType +
-                ", createdAt=" + createdAt +
-                ", deletedAt=" + deletedAt +
-                ", sender=" + sender +
+                ", contentType='" + contentType + '\'' +
+                ", categoryType='" + categoryType + '\'' +
+                ", createdAt='" + createdAt + '\'' +
+                ", deletedAt='" + deletedAt + '\'' +
+                ", sender='" + sender + '\'' +
                 '}';
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepository.java
@@ -1,27 +1,12 @@
 package kr.co.pennyway.domain.common.redis.message.repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Repository;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.Set;
 
-@Slf4j
-@Repository
-@RequiredArgsConstructor
-public class ChatMessageRepository {
-    private final RedisTemplate<String, String> redisTemplate;
-    private final ObjectMapper objectMapper;
-
+public interface ChatMessageRepository {
     /**
      * 채팅 메시지를 Redis에 저장합니다.
      * 메시지는 JSON 형태로 직렬화되어 저장되며, TSID를 score로 사용하여 정렬됩니다.
@@ -29,23 +14,7 @@ public class ChatMessageRepository {
      * @param message {@link ChatMessage}: 저장할 채팅 메시지
      * @throws JsonProcessingException JSON 직렬화에 실패한 경우
      */
-    public ChatMessage save(ChatMessage message) {
-        try {
-            String messageJson = objectMapper.writeValueAsString(message);
-            String chatRoomKey = getChatRoomKey(message.getChatRoomId());
-
-            redisTemplate.opsForZSet().add( // ZADD
-                    chatRoomKey,
-                    messageJson,
-                    message.getChatId()
-            );
-        } catch (JsonProcessingException e) {
-            log.error("Failed to save chat message: {}", message, e);
-//            throw new RedisOperationException("Failed to save chat message", e);
-        }
-
-        return message;
-    }
+    ChatMessage save(ChatMessage message);
 
     /**
      * 채팅방의 최근 메시지를 조회합니다.
@@ -55,17 +24,7 @@ public class ChatMessageRepository {
      * @param limit  int: 조회할 메시지 개수
      * @return 최근 메시지 목록
      */
-    public List<ChatMessage> findRecentMessages(Long roomId, int limit) {
-        String chatRoomKey = getChatRoomKey(roomId);
-
-        Set<String> messageJsonSet = redisTemplate.opsForZSet().reverseRange( // ZREVRANGE
-                chatRoomKey,
-                0,
-                limit - 1
-        );
-
-        return convertToMessages(messageJsonSet);
-    }
+    List<ChatMessage> findRecentMessages(Long roomId, int limit);
 
     /**
      * 특정 메시지 ID 이전의 메시지들을 페이징하여 조회합니다.
@@ -77,51 +36,7 @@ public class ChatMessageRepository {
      * @param size          int: 조회할 메시지 개수
      * @return 페이징된 메시지 목록과 다음 페이지 존재 여부
      */
-    public SliceImpl<ChatMessage> findMessagesBefore(Long roomId, Long lastMessageId, int size) {
-        String chatRoomKey = getChatRoomKey(roomId);
-
-        Set<String> messageJsonSet = redisTemplate.opsForZSet().reverseRangeByScore( // ZREVRANGEBYSCORE
-                chatRoomKey,
-                0, // 최소값
-                lastMessageId - 1, // 마지막으로 조회한 메시지 이전까지
-                0, // offset
-                size + 1 // size + 1 만큼 조회하여 다음 페이지 존재 여부 확인
-        );
-
-        List<ChatMessage> messages = convertToMessages(messageJsonSet);
-        boolean hasNext = messages.size() > size;
-
-        if (hasNext) {
-            messages = messages.subList(0, size);
-        }
-
-        return new SliceImpl<>(messages, PageRequest.of(0, size), hasNext);
-    }
-
-    /**
-     * JSON 문자열 집합을 ChatMessage 객체 리스트로 변환합니다.
-     * 변환 실패한 메시지는 무시됩니다.
-     *
-     * @param messageJsonSet JSON 문자열 집합
-     * @return 변환된 ChatMessage 객체 리스트
-     */
-    private List<ChatMessage> convertToMessages(Set<String> messageJsonSet) {
-        if (messageJsonSet == null || messageJsonSet.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        return messageJsonSet.stream()
-                .map(json -> {
-                    try {
-                        return objectMapper.readValue(json, ChatMessage.class);
-                    } catch (JsonProcessingException e) {
-                        log.error("Failed to parse chat message JSON: {}", json, e);
-                        return null;
-                    }
-                })
-                .filter(Objects::nonNull)
-                .toList();
-    }
+    SliceImpl<ChatMessage> findMessagesBefore(Long roomId, Long lastMessageId, int size);
 
     /**
      * 사용자가 마지막으로 읽은 메시지 이후의 안 읽은 메시지 개수를 조회합니다.
@@ -130,24 +45,5 @@ public class ChatMessageRepository {
      * @param lastReadMessageId 사용자가 마지막으로 읽은 메시지의 TSID
      * @return 안 읽은 메시지 개수
      */
-    public Long countUnreadMessages(Long roomId, Long lastReadMessageId) {
-        String chatRoomKey = getChatRoomKey(roomId);
-
-        // lastReadMessageId보다 큰 score를 가진 메시지의 개수를 조회
-        return redisTemplate.opsForZSet().count( // ZCOUNT
-                chatRoomKey,
-                lastReadMessageId + 1,  // 최소값 (lastReadMessageId 이후)
-                Double.POSITIVE_INFINITY  // 최대값
-        );
-    }
-
-    /**
-     * 채팅방의 조회용 Redis key를 생성합니다.
-     *
-     * @param roomId 채팅방 ID
-     * @return 생성된 Redis key
-     */
-    private String getChatRoomKey(Long roomId) {
-        return "chatroom:" + roomId + ":message";
-    }
+    Long countUnreadMessages(Long roomId, Long lastReadMessageId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepository.java
@@ -1,7 +1,153 @@
 package kr.co.pennyway.domain.common.redis.message.repository;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
-import org.springframework.data.repository.CrudRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
 
-public interface ChatMessageRepository extends CrudRepository<ChatMessage, String> {
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageRepository {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 채팅 메시지를 Redis에 저장합니다.
+     * 메시지는 JSON 형태로 직렬화되어 저장되며, TSID를 score로 사용하여 정렬됩니다.
+     *
+     * @param message {@link ChatMessage}: 저장할 채팅 메시지
+     * @throws JsonProcessingException JSON 직렬화에 실패한 경우
+     */
+    public ChatMessage save(ChatMessage message) {
+        try {
+            String messageJson = objectMapper.writeValueAsString(message);
+            String chatRoomKey = getChatRoomKey(message.getChatRoomId());
+
+            redisTemplate.opsForZSet().add( // ZADD
+                    chatRoomKey,
+                    messageJson,
+                    message.getChatId()
+            );
+        } catch (JsonProcessingException e) {
+            log.error("Failed to save chat message: {}", message, e);
+//            throw new RedisOperationException("Failed to save chat message", e);
+        }
+
+        return message;
+    }
+
+    /**
+     * 채팅방의 최근 메시지를 조회합니다.
+     * 메시지는 시간 순으로 정렬되어 반환됩니다.
+     *
+     * @param roomId Long: 채팅방 ID
+     * @param limit  int: 조회할 메시지 개수
+     * @return 최근 메시지 목록
+     */
+    public List<ChatMessage> findRecentMessages(Long roomId, int limit) {
+        String chatRoomKey = getChatRoomKey(roomId);
+
+        Set<String> messageJsonSet = redisTemplate.opsForZSet().reverseRange( // ZREVRANGE
+                chatRoomKey,
+                0,
+                limit - 1
+        );
+
+        return convertToMessages(messageJsonSet);
+    }
+
+    /**
+     * 특정 메시지 ID 이전의 메시지들을 페이징하여 조회합니다.
+     * TSID를 기준으로 정렬된 결과를 반환하며, lastMessageId에 해당하는 메시지는 포함되지 않습니다.
+     * 만약, lastMessageId에 해당하는 메시지가 필요한 경우 인자는 lastMessageId + 1로 설정해야 합니다.
+     *
+     * @param roomId        Long: 채팅방 ID
+     * @param lastMessageId Long: 마지막으로 조회한 메시지의 TSID
+     * @param size          int: 조회할 메시지 개수
+     * @return 페이징된 메시지 목록과 다음 페이지 존재 여부
+     */
+    public SliceImpl<ChatMessage> findMessagesBefore(Long roomId, Long lastMessageId, int size) {
+        String chatRoomKey = getChatRoomKey(roomId);
+
+        Set<String> messageJsonSet = redisTemplate.opsForZSet().reverseRangeByScore( // ZREVRANGEBYSCORE
+                chatRoomKey,
+                0, // 최소값
+                lastMessageId - 1, // 마지막으로 조회한 메시지 이전까지
+                0, // offset
+                size + 1 // size + 1 만큼 조회하여 다음 페이지 존재 여부 확인
+        );
+
+        List<ChatMessage> messages = convertToMessages(messageJsonSet);
+        boolean hasNext = messages.size() > size;
+
+        if (hasNext) {
+            messages = messages.subList(0, size);
+        }
+
+        return new SliceImpl<>(messages, PageRequest.of(0, size), hasNext);
+    }
+
+    /**
+     * JSON 문자열 집합을 ChatMessage 객체 리스트로 변환합니다.
+     * 변환 실패한 메시지는 무시됩니다.
+     *
+     * @param messageJsonSet JSON 문자열 집합
+     * @return 변환된 ChatMessage 객체 리스트
+     */
+    private List<ChatMessage> convertToMessages(Set<String> messageJsonSet) {
+        if (messageJsonSet == null || messageJsonSet.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return messageJsonSet.stream()
+                .map(json -> {
+                    try {
+                        return objectMapper.readValue(json, ChatMessage.class);
+                    } catch (JsonProcessingException e) {
+                        log.error("Failed to parse chat message JSON: {}", json, e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * 사용자가 마지막으로 읽은 메시지 이후의 안 읽은 메시지 개수를 조회합니다.
+     *
+     * @param roomId            채팅방 ID
+     * @param lastReadMessageId 사용자가 마지막으로 읽은 메시지의 TSID
+     * @return 안 읽은 메시지 개수
+     */
+    public Long countUnreadMessages(Long roomId, Long lastReadMessageId) {
+        String chatRoomKey = getChatRoomKey(roomId);
+
+        // lastReadMessageId보다 큰 score를 가진 메시지의 개수를 조회
+        return redisTemplate.opsForZSet().count( // ZCOUNT
+                chatRoomKey,
+                lastReadMessageId + 1,  // 최소값 (lastReadMessageId 이후)
+                Double.POSITIVE_INFINITY  // 최대값
+        );
+    }
+
+    /**
+     * 채팅방의 조회용 Redis key를 생성합니다.
+     *
+     * @param roomId 채팅방 ID
+     * @return 생성된 Redis key
+     */
+    private String getChatRoomKey(Long roomId) {
+        return "chatroom:" + roomId + ":message";
+    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryImpl.java
@@ -1,0 +1,123 @@
+package kr.co.pennyway.domain.common.redis.message.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageRepositoryImpl implements ChatMessageRepository {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public ChatMessage save(ChatMessage message) {
+        try {
+            String messageJson = objectMapper.writeValueAsString(message);
+            String chatRoomKey = getChatRoomKey(message.getChatRoomId());
+
+            redisTemplate.opsForZSet().add( // ZADD
+                    chatRoomKey,
+                    messageJson,
+                    message.getChatId()
+            );
+        } catch (JsonProcessingException e) {
+            log.error("Failed to save chat message: {}", message, e);
+            throw new RuntimeException("Failed to save chat message", e);
+        }
+
+        return message;
+    }
+
+    @Override
+    public List<ChatMessage> findRecentMessages(Long roomId, int limit) {
+        String chatRoomKey = getChatRoomKey(roomId);
+
+        Set<String> messageJsonSet = redisTemplate.opsForZSet().reverseRange( // ZREVRANGE
+                chatRoomKey,
+                0,
+                limit - 1
+        );
+
+        return convertToMessages(messageJsonSet);
+    }
+
+    @Override
+    public SliceImpl<ChatMessage> findMessagesBefore(Long roomId, Long lastMessageId, int size) {
+        String chatRoomKey = getChatRoomKey(roomId);
+
+        Set<String> messageJsonSet = redisTemplate.opsForZSet().reverseRangeByScore( // ZREVRANGEBYSCORE
+                chatRoomKey,
+                0, // 최소값
+                lastMessageId - 1, // 마지막으로 조회한 메시지 이전까지
+                0, // offset
+                size + 1 // size + 1 만큼 조회하여 다음 페이지 존재 여부 확인
+        );
+
+        List<ChatMessage> messages = convertToMessages(messageJsonSet);
+        boolean hasNext = messages.size() > size;
+
+        if (hasNext) {
+            messages = messages.subList(0, size);
+        }
+
+        return new SliceImpl<>(messages, PageRequest.of(0, size), hasNext);
+    }
+
+    /**
+     * JSON 문자열 집합을 ChatMessage 객체 리스트로 변환합니다.
+     * 변환 실패한 메시지는 무시됩니다.
+     *
+     * @param messageJsonSet JSON 문자열 집합
+     * @return 변환된 ChatMessage 객체 리스트
+     */
+    private List<ChatMessage> convertToMessages(Set<String> messageJsonSet) {
+        if (messageJsonSet == null || messageJsonSet.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return messageJsonSet.stream()
+                .map(json -> {
+                    try {
+                        return objectMapper.readValue(json, ChatMessage.class);
+                    } catch (JsonProcessingException e) {
+                        log.error("Failed to parse chat message JSON: {}", json, e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    public Long countUnreadMessages(Long roomId, Long lastReadMessageId) {
+        String chatRoomKey = getChatRoomKey(roomId);
+
+        return redisTemplate.opsForZSet().count( // ZCOUNT
+                chatRoomKey,
+                lastReadMessageId + 1,  // 최소값 (lastReadMessageId 이후)
+                Double.POSITIVE_INFINITY  // 최대값
+        );
+    }
+
+    /**
+     * 채팅방의 조회용 Redis key를 생성합니다.
+     *
+     * @param roomId 채팅방 ID
+     * @return 생성된 Redis key
+     */
+    private String getChatRoomKey(Long roomId) {
+        return "chatroom:" + roomId + ":message";
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/service/ChatMessageService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/service/ChatMessageService.java
@@ -2,7 +2,7 @@ package kr.co.pennyway.domain.common.redis.message.service;
 
 import kr.co.pennyway.common.annotation.DomainService;
 import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
-import kr.co.pennyway.domain.common.redis.message.repository.ChatMessageRepository;
+import kr.co.pennyway.domain.common.redis.message.repository.ChatMessageRepositoryImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -10,9 +10,9 @@ import lombok.extern.slf4j.Slf4j;
 @DomainService
 @RequiredArgsConstructor
 public class ChatMessageService {
-    private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageRepositoryImpl chatMessageRepositoryImpl;
 
     public ChatMessage save(ChatMessage chatMessage) {
-        return chatMessageRepository.save(chatMessage);
+        return chatMessageRepositoryImpl.save(chatMessage);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/service/ChatMessageService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/service/ChatMessageService.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ChatMessageService {
     private final ChatMessageRepositoryImpl chatMessageRepositoryImpl;
 
-    public ChatMessage save(ChatMessage chatMessage) {
+    public ChatMessage create(ChatMessage chatMessage) {
         return chatMessageRepositoryImpl.save(chatMessage);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/service/ChatMessageService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/service/ChatMessageService.java
@@ -15,8 +15,4 @@ public class ChatMessageService {
     public ChatMessage save(ChatMessage chatMessage) {
         return chatMessageRepository.save(chatMessage);
     }
-
-    public void delete(final long chatRoomId, final long chatId) {
-        chatMessageRepository.deleteById("chatroom:" + chatRoomId + ":message:" + chatId);
-    }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/service/ChatMessageService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/service/ChatMessageService.java
@@ -5,6 +5,9 @@ import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
 import kr.co.pennyway.domain.common.redis.message.repository.ChatMessageRepositoryImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
 
 @Slf4j
 @DomainService
@@ -14,5 +17,41 @@ public class ChatMessageService {
 
     public ChatMessage create(ChatMessage chatMessage) {
         return chatMessageRepositoryImpl.save(chatMessage);
+    }
+
+    /**
+     * 채팅방의 최근 메시지를 조회합니다.
+     *
+     * @param roomId Long: 채팅방 ID
+     * @param limit  int: 조회할 메시지 개수
+     * @return 최근 시간 순으로 정렬된 최근 메시지 목록
+     */
+    public List<ChatMessage> readRecentMessages(Long roomId, int limit) {
+        return chatMessageRepositoryImpl.findRecentMessages(roomId, limit);
+    }
+
+    /**
+     * 특정 메시지 ID 이전의 메시지들을 페이징하여 조회합니다.
+     * 최근 시간 기준으로 정렬된 결과를 반환하며, lastMessageId에 해당하는 메시지는 포함되지 않습니다.
+     * 만약, lastMessageId에 해당하는 메시지가 필요한 경우 인자는 lastMessageId + 1로 설정해야 합니다.
+     *
+     * @param roomId        Long: 채팅방 ID
+     * @param lastMessageId Long: 마지막으로 조회한 메시지의 TSID
+     * @param size          int: 조회할 메시지 개수
+     * @return 페이징된 메시지 목록
+     */
+    public Slice<ChatMessage> readMessagesBefore(Long roomId, Long lastMessageId, int size) {
+        return chatMessageRepositoryImpl.findMessagesBefore(roomId, lastMessageId, size);
+    }
+
+    /**
+     * 사용자가 마지막으로 읽은 메시지 이후의 안 읽은 메시지 개수를 조회합니다.
+     *
+     * @param roomId            채팅방 ID
+     * @param lastReadMessageId 사용자가 마지막으로 읽은 메시지의 TSID
+     * @return 안 읽은 메시지 개수
+     */
+    public Long countUnreadMessages(Long roomId, Long lastReadMessageId) {
+        return chatMessageRepositoryImpl.countUnreadMessages(roomId, lastReadMessageId);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/exception/ChatMemberErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/exception/ChatMemberErrorCode.java
@@ -11,6 +11,9 @@ public enum ChatMemberErrorCode implements BaseErrorCode {
     /* 403 FORBIDDEN */
     BANNED(StatusCode.FORBIDDEN, ReasonCode.ACCESS_TO_THE_REQUESTED_RESOURCE_IS_FORBIDDEN, "차단된 회원입니다."),
 
+    /* 404 NOT FOUND */
+    NOT_FOUND(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "회원을 찾을 수 없습니다."),
+
     /* 409 Conflict */
     ALREADY_JOINED(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 가입한 회원입니다."),
     ;

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
@@ -5,11 +5,25 @@ import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface ChatMemberRepository extends ExtendedRepository<ChatMember, Long>, CustomChatMemberRepository {
     @Transactional(readOnly = true)
     Set<ChatMember> findByChatRoom_IdAndUser_Id(Long chatRoomId, Long userId);
+
+    @Transactional(readOnly = true)
+    @Query("SELECT cm FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.user.id = :userId AND cm.deletedAt IS NULL")
+    Optional<ChatMember> findActiveChatMember(Long chatRoomId, Long userId);
+
+    @Transactional(readOnly = true)
+    @Query("SELECT cm FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.user.id IN :memberIds AND cm.deletedAt IS NULL")
+    List<ChatMember> findByChatRoom_IdAndUser_IdIn(Long chatRoomId, Set<Long> memberIds);
+
+    @Transactional(readOnly = true)
+    @Query("SELECT cm.user.id FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.user.id NOT IN :memberIds AND cm.deletedAt IS NULL")
+    List<Long> findByChatRoom_IdAndUser_IdNotIn(Long chatRoomId, Set<Long> memberIds);
 
     @Transactional(readOnly = true)
     @Query("SELECT COUNT(*) FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.deletedAt IS NULL")

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Slf4j
@@ -46,7 +48,22 @@ public class ChatMemberService {
         return chatMemberRepository.save(chatMember);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
+    public Optional<ChatMember> readChatMember(Long userId, Long chatRoomId) {
+        return chatMemberRepository.findActiveChatMember(chatRoomId, userId).stream().findFirst();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatMember> readChatMembersByMemberIdIn(Long chatRoomId, Set<Long> memberIds) {
+        return chatMemberRepository.findByChatRoom_IdAndUser_IdIn(chatRoomId, memberIds);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> readChatMemberIdsByMemberIdNotIn(Long chatRoomId, Set<Long> memberIds) {
+        return chatMemberRepository.findByChatRoom_IdAndUser_IdNotIn(chatRoomId, memberIds);
+    }
+
+    @Transactional(readOnly = true)
     public Set<Long> readChatRoomIdsByUserId(Long userId) {
         return chatMemberRepository.findChatRoomIdsByUserId(userId);
     }

--- a/pennyway-domain/src/main/resources/application-domain.yml
+++ b/pennyway-domain/src/main/resources/application-domain.yml
@@ -86,4 +86,3 @@ spring:
 logging:
   level:
     org.springframework.jdbc: debug
-    io.lettuce.core: DEBUG

--- a/pennyway-domain/src/main/resources/application-domain.yml
+++ b/pennyway-domain/src/main/resources/application-domain.yml
@@ -86,3 +86,4 @@ spring:
 logging:
   level:
     org.springframework.jdbc: debug
+    io.lettuce.core: DEBUG

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryImplTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryImplTest.java
@@ -30,9 +30,9 @@ import static org.junit.jupiter.api.Assertions.*;
 @Slf4j
 @ContextConfiguration(classes = {RedisConfig.class})
 @DataRedisTest(properties = "spring.config.location=classpath:application-domain.yml")
-@Import({ChatMessageRepository.class})
+@Import({ChatMessageRepositoryImpl.class})
 @ActiveProfiles("test")
-public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
+public class ChatMessageRepositoryImplTest extends ContainerRedisTestConfig {
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
 
@@ -40,13 +40,13 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
     private ObjectMapper objectMapper;
 
     //    @Autowired
-    private ChatMessageRepository chatMessageRepository;
+    private ChatMessageRepositoryImpl chatMessageRepositoryImpl;
 
     private ChatMessage chatMessage;
 
     @BeforeEach
     void setUp() {
-        chatMessageRepository = new ChatMessageRepository(redisTemplate, objectMapper);
+        chatMessageRepositoryImpl = new ChatMessageRepositoryImpl(redisTemplate, objectMapper);
         chatMessage = ChatMessageBuilder.builder()
                 .chatRoomId(1L)
                 .chatId(1L)
@@ -61,10 +61,10 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
     @DisplayName("Happy Path: 채팅 메시지 저장에 성공한다")
     void successSaveChatMessage() {
         // when
-        chatMessageRepository.save(chatMessage);
+        chatMessageRepositoryImpl.save(chatMessage);
 
         // then
-        List<ChatMessage> messages = chatMessageRepository.findRecentMessages(1L, 1);
+        List<ChatMessage> messages = chatMessageRepositoryImpl.findRecentMessages(1L, 1);
         assertFalse(messages.isEmpty(), "저장된 메시지는 조회할 수 있어야 합니다");
     }
 
@@ -75,7 +75,7 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
         saveMessagesInOrder(1L, 5);
 
         // when
-        List<ChatMessage> messages = chatMessageRepository.findRecentMessages(1L, 3);
+        List<ChatMessage> messages = chatMessageRepositoryImpl.findRecentMessages(1L, 3);
 
         // then
         assertAll(
@@ -93,7 +93,7 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
         saveMessagesInOrder(1L, 10);
 
         // when
-        Slice<ChatMessage> messageSlice = chatMessageRepository.findMessagesBefore(1L, 8L, 2);
+        Slice<ChatMessage> messageSlice = chatMessageRepositoryImpl.findMessagesBefore(1L, 8L, 2);
 
         // then
         assertAll(
@@ -108,10 +108,10 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
     @DisplayName("Enum 타입들이 올바르게 저장 및 조회된다")
     void successSaveAndFindEnumTypes() {
         // given
-        chatMessageRepository.save(chatMessage);
+        chatMessageRepositoryImpl.save(chatMessage);
 
         // when
-        List<ChatMessage> messages = chatMessageRepository.findRecentMessages(1L, 1);
+        List<ChatMessage> messages = chatMessageRepositoryImpl.findRecentMessages(1L, 1);
         ChatMessage foundMessage = messages.get(0);
 
         // then
@@ -130,7 +130,7 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
         saveMessagesInOrder(1L, 5);
 
         // when
-        Long unreadCount = chatMessageRepository.countUnreadMessages(1L, 3L);
+        Long unreadCount = chatMessageRepositoryImpl.countUnreadMessages(1L, 3L);
 
         // then
         assertEquals(2L, unreadCount, "마지막으로 읽은 메시지(ID: 3) 이후의 메시지 개수(4, 5)가 반환되어야 합니다");
@@ -162,7 +162,7 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
         saveMessagesInOrder(1L, 5);
 
         // when
-        Slice<ChatMessage> messageSlice = chatMessageRepository.findMessagesBefore(1L, Long.MAX_VALUE, 2);
+        Slice<ChatMessage> messageSlice = chatMessageRepositoryImpl.findMessagesBefore(1L, Long.MAX_VALUE, 2);
 
         // then
         assertAll(
@@ -180,7 +180,7 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
         saveMessagesInOrder(1L, 5);
 
         // when
-        Slice<ChatMessage> messageSlice = chatMessageRepository.findMessagesBefore(1L, 2L, 2);
+        Slice<ChatMessage> messageSlice = chatMessageRepositoryImpl.findMessagesBefore(1L, 2L, 2);
 
         // then
         assertAll(
@@ -198,8 +198,8 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
         saveMessagesInOrder(2L, 3);  // room 2
 
         // when
-        List<ChatMessage> room1Messages = chatMessageRepository.findRecentMessages(1L, 5);
-        List<ChatMessage> room2Messages = chatMessageRepository.findRecentMessages(2L, 5);
+        List<ChatMessage> room1Messages = chatMessageRepositoryImpl.findRecentMessages(1L, 5);
+        List<ChatMessage> room2Messages = chatMessageRepositoryImpl.findRecentMessages(2L, 5);
 
         // then
         assertAll(
@@ -214,7 +214,7 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
     @DisplayName("존재하지 않는 채팅방 조회 시 빈 목록을 반환한다")
     void returnEmptyForNonExistingRoom() {
         // when
-        List<ChatMessage> messages = chatMessageRepository.findRecentMessages(999L, 10);
+        List<ChatMessage> messages = chatMessageRepositoryImpl.findRecentMessages(999L, 10);
 
         // then
         assertTrue(messages.isEmpty());
@@ -224,7 +224,7 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
     @DisplayName("존재하지 않는 메시지 ID로 페이징 조회 시 빈 Slice를 반환한다")
     void returnEmptySliceForNonExistingMessage() {
         // when
-        Slice<ChatMessage> messageSlice = chatMessageRepository.findMessagesBefore(1L, 999L, 10);
+        Slice<ChatMessage> messageSlice = chatMessageRepositoryImpl.findMessagesBefore(1L, 999L, 10);
 
         // then
         assertAll(
@@ -240,7 +240,7 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
         saveMessagesInOrder(1L, 3);
 
         // when
-        List<ChatMessage> messages = chatMessageRepository.findRecentMessages(1L, 10);
+        List<ChatMessage> messages = chatMessageRepositoryImpl.findRecentMessages(1L, 10);
 
         // then
         assertEquals(3, messages.size());
@@ -262,12 +262,12 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
                     .sender(1L)
                     .build();
             ReflectionTestUtils.setField(message, "createdAt", now);
-            
-            chatMessageRepository.save(message);
+
+            chatMessageRepositoryImpl.save(message);
         }
 
         // when
-        List<ChatMessage> messages = chatMessageRepository.findRecentMessages(1L, 3);
+        List<ChatMessage> messages = chatMessageRepositoryImpl.findRecentMessages(1L, 3);
 
         // then
         assertAll(
@@ -288,7 +288,7 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
                     .categoryType(MessageCategoryType.NORMAL)
                     .sender(1L)
                     .build();
-            chatMessageRepository.save(message);
+            chatMessageRepositoryImpl.save(message);
         }
     }
 

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryTest.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.domain.common.redis.message.repository;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
 import kr.co.pennyway.domain.common.redis.message.domain.ChatMessageBuilder;
 import kr.co.pennyway.domain.common.redis.message.type.MessageCategoryType;
@@ -7,35 +8,43 @@ import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;
 import kr.co.pennyway.domain.config.ContainerRedisTestConfig;
 import kr.co.pennyway.domain.config.RedisConfig;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.util.Optional;
+import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
 @ContextConfiguration(classes = {RedisConfig.class})
 @DataRedisTest(properties = "spring.config.location=classpath:application-domain.yml")
+@Import({ChatMessageRepository.class})
 @ActiveProfiles("test")
 public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
     @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    //    @Autowired
     private ChatMessageRepository chatMessageRepository;
 
     private ChatMessage chatMessage;
 
     @BeforeEach
     void setUp() {
+        chatMessageRepository = new ChatMessageRepository(redisTemplate, objectMapper);
         chatMessage = ChatMessageBuilder.builder()
                 .chatRoomId(1L)
                 .chatId(1L)
@@ -47,108 +56,118 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
     }
 
     @Test
-    @DisplayName("Happy Path: 채팅 메시지 저장에 성공한다.")
+    @DisplayName("Happy Path: 채팅 메시지 저장에 성공한다")
     void successSaveChatMessage() {
         // when
-        ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+        chatMessageRepository.save(chatMessage);
 
         // then
-        log.info("Saved message: {}", savedMessage);
-        assertAll(
-                () -> assertNotNull(savedMessage, "저장된 메시지는 null이 아니어야 합니다"),
-                () -> assertTrue(savedMessage.getId().matches("\\d+:message:\\d+"), "ID는 'chatroom:{roomId}:message:{messageId}' 형태여야 합니다 ('chatroom:'은 hash key로 제외)"),
-                () -> assertEquals(chatMessage.getId(), savedMessage.getId(), "저장 전후의 ID가 동일해야 합니다")
-        );
+        List<ChatMessage> messages = chatMessageRepository.findRecentMessages(1L, 1);
+        assertFalse(messages.isEmpty(), "저장된 메시지는 조회할 수 있어야 합니다");
     }
 
     @Test
-    @DisplayName("ID로 채팅 메시지 조회에 성공한다.")
-    void successFindChatMessageById() {
+    @DisplayName("최근 메시지를 지정한 개수만큼 조회한다")
+    void successFindRecentMessages() {
         // given
-        ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+        int messageCount = 5;
+        for (long i = 1; i <= messageCount; i++) {
+            ChatMessage message = ChatMessageBuilder.builder()
+                    .chatRoomId(1L)
+                    .chatId(i)
+                    .content("Message " + i)
+                    .contentType(MessageContentType.TEXT)
+                    .categoryType(MessageCategoryType.NORMAL)
+                    .sender(1L)
+                    .build();
+            chatMessageRepository.save(message);
+        }
 
         // when
-        Optional<ChatMessage> foundMessage = chatMessageRepository.findById(chatMessage.getId());
+        List<ChatMessage> messages = chatMessageRepository.findRecentMessages(1L, 3);
 
         // then
         assertAll(
-                () -> assertTrue(foundMessage.isPresent(), "저장된 메시지는 조회할 수 있어야 합니다"),
-                () -> assertEquals(savedMessage.getId(), foundMessage.get().getId(), "조회된 메시지의 ID가 일치해야 합니다")
+                () -> assertEquals(3, messages.size(), "요청한 개수만큼 메시지가 조회되어야 합니다"),
+                () -> assertEquals("Message 5", messages.get(0).getContent(), "최신 메시지가 먼저 조회되어야 합니다"),
+                () -> assertEquals("Message 4", messages.get(1).getContent()),
+                () -> assertEquals("Message 3", messages.get(2).getContent())
         );
     }
 
     @Test
-    @DisplayName("Enum 타입들이 올바르게 저장 및 조회된다.")
+    @DisplayName("특정 메시지 이전의 메시지들을 페이징하여 조회한다")
+    void successFindMessagesAfter() {
+        // given
+        int messageCount = 10;
+        for (long i = 1; i <= messageCount; i++) {
+            ChatMessage message = ChatMessageBuilder.builder()
+                    .chatRoomId(1L)
+                    .chatId(i)
+                    .content("Message " + i)
+                    .contentType(MessageContentType.TEXT)
+                    .categoryType(MessageCategoryType.NORMAL)
+                    .sender(1L)
+                    .build();
+            chatMessageRepository.save(message);
+        }
+
+        // when
+        Slice<ChatMessage> messageSlice = chatMessageRepository.findMessagesBefore(1L, 8L, 2);
+
+        // then
+        assertAll(
+                () -> assertEquals(2, messageSlice.getContent().size(), "요청한 크기만큼 메시지가 조회되어야 합니다"),
+                () -> assertEquals("Message 7", messageSlice.getContent().get(0).getContent()),
+                () -> assertEquals("Message 6", messageSlice.getContent().get(1).getContent()),
+                () -> assertTrue(messageSlice.hasNext(), "남은 메시지가 더 존재해야 합니다.")
+        );
+    }
+
+    @Test
+    @DisplayName("Enum 타입들이 올바르게 저장 및 조회된다")
     void successSaveAndFindEnumTypes() {
         // given
-        ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+        chatMessageRepository.save(chatMessage);
 
         // when
-        Optional<ChatMessage> foundMessage = chatMessageRepository.findById(savedMessage.getId());
+        List<ChatMessage> messages = chatMessageRepository.findRecentMessages(1L, 1);
+        ChatMessage foundMessage = messages.get(0);
 
         // then
         assertAll(
-                () -> assertTrue(foundMessage.isPresent(), "저장된 메시지는 조회할 수 있어야 합니다"),
-                () -> assertEquals(MessageContentType.TEXT, foundMessage.get().getContentType(),
+                () -> assertEquals(MessageContentType.TEXT, foundMessage.getContentType(),
                         "contentType이 올바르게 저장/조회되어야 합니다"),
-                () -> assertEquals(MessageCategoryType.NORMAL, foundMessage.get().getCategoryType(),
+                () -> assertEquals(MessageCategoryType.NORMAL, foundMessage.getCategoryType(),
                         "categoryType이 올바르게 저장/조회되어야 합니다")
         );
     }
 
     @Test
-    @DisplayName("동일한 메시지를 여러 스레드에서 동시에 저장할 때, 중복 저장되지 않는다.")
-    void successSaveChatMessageConcurrently() throws InterruptedException {
+    @DisplayName("안 읽은 메시지 개수를 정확히 계산한다")
+    void successCountUnreadMessages() {
         // given
-        int threadCount = 10;
-        CountDownLatch latch = new CountDownLatch(threadCount);
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        Set<String> savedIds = ConcurrentHashMap.newKeySet();
-
-        // when
-        for (int i = 0; i < threadCount; i++) {
-            executorService.execute(() -> {
-                try {
-                    ChatMessage saved = chatMessageRepository.save(chatMessage);
-                    savedIds.add(saved.getId());
-                } finally {
-                    latch.countDown();
-                }
-            });
+        for (long i = 1; i <= 5; i++) {
+            ChatMessage message = ChatMessageBuilder.builder()
+                    .chatRoomId(1L)
+                    .chatId(i)
+                    .content("Message " + i)
+                    .contentType(MessageContentType.TEXT)
+                    .categoryType(MessageCategoryType.NORMAL)
+                    .sender(1L)
+                    .build();
+            chatMessageRepository.save(message);
         }
-        latch.await();
-        executorService.shutdown();
-
-        // then
-        assertEquals(1, savedIds.size(), "동일한 ID의 메시지는 한 번만 저장되어야 합니다");
-        ChatMessage foundMessage = chatMessageRepository.findById(chatMessage.getId()).orElse(null);
-        assertNotNull(foundMessage, "저장된 메시지는 조회할 수 있어야 합니다");
-    }
-
-    @Test
-    @DisplayName("데이터 정합성 검증")
-    void successCheckDataIntegrity() {
-        // given
-        chatMessageRepository.save(chatMessage);
 
         // when
-        ChatMessage foundMessage = chatMessageRepository.findById(chatMessage.getId()).orElse(null);
+        Long unreadCount = chatMessageRepository.countUnreadMessages(1L, 3L);
 
         // then
-        log.info("Found message: {}", foundMessage);
-        assertAll(
-                () -> assertEquals(chatMessage.getId(), foundMessage.getId()),
-                () -> assertEquals(chatMessage.getContent(), foundMessage.getContent()),
-                () -> assertEquals(chatMessage.getContentType(), foundMessage.getContentType()),
-                () -> assertEquals(chatMessage.getCategoryType(), foundMessage.getCategoryType()),
-                () -> assertEquals(chatMessage.getCreatedAt(), foundMessage.getCreatedAt()),
-                () -> assertEquals(chatMessage.getDeletedAt(), foundMessage.getDeletedAt()),
-                () -> assertEquals(chatMessage.getSender(), foundMessage.getSender())
-        );
+        assertEquals(2L, unreadCount, "마지막으로 읽은 메시지(ID: 3) 이후의 메시지 개수(4, 5)가 반환되어야 합니다");
     }
 
     @Test
-    @DisplayName("메시지 내용이 5000자를 초과하면 저장 시 예외가 발생한다.")
+    @DisplayName("메시지 내용이 5000자를 초과하면 저장 시 예외가 발생한다")
     void throwExceptionWhenContentExceeds5000Characters() {
         // given
         String longContent = "a".repeat(5001);
@@ -164,5 +183,13 @@ public class ChatMessageRepositoryTest extends ContainerRedisTestConfig {
                         .sender(1L)
                         .build(),
                 "메시지 내용이 5000자를 초과하면 예외가 발생해야 합니다");
+    }
+
+    @AfterEach
+    void tearDown() {
+        Set<String> keys = redisTemplate.keys("chatroom:*:message");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.java
@@ -38,8 +38,8 @@ public class ChatMessageSendService {
                 .categoryType(command.categoryType())
                 .sender(command.senderId())
                 .build();
-        message = chatMessageService.save(message);
-        
+        message = chatMessageService.create(message);
+
         ChatMessageDto.Response response = ChatMessageDto.Response.from(message);
 
         messageBrokerAdapter.convertAndSend(


### PR DESCRIPTION
## 작업 이유
- Enable users to retrieve chatroom details (e.g., recent messages, participants, user info) upon accessing the chatroom.

<br/>

## 작업 사항
### 1️⃣ Design
Data requirements:
1. myInfo
2. recentChatMessages
3. recentParticipants
4. otherParticipantIds
  
Since the participant list can reach a max of 300 users, sending all at once is impractical. To handle this, the server will first send recently active participants. The client can then request additional participant details as needed.

<br/>

### 2️⃣  Reuqest & Response Specification
- request
  - url: `GET /v2/chat-rooms/{chatroom_id}`
  - pre-condition: Authenticated User, Joined Chatroom
- response
![image](https://github.com/user-attachments/assets/55b49e0e-df27-4ff5-85b1-500826ac88e5)

<br/>

### 3️⃣ Redis Chat Message Structure
Previously, we stored chat messages with a key format of `chatroom:{chatroom_id}:message:{message_id}` in a hash. Although `message_id` is unique and sortable, it didn’t ensure order when saving. By switching to a `Sorted Set`, we resolve issues around slicing chat history and counting unread messages.

<br/>

### 4️⃣ DTO Naming
- We need a response DTO, but `ChatRoomRes.Detail` already exists.
- Maybe we can try to serialize with ignored fields in the original detail DTO. (Creation must be processed using a static factory method.)
   - This requires thorough testing, and exception handling is challenging since record types provide a public constructor by default.

```java
// 1. View 중심의 네이밍
public final class ChatRoomRes {
    public record Summary(...) { }  // 목록 표시용 간단 정보
    public record Info(...) { }     // 기존 Detail을 Info로 변경 (기본 정보)
    public record View(...) { }     // 새로운 DTO (상세 페이지 전체 뷰)
}

// 2. 사용 목적 중심의 네이밍
public final class ChatRoomRes {
    public record Summary(...) { }           // 현재와 동일
    public record BasicDetail(...) { }       // 기존 Detail
    public record CompleteDetail(...) { }    // 새로운 DTO
}

// 3. 도메인 중심의 네이밍
public final class ChatRoomRes {
    public record Summary(...) { }                 // 현재와 동일
    public record RoomDetail(...) { }             // 기존 Detail (방 정보만)
    public record RoomWithParticipants(...) { }   // 새로운 DTO (방+참여자+메시지)
}
```
- I selected the third solution among the three choices:
   - clarity of domain information
   - other developers can easily infer what information it contains
   - intuitive and straightforward documentation.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- I think the client has the responsibility for sorting based on the user’s name, as the server initially fetches only partial data.
- Is the hasty data send at first approach optimal?

<br/>

## 발견한 이슈
- Update the socket application image to reflect the revised chat message-saving strategy.
- Add unread message count to chatroom search response.

