### PR TITLE
Ignore: ✨ Get Chat Member Informations By Batch

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 import kr.co.pennyway.api.apis.chat.dto.ChatMemberReq;
 import kr.co.pennyway.api.apis.chat.dto.ChatMemberRes;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
@@ -59,5 +59,5 @@ public interface ChatMemberApi {
             @ApiExceptionExplanation(value = ApiErrorCode.class, constant = "OVERFLOW_QUERY_PARAMETER", summary = "쿼리 파라미터 오버플로우", description = "쿼리 파라미터가 최대 개수를 초과하여 채팅방 멤버 조회에 실패했습니다.")
     })
     @ApiResponse(responseCode = "200", description = "채팅방 멤버 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatMembers", array = @ArraySchema(schema = @Schema(implementation = ChatMemberRes.Detail.class)))))
-    ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotNull @RequestParam("ids") Set<Long> ids);
+    ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotEmpty @RequestParam("ids") Set<Long> ids);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -4,15 +4,19 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
 import kr.co.pennyway.api.apis.chat.dto.ChatMemberReq;
+import kr.co.pennyway.api.apis.chat.dto.ChatMemberRes;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
 import kr.co.pennyway.api.common.annotation.ApiExceptionExplanation;
 import kr.co.pennyway.api.common.annotation.ApiResponseExplanations;
+import kr.co.pennyway.api.common.exception.ApiErrorCode;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorCode;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
@@ -21,6 +25,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Set;
 
 @Tag(name = "[채팅방 멤버 API]")
 public interface ChatMemberApi {
@@ -42,4 +49,15 @@ public interface ChatMemberApi {
             @Validated @RequestBody ChatMemberReq.Join payload,
             @AuthenticationPrincipal SecurityUserDetails user
     );
+
+    @Operation(summary = "채팅방 멤버 조회", method = "GET", description = "채팅방 멤버 목록을 조회한다. 오로지 요청자의 채팅방 접근 권한만을 검사하며, 요청 아이디의 채팅방 포함 여부에 대한 검사 및 응답은 포함하지 않는다.")
+    @Parameters({
+            @Parameter(name = "chatRoomId", description = "채팅방 ID", required = true, in = ParameterIn.PATH),
+            @Parameter(name = "ids", description = "멤버 ID 목록. 중복을 허용하며, 순서가 일관되지 않아도 된다. 단, 최대 50개까지 조회 가능하며, null을 허용하지 않는다.", required = true, in = ParameterIn.QUERY, array = @ArraySchema(schema = @Schema(type = "integer")))
+    })
+    @ApiResponseExplanations(errors = {
+            @ApiExceptionExplanation(value = ApiErrorCode.class, constant = "OVERFLOW_QUERY_PARAMETER", summary = "쿼리 파라미터 오버플로우", description = "쿼리 파라미터가 최대 개수를 초과하여 채팅방 멤버 조회에 실패했습니다.")
+    })
+    @ApiResponse(responseCode = "200", description = "채팅방 멤버 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatMembers", array = @ArraySchema(schema = @Schema(implementation = ChatMemberRes.Detail.class)))))
+    ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotNull @RequestParam("ids") Set<Long> ids);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -53,7 +53,9 @@ public interface ChatMemberApi {
     @Operation(summary = "채팅방 멤버 조회", method = "GET", description = "채팅방 멤버 목록을 조회한다. 오로지 요청자의 채팅방 접근 권한만을 검사하며, 요청 아이디의 채팅방 포함 여부에 대한 검사 및 응답은 포함하지 않는다.")
     @Parameters({
             @Parameter(name = "chatRoomId", description = "채팅방 ID", required = true, in = ParameterIn.PATH),
-            @Parameter(name = "ids", description = "멤버 ID 목록. 중복을 허용하며, 순서가 일관되지 않아도 된다. 단, 최대 50개까지 조회 가능하며, null을 허용하지 않는다. ", required = true, in = ParameterIn.QUERY, array = @ArraySchema(schema = @Schema(type = "integer")))
+            @Parameter(name = "ids", description = """
+                    멤버 ID 목록. 중복을 허용하며, 순서가 일관되지 않아도 된다. 단, 최대 50개까지 조회 가능하며, null을 허용하지 않는다. 값은 `[채팅방 API] 채팅방 조회`의 응답으로 얻은 `otherParticipantIds`의 값을 사용하면 된다. (주의, userId가 아님!)"""
+                    , required = true, in = ParameterIn.QUERY, array = @ArraySchema(schema = @Schema(type = "integer")))
     })
     @ApiResponseExplanations(errors = {
             @ApiExceptionExplanation(value = ApiErrorCode.class, constant = "OVERFLOW_QUERY_PARAMETER", summary = "쿼리 파라미터 오버플로우", description = "쿼리 파라미터가 최대 개수를 초과하여 채팅방 멤버 조회에 실패했습니다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -53,7 +53,7 @@ public interface ChatMemberApi {
     @Operation(summary = "채팅방 멤버 조회", method = "GET", description = "채팅방 멤버 목록을 조회한다. 오로지 요청자의 채팅방 접근 권한만을 검사하며, 요청 아이디의 채팅방 포함 여부에 대한 검사 및 응답은 포함하지 않는다.")
     @Parameters({
             @Parameter(name = "chatRoomId", description = "채팅방 ID", required = true, in = ParameterIn.PATH),
-            @Parameter(name = "ids", description = "멤버 ID 목록. 중복을 허용하며, 순서가 일관되지 않아도 된다. 단, 최대 50개까지 조회 가능하며, null을 허용하지 않는다.", required = true, in = ParameterIn.QUERY, array = @ArraySchema(schema = @Schema(type = "integer")))
+            @Parameter(name = "ids", description = "멤버 ID 목록. 중복을 허용하며, 순서가 일관되지 않아도 된다. 단, 최대 50개까지 조회 가능하며, null을 허용하지 않는다. ", required = true, in = ParameterIn.QUERY, array = @ArraySchema(schema = @Schema(type = "integer")))
     })
     @ApiResponseExplanations(errors = {
             @ApiExceptionExplanation(value = ApiErrorCode.class, constant = "OVERFLOW_QUERY_PARAMETER", summary = "쿼리 파라미터 오버플로우", description = "쿼리 파라미터가 최대 개수를 초과하여 채팅방 멤버 조회에 실패했습니다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -1,6 +1,6 @@
 package kr.co.pennyway.api.apis.chat.controller;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 import kr.co.pennyway.api.apis.chat.api.ChatMemberApi;
 import kr.co.pennyway.api.apis.chat.dto.ChatMemberReq;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
@@ -45,7 +45,7 @@ public class ChatMemberController implements ChatMemberApi {
     @Override
     @GetMapping("")
     @PreAuthorize("isAuthenticated() and @chatRoomManager.hasPermission(principal.userId, #chatRoomId)")
-    public ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotNull @RequestParam("ids") Set<Long> ids) {
+    public ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotEmpty @RequestParam("ids") Set<Long> ids) {
         if (ids.size() > 50) {
             throw new ApiErrorException(ApiErrorCode.OVERFLOW_QUERY_PARAMETER);
         }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -45,11 +45,11 @@ public class ChatMemberController implements ChatMemberApi {
     @Override
     @GetMapping("")
     @PreAuthorize("isAuthenticated() and @chatRoomManager.hasPermission(principal.userId, #chatRoomId)")
-    public ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotEmpty @RequestParam("ids") Set<Long> ids) {
-        if (ids.size() > 50) {
+    public ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotEmpty @RequestParam("chatMemberIds") Set<Long> chatMemberIds) {
+        if (chatMemberIds.size() > 50) {
             throw new ApiErrorException(ApiErrorCode.OVERFLOW_QUERY_PARAMETER);
         }
 
-        return ResponseEntity.ok(SuccessResponse.from(CHAT_MEMBERS, chatMemberUseCase.readChatMembers(chatRoomId, ids)));
+        return ResponseEntity.ok(SuccessResponse.from(CHAT_MEMBERS, chatMemberUseCase.readChatMembers(chatRoomId, chatMemberIds)));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -45,7 +45,7 @@ public class ChatMemberController implements ChatMemberApi {
     @Override
     @GetMapping("")
     @PreAuthorize("isAuthenticated() and @chatRoomManager.hasPermission(principal.userId, #chatRoomId)")
-    public ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotEmpty @RequestParam("chatMemberIds") Set<Long> chatMemberIds) {
+    public ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotEmpty @RequestParam("ids") Set<Long> chatMemberIds) {
         if (chatMemberIds.size() > 50) {
             throw new ApiErrorException(ApiErrorCode.OVERFLOW_QUERY_PARAMETER);
         }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -1,9 +1,12 @@
 package kr.co.pennyway.api.apis.chat.controller;
 
+import jakarta.validation.constraints.NotNull;
 import kr.co.pennyway.api.apis.chat.api.ChatMemberApi;
 import kr.co.pennyway.api.apis.chat.dto.ChatMemberReq;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
 import kr.co.pennyway.api.apis.chat.usecase.ChatMemberUseCase;
+import kr.co.pennyway.api.common.exception.ApiErrorCode;
+import kr.co.pennyway.api.common.exception.ApiErrorException;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import kr.co.pennyway.api.common.security.authentication.SecurityUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -14,12 +17,16 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Set;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v2/chat-rooms/{chatRoomId}/chat-members")
 public class ChatMemberController implements ChatMemberApi {
     private static final String CHAT_ROOM = "chatRoom";
+    private static final String CHAT_MEMBERS = "chatMembers";
+
     private final ChatMemberUseCase chatMemberUseCase;
 
     @Override
@@ -33,5 +40,16 @@ public class ChatMemberController implements ChatMemberApi {
         ChatRoomRes.Detail detail = chatMemberUseCase.joinChatRoom(user.getUserId(), chatRoomId, payload.password());
 
         return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOM, detail));
+    }
+
+    @Override
+    @GetMapping("")
+    @PreAuthorize("isAuthenticated() and @chatRoomManager.hasPermission(principal.userId, #chatRoomId)")
+    public ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotNull @RequestParam("ids") Set<Long> ids) {
+        if (ids.size() > 50) {
+            throw new ApiErrorException(ApiErrorCode.OVERFLOW_QUERY_PARAMETER);
+        }
+
+        return ResponseEntity.ok(SuccessResponse.from(CHAT_MEMBERS, chatMemberUseCase.readChatMembers(chatRoomId, ids)));
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatMemberMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatMemberMapper.java
@@ -1,0 +1,16 @@
+package kr.co.pennyway.api.apis.chat.mapper;
+
+import kr.co.pennyway.api.apis.chat.dto.ChatMemberRes;
+import kr.co.pennyway.common.annotation.Mapper;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+
+import java.util.List;
+
+@Mapper
+public final class ChatMemberMapper {
+    public static List<ChatMemberRes.Detail> toChatMemberResDetail(List<ChatMember> chatMembers) {
+        return chatMembers.stream()
+                .map(chatMember -> ChatMemberRes.Detail.from(chatMember, false))
+                .toList();
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberSearchService.java
@@ -19,7 +19,7 @@ public class ChatMemberSearchService {
         return chatMemberService.readChatRoomIdsByUserId(userId);
     }
 
-    public List<ChatMember> readChatMembers(Long chatRoomId, Set<Long> memberIds) {
-        return chatMemberService.readChatMembersByMemberIdIn(chatRoomId, memberIds);
+    public List<ChatMember> readChatMembers(Long chatRoomId, Set<Long> chatMemberIds) {
+        return chatMemberService.readChatMembersByIdIn(chatRoomId, chatMemberIds);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberSearchService.java
@@ -1,10 +1,12 @@
 package kr.co.pennyway.api.apis.chat.service;
 
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Set;
 
 @Slf4j
@@ -15,5 +17,9 @@ public class ChatMemberSearchService {
 
     public Set<Long> readJoinedChatRoomIds(Long userId) {
         return chatMemberService.readChatRoomIdsByUserId(userId);
+    }
+
+    public List<ChatMember> readChatMembers(Long chatRoomId, Set<Long> memberIds) {
+        return chatMemberService.readChatMembersByMemberIdIn(chatRoomId, memberIds);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
@@ -38,10 +38,10 @@ public class ChatRoomWithParticipantsSearchService {
                 .filter(sender -> !sender.equals(userId))
                 .collect(Collectors.toSet());
 
-        List<ChatMember> recentParticipants = chatMemberService.readChatMembersByMemberIdIn(chatRoomId, recentParticipantIds);
+        List<ChatMember> recentParticipants = chatMemberService.readChatMembersByUserIdIn(chatRoomId, recentParticipantIds);
 
         recentParticipantIds.add(userId);
-        List<Long> otherMemberIds = chatMemberService.readChatMemberIdsByMemberIdNotIn(chatRoomId, recentParticipantIds);
+        List<Long> otherMemberIds = chatMemberService.readChatMemberIdsByUserIdNotIn(chatRoomId, recentParticipantIds);
 
         return ChatRoomMapper.toChatRoomResRoomWithParticipants(myInfo, recentParticipants, otherMemberIds, chatMessages);
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -29,8 +29,8 @@ public class ChatMemberUseCase {
         return ChatRoomMapper.toChatRoomResDetail(chatRoom.getLeft(), false, chatRoom.getRight());
     }
 
-    public List<ChatMemberRes.Detail> readChatMembers(Long chatRoomId, Set<Long> memberIds) {
-        List<ChatMember> chatMembers = chatMemberSearchService.readChatMembers(chatRoomId, memberIds);
+    public List<ChatMemberRes.Detail> readChatMembers(Long chatRoomId, Set<Long> chatMemberIds) {
+        List<ChatMember> chatMembers = chatMemberSearchService.readChatMembers(chatRoomId, chatMemberIds);
 
         return ChatMemberMapper.toChatMemberResDetail(chatMembers);
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -1,23 +1,37 @@
 package kr.co.pennyway.api.apis.chat.usecase;
 
+import kr.co.pennyway.api.apis.chat.dto.ChatMemberRes;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
+import kr.co.pennyway.api.apis.chat.mapper.ChatMemberMapper;
 import kr.co.pennyway.api.apis.chat.mapper.ChatRoomMapper;
 import kr.co.pennyway.api.apis.chat.service.ChatMemberJoinService;
+import kr.co.pennyway.api.apis.chat.service.ChatMemberSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class ChatMemberUseCase {
     private final ChatMemberJoinService chatMemberJoinService;
+    private final ChatMemberSearchService chatMemberSearchService;
 
     public ChatRoomRes.Detail joinChatRoom(Long userId, Long chatRoomId, Integer password) {
         Pair<ChatRoom, Integer> chatRoom = chatMemberJoinService.execute(userId, chatRoomId, password);
 
         return ChatRoomMapper.toChatRoomResDetail(chatRoom.getLeft(), false, chatRoom.getRight());
+    }
+
+    public List<ChatMemberRes.Detail> readChatMembers(Long chatRoomId, Set<Long> memberIds) {
+        List<ChatMember> chatMembers = chatMemberSearchService.readChatMembers(chatRoomId, memberIds);
+
+        return ChatMemberMapper.toChatMemberResDetail(chatMembers);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/exception/ApiErrorCode.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/exception/ApiErrorCode.java
@@ -1,0 +1,30 @@
+package kr.co.pennyway.api.common.exception;
+
+import kr.co.pennyway.common.exception.BaseErrorCode;
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.ReasonCode;
+import kr.co.pennyway.common.exception.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiErrorCode implements BaseErrorCode {
+    // 400 Bad Request
+    OVERFLOW_QUERY_PARAMETER(StatusCode.BAD_REQUEST, ReasonCode.INVALID_REQUEST, "쿼리 파라미터가 너무 많습니다."),
+    ;
+
+    private final StatusCode statusCode;
+    private final ReasonCode reasonCode;
+    private final String message;
+
+    @Override
+    public CausedBy causedBy() {
+        return CausedBy.of(statusCode, reasonCode);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldError {
+        return message;
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/exception/ApiErrorException.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/exception/ApiErrorException.java
@@ -1,0 +1,22 @@
+package kr.co.pennyway.api.common.exception;
+
+import kr.co.pennyway.common.exception.CausedBy;
+import kr.co.pennyway.common.exception.GlobalErrorException;
+
+public class ApiErrorException extends GlobalErrorException {
+    private final ApiErrorCode errorCode;
+
+    public ApiErrorException(ApiErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public CausedBy causedBy() {
+        return errorCode.causedBy();
+    }
+
+    public String getExplainError() {
+        return errorCode.getExplainError();
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberBathGetControllerTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberBathGetControllerTest.java
@@ -1,0 +1,126 @@
+package kr.co.pennyway.api.apis.chat.controller;
+
+import kr.co.pennyway.api.apis.chat.dto.ChatMemberRes;
+import kr.co.pennyway.api.apis.chat.usecase.ChatMemberUseCase;
+import kr.co.pennyway.api.config.supporter.WithSecurityMockUser;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ChatMemberController.class)
+@ActiveProfiles("test")
+public class ChatMemberBathGetControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ChatMemberUseCase chatMemberUseCase;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .defaultRequest(MockMvcRequestBuilders.get("/**").with(csrf()))
+                .build();
+    }
+
+    @Test
+    @DisplayName("채팅방 멤버 조회에 성공한다")
+    @WithSecurityMockUser
+    void successReadChatMembers() throws Exception {
+        // given
+        Long chatRoomId = 1L;
+        Set<Long> memberIds = Set.of(1L, 2L, 3L);
+        List<ChatMemberRes.Detail> expectedResponse = createMockMemberDetails();
+
+        given(chatMemberUseCase.readChatMembers(chatRoomId, memberIds)).willReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.get("/v2/chat-rooms/{chatRoomId}/chat-members", chatRoomId)
+                        .param("ids", "1,2,3")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.chatMembers").isArray())
+                .andExpect(jsonPath("$.data.chatMembers.length()").value(3))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("50개를 초과하는 멤버 ID 요청 시 실패한다")
+    @WithSecurityMockUser
+    void failReadChatMembersWhenExceedLimit() throws Exception {
+        // given
+        Long chatRoomId = 1L;
+        Set<Long> memberIds = LongStream.rangeClosed(1, 51)
+                .boxed()
+                .collect(Collectors.toSet());
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.get("/v2/chat-rooms/{chatRoomId}/chat-members", chatRoomId)
+                        .param("ids", memberIds.stream()
+                                .map(String::valueOf)
+                                .collect(Collectors.joining(",")))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("ids가 null인 경우 실패한다 <400 Bad Request>")
+    @WithSecurityMockUser
+    void failReadChatMembersWhenIdsIsNull() throws Exception {
+        // given
+        Long chatRoomId = 1L;
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.get("/v2/chat-rooms/{chatRoomId}/chat-members", chatRoomId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("ids가 빈 값일 경우 실패한다")
+    @WithSecurityMockUser
+    void failReadChatMembersWhenIdsIsEmpty() throws Exception {
+        // given
+        Long chatRoomId = 1L;
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.get("/v2/chat-rooms/{chatRoomId}/chat-members", chatRoomId)
+                        .param("ids", "")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    private List<ChatMemberRes.Detail> createMockMemberDetails() {
+        return List.of(
+                new ChatMemberRes.Detail(1L, "User1", ChatMemberRole.MEMBER, null, LocalDateTime.now()),
+                new ChatMemberRes.Detail(2L, "User2", ChatMemberRole.MEMBER, null, LocalDateTime.now()),
+                new ChatMemberRes.Detail(3L, "User3", ChatMemberRole.MEMBER, null, LocalDateTime.now())
+        );
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatMemberBatchGetIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatMemberBatchGetIntegrationTest.java
@@ -1,0 +1,110 @@
+package kr.co.pennyway.api.apis.chat.integration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.chat.dto.ChatMemberRes;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import kr.co.pennyway.api.common.util.ApiTestHelper;
+import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
+import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
+import kr.co.pennyway.api.config.fixture.ChatRoomFixture;
+import kr.co.pennyway.api.config.fixture.UserFixture;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomService;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.service.UserService;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+@ExternalApiIntegrationTest
+public class ChatMemberBatchGetIntegrationTest extends ExternalApiDBTestConfig {
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ChatRoomService chatRoomService;
+
+    @Autowired
+    private ChatMemberService chatMemberService;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private JwtProvider accessTokenProvider;
+
+    @LocalServerPort
+    private int port;
+
+    private ApiTestHelper apiTestHelper;
+
+    private User owner;
+    private ChatRoom chatRoom;
+    private ChatMember ownerMember;
+
+    @BeforeEach
+    void setUp() {
+        apiTestHelper = new ApiTestHelper(restTemplate, objectMapper, accessTokenProvider);
+
+        owner = userService.createUser(UserFixture.GENERAL_USER.toUser());
+        chatRoom = chatRoomService.create(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(1L));
+        ownerMember = chatMemberService.createAdmin(owner, chatRoom);
+    }
+
+    @Test
+    @DisplayName("채팅방 멤버 조회를 성공한다")
+    void successReadChatMembers() {
+        // given
+        List<User> members = createTestMembers(10);
+        List<Long> memberIds = members.stream().map(User::getId).toList();
+
+        // when
+        ResponseEntity<?> response = apiTestHelper.callApi(
+                "http://localhost:" + port + "/v2/chat-rooms/{chatRoomId}/chat-members?ids={ids}",
+                HttpMethod.GET,
+                owner,
+                null,
+                new TypeReference<SuccessResponse<Map<String, List<ChatMemberRes.Detail>>>>() {
+                },
+                chatRoom.getId(),
+                String.join(",", memberIds.stream().map(String::valueOf).toList())
+        );
+        SuccessResponse<Map<String, List<ChatMemberRes.Detail>>> body = (SuccessResponse<Map<String, List<ChatMemberRes.Detail>>>) response.getBody();
+        List<ChatMemberRes.Detail> payload = body.getData().get("chatMembers");
+
+        // then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(memberIds.size(), payload.size());
+    }
+
+    private List<User> createTestMembers(int count) {
+        List<User> createdMembers = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            User member = userService.createUser(UserFixture.GENERAL_USER.toUser());
+            chatMemberService.createMember(member, chatRoom);
+            createdMembers.add(member);
+        }
+        return createdMembers;
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatMemberBatchGetIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatMemberBatchGetIntegrationTest.java
@@ -76,8 +76,8 @@ public class ChatMemberBatchGetIntegrationTest extends ExternalApiDBTestConfig {
     @DisplayName("채팅방 멤버 조회를 성공한다")
     void successReadChatMembers() {
         // given
-        List<User> members = createTestMembers(10);
-        List<Long> memberIds = members.stream().map(User::getId).toList();
+        List<ChatMember> members = createTestMembers(10);
+        List<Long> memberIds = members.stream().map(ChatMember::getId).toList();
 
         // when
         ResponseEntity<?> response = apiTestHelper.callApi(
@@ -98,12 +98,11 @@ public class ChatMemberBatchGetIntegrationTest extends ExternalApiDBTestConfig {
         assertEquals(memberIds.size(), payload.size());
     }
 
-    private List<User> createTestMembers(int count) {
-        List<User> createdMembers = new ArrayList<>();
+    private List<ChatMember> createTestMembers(int count) {
+        List<ChatMember> createdMembers = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             User member = userService.createUser(UserFixture.GENERAL_USER.toUser());
-            chatMemberService.createMember(member, chatRoom);
-            createdMembers.add(member);
+            createdMembers.add(chatMemberService.createMember(member, chatRoom));
         }
         return createdMembers;
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchServiceTest.java
@@ -64,8 +64,8 @@ public class ChatRoomWithParticipantsSearchServiceTest {
 
         given(chatMemberService.readChatMember(userId, chatRoom.getId())).willReturn(Optional.of(myInfo));
         given(chatMessageService.readRecentMessages(eq(chatRoom.getId()), anyInt())).willReturn(recentMessages);
-        given(chatMemberService.readChatMembersByMemberIdIn(eq(chatRoom.getId()), anySet())).willReturn(recentParticipants);
-        given(chatMemberService.readChatMemberIdsByMemberIdNotIn(eq(chatRoom.getId()), anySet())).willReturn(otherMemberIds);
+        given(chatMemberService.readChatMembersByUserIdIn(eq(chatRoom.getId()), anySet())).willReturn(recentParticipants);
+        given(chatMemberService.readChatMemberIdsByUserIdNotIn(eq(chatRoom.getId()), anySet())).willReturn(otherMemberIds);
 
         // when
         ChatRoomRes.RoomWithParticipants result = service.execute(userId, chatRoom.getId());
@@ -83,8 +83,8 @@ public class ChatRoomWithParticipantsSearchServiceTest {
         // verify
         verify(chatMemberService).readChatMember(userId, chatRoom.getId());
         verify(chatMessageService).readRecentMessages(eq(chatRoom.getId()), anyInt());
-        verify(chatMemberService).readChatMembersByMemberIdIn(eq(chatRoom.getId()), anySet());
-        verify(chatMemberService).readChatMemberIdsByMemberIdNotIn(eq(chatRoom.getId()), anySet());
+        verify(chatMemberService).readChatMembersByUserIdIn(eq(chatRoom.getId()), anySet());
+        verify(chatMemberService).readChatMemberIdsByUserIdNotIn(eq(chatRoom.getId()), anySet());
     }
 
     @Test

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
@@ -14,6 +14,10 @@ public interface ChatMemberRepository extends ExtendedRepository<ChatMember, Lon
     Set<ChatMember> findByChatRoom_IdAndUser_Id(Long chatRoomId, Long userId);
 
     @Transactional(readOnly = true)
+    @Query("SELECT cm FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.id IN :chatMemberIds")
+    List<ChatMember> findByChatRoom_IdAndIdIn(Long chatRoomId, Set<Long> chatMemberIds);
+
+    @Transactional(readOnly = true)
     @Query("SELECT cm FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.user.id = :userId AND cm.deletedAt IS NULL")
     Optional<ChatMember> findActiveChatMember(Long chatRoomId, Long userId);
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -54,13 +54,18 @@ public class ChatMemberService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatMember> readChatMembersByMemberIdIn(Long chatRoomId, Set<Long> memberIds) {
-        return chatMemberRepository.findByChatRoom_IdAndUser_IdIn(chatRoomId, memberIds);
+    public List<ChatMember> readChatMembersByIdIn(Long chatRoomId, Set<Long> chatMemberIds) {
+        return chatMemberRepository.findByChatRoom_IdAndIdIn(chatRoomId, chatMemberIds);
     }
 
     @Transactional(readOnly = true)
-    public List<Long> readChatMemberIdsByMemberIdNotIn(Long chatRoomId, Set<Long> memberIds) {
-        return chatMemberRepository.findByChatRoom_IdAndUser_IdNotIn(chatRoomId, memberIds);
+    public List<ChatMember> readChatMembersByUserIdIn(Long chatRoomId, Set<Long> userIds) {
+        return chatMemberRepository.findByChatRoom_IdAndUser_IdIn(chatRoomId, userIds);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> readChatMemberIdsByUserIdNotIn(Long chatRoomId, Set<Long> userIds) {
+        return chatMemberRepository.findByChatRoom_IdAndUser_IdNotIn(chatRoomId, userIds);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 작업 이유
> 시간 없어서 한글로 빠르게..
- #188 이전 PR의 `급한 데이터 우선 로딩` 전략 이후, 아직 조회하지 않은 채팅방 멤버 정보 조회를 위한 API

<br/>

## 작업 사항
- request
   - url: `GET /v2/chat-rooms/{chat_room_id}/chat-members?ids=`
   - pre-condition: 인증된 사용자. 채팅방 가입자
   - query param:
      - `ids`: 조회할 멤버 ID 목록. 중복을 허용하며, 순서가 일관되지 않아도 된다. 단, 최대 50개까지 조회 가능하며, null을 허용하지 않는다.
- response
   ```json
  {
      "chatMembers": [
        {
            "id": 0,
            "title": "string",
            "description": "string",
            "backgroundImageUrl": "string",
            "isPrivate": true,
            "isAdmin": true,
            "participantCount": 0,
            "createdAt": "2024-11-02 10:19:45"
         }
      ]
  }
   ```

<br/>

요청할 때, 모든 `chat_member.id` 값을 query 파라미터로 받는 것에 거부감은 있었다만..  

```
GET /v2/chat-rooms/{chatRoomId}/chat-members?ids=1,2,3,...,50&orderBy=name

기본 path: /v2/chat-rooms/123/chat-members  // ~30자
파라미터 key: ?ids=  // 5자
ID 값: 각 ID가 최대 19자 (Java Long.MAX_VALUE = 9223372036854775807)
구분자: 콤마 49개 (49자)
orderBy 파라미터: &orderBy=name  // ~12자

최대 길이 = 30 + 5 + (19 * 50) + 49 + 12 = ~1046자
```
각 브라우저/서버의 URL 길이 제한:
- 브라우저
   - Chrome: ~32,779자
   - Firefox: ~65,536자
   - Safari: ~80,000자
   - Edge: ~2,083자

- 서버
   - Apache: 기본 8,192자
   - Nginx: 기본 4,096자
   - Tomcat: 기본 8,192자
   - IIS: ~16,384자

- 최대 URL 길이(~1046자)가 대부분의 브라우저/서버 제한보다 충분히 작음.
- Proxy나 방화벽에서 긴 URL 차단 가능성
- URL 인코딩 시 길이가 더 늘어날 수 있음
- 로깅 시스템에서 URL 잘림 가능성

어차피 클라이언트한테 노출되는 url도 아니고, REST 명세를 지키려면 이게 또 맞긴 하고..  
전략 자체를 수정할 게 아니면 어찌할 방법이 없어서 패스.  

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- query param 말고 다른 방법 있을지?
- 요청할 때 자신의 member_id를 넣는 경우는 굳이 고려하지 않음. 클라이언트가 실수로 넣는다고 딱히 아무 일 없음.  
- 조회할 때 room_id를 where 절에 포함하는 이유는, member_id만 사용할 경우 아무 값이나 넣어서 다른 채팅방 클라이언트 정보를 확인할 여지가 존재하기 때문.  

<br/>

## 발견한 이슈
- 바보같이 `ids`를 `chat_member.id`가 아니라, `user.id` 넣고 테스트 돌리던 도중 뭔가 이상해서 싹 다 다시 고침. 능지 이슈  