### PR TITLE
Api: ✏️ Append UnreadMessageCount Field in the ChatRoomResponse

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -60,6 +60,6 @@ public interface ChatMemberApi {
     @ApiResponseExplanations(errors = {
             @ApiExceptionExplanation(value = ApiErrorCode.class, constant = "OVERFLOW_QUERY_PARAMETER", summary = "쿼리 파라미터 오버플로우", description = "쿼리 파라미터가 최대 개수를 초과하여 채팅방 멤버 조회에 실패했습니다.")
     })
-    @ApiResponse(responseCode = "200", description = "채팅방 멤버 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatMembers", array = @ArraySchema(schema = @Schema(implementation = ChatMemberRes.Detail.class)))))
+    @ApiResponse(responseCode = "200", description = "채팅방 멤버 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatMembers", array = @ArraySchema(schema = @Schema(implementation = ChatMemberRes.MemberDetail.class)))))
     ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotEmpty @RequestParam("ids") Set<Long> ids);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
@@ -41,7 +41,7 @@ public interface ChatRoomApi {
     @ApiResponse(responseCode = "200", description = "채팅방 검색 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRooms", schema = @Schema(implementation = SliceResponseTemplate.class))))
     ResponseEntity<?> searchChatRooms(@Validated ChatRoomReq.SearchQuery query, @AuthenticationPrincipal SecurityUserDetails user);
 
-    @Operation(summary = "채팅방 조회", method = "GET", description = "사용자가 가입한 채팅방 중 특정 채팅방의 상세 정보를 조회한다. 채팅방의 상세 정보에는 채팅방의 참여자 목록과 최근 채팅 메시지 목록 등이 포함된다.")
+    @Operation(summary = "채팅방 상세 조회", method = "GET", description = "사용자가 가입한 채팅방 중 특정 채팅방의 상세 정보를 조회한다. 채팅방의 상세 정보에는 채팅방의 참여자 목록과 최근 채팅 메시지 목록 등이 포함된다.")
     @Parameter(name = "chatRoomId", description = "조회할 채팅방의 식별자", example = "1", required = true)
     @ApiResponse(responseCode = "200", description = "채팅방 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRoom", schema = @Schema(implementation = ChatRoomRes.RoomWithParticipants.class))))
     ResponseEntity<?> getChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @AuthenticationPrincipal SecurityUserDetails user);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberRes.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 
 public final class ChatMemberRes {
     @Schema(description = "채팅방 참여자 상세 정보")
-    public record Detail(
+    public record MemberDetail(
             @Schema(description = "채팅방 참여자 ID", type = "long")
             Long id,
             @Schema(description = "채팅방 참여자 이름")
@@ -27,8 +27,8 @@ public final class ChatMemberRes {
             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime createdAt
     ) {
-        public static Detail from(ChatMember chatMember, boolean isContainNotifyEnabled) {
-            return new Detail(
+        public static MemberDetail from(ChatMember chatMember, boolean isContainNotifyEnabled) {
+            return new MemberDetail(
                     chatMember.getId(),
                     chatMember.getName(),
                     chatMember.getRole(),

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRes.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 
 public final class ChatRes {
     @Schema(description = "채팅 메시지 상세 정보")
-    public record Detail(
+    public record ChatDetail(
             @Schema(description = "채팅방 ID", type = "long")
             Long chatRoomId,
             @Schema(description = "채팅 ID", type = "long")
@@ -30,8 +30,8 @@ public final class ChatRes {
             @Schema(description = "채팅 보낸 사람 ID", type = "long")
             Long senderId
     ) {
-        public static Detail from(ChatMessage message) {
-            return new Detail(
+        public static ChatDetail from(ChatMessage message) {
+            return new ChatDetail(
                     message.getChatRoomId(),
                     message.getChatId(),
                     message.getContent(),

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -32,9 +32,11 @@ public final class ChatRoomRes {
             @Schema(description = "채팅방 개설일")
             @JsonSerialize(using = LocalDateTimeSerializer.class)
             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            @Schema(description = "읽지 않은 메시지 수. 100 이상의 값을 가지면, 100으로 표시된다.")
+            long unreadMessageCount
     ) {
-        public Detail(Long id, String title, String description, String backgroundImageUrl, boolean isPrivate, boolean isAdmin, int participantCount, LocalDateTime createdAt) {
+        public Detail(Long id, String title, String description, String backgroundImageUrl, boolean isPrivate, boolean isAdmin, int participantCount, LocalDateTime createdAt, long unreadMessageCount) {
             this.id = id;
             this.title = title;
             this.description = Objects.toString(description, "");
@@ -43,9 +45,10 @@ public final class ChatRoomRes {
             this.isAdmin = isAdmin;
             this.participantCount = participantCount;
             this.createdAt = createdAt;
+            this.unreadMessageCount = (unreadMessageCount > 100) ? 100 : unreadMessageCount;
         }
 
-        public static Detail from(ChatRoom chatRoom, boolean isAdmin, int participantCount) {
+        public static Detail of(ChatRoom chatRoom, boolean isAdmin, int participantCount, long unreadMessageCount) {
             return new Detail(
                     chatRoom.getId(),
                     chatRoom.getTitle(),
@@ -54,7 +57,8 @@ public final class ChatRoomRes {
                     chatRoom.getPassword() != null,
                     isAdmin,
                     participantCount,
-                    chatRoom.getCreatedAt()
+                    chatRoom.getCreatedAt(),
+                    unreadMessageCount
             );
         }
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -80,7 +80,7 @@ public final class ChatRoomRes {
             @Schema(description = "채팅방에서 내 정보와 최근 활동자를 제외한 참여자 ID 목록")
             List<Long> otherParticipantIds,
             @Schema(description = "최근 채팅 이력. 메시지는 최신순으로 정렬되어 반환.")
-            List<ChatRes.Detail> recentMessages
+            List<ChatRes.ChatDetail> recentMessages
     ) {
 
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -74,9 +74,9 @@ public final class ChatRoomRes {
     @Builder
     public record RoomWithParticipants(
             @Schema(description = "채팅방에서 내 정보")
-            ChatMemberRes.Detail myInfo,
+            ChatMemberRes.MemberDetail myInfo,
             @Schema(description = "최근에 채팅 메시지를 보낸 참여자의 상세 정보 목록")
-            List<ChatMemberRes.Detail> recentParticipants,
+            List<ChatMemberRes.MemberDetail> recentParticipants,
             @Schema(description = "채팅방에서 내 정보와 최근 활동자를 제외한 참여자 ID 목록")
             List<Long> otherParticipantIds,
             @Schema(description = "최근 채팅 이력. 메시지는 최신순으로 정렬되어 반환.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatMemberMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatMemberMapper.java
@@ -8,9 +8,9 @@ import java.util.List;
 
 @Mapper
 public final class ChatMemberMapper {
-    public static List<ChatMemberRes.Detail> toChatMemberResDetail(List<ChatMember> chatMembers) {
+    public static List<ChatMemberRes.MemberDetail> toChatMemberResDetail(List<ChatMember> chatMembers) {
         return chatMembers.stream()
-                .map(chatMember -> ChatMemberRes.Detail.from(chatMember, false))
+                .map(chatMember -> ChatMemberRes.MemberDetail.from(chatMember, false))
                 .toList();
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
@@ -71,8 +71,8 @@ public final class ChatRoomMapper {
                 .map(participant -> ChatMemberRes.MemberDetail.from(participant, false))
                 .toList();
 
-        List<ChatRes.Detail> chatMessagesRes = chatMessages.stream()
-                .map(ChatRes.Detail::from)
+        List<ChatRes.ChatDetail> chatMessagesRes = chatMessages.stream()
+                .map(ChatRes.ChatDetail::from)
                 .toList();
 
         return ChatRoomRes.RoomWithParticipants.builder()

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
@@ -14,21 +14,36 @@ import org.springframework.data.domain.Slice;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Mapper
 public final class ChatRoomMapper {
-
-
     public static SliceResponseTemplate<ChatRoomRes.Detail> toChatRoomResDetails(Slice<ChatRoomDetail> details, Pageable pageable) {
-        List<ChatRoomRes.Detail> contents = toChatRoomResDetails(details.getContent());
+        List<ChatRoomRes.Detail> contents = new ArrayList<>();
+        for (ChatRoomDetail detail : details.getContent()) {
+            contents.add(
+                    new ChatRoomRes.Detail(
+                            detail.id(),
+                            detail.title(),
+                            detail.description(),
+                            detail.backgroundImageUrl(),
+                            detail.password() != null,
+                            detail.isAdmin(),
+                            detail.participantCount(),
+                            detail.createdAt(),
+                            0
+                    )
+            );
+        }
 
         return SliceResponseTemplate.of(contents, pageable, contents.size(), details.hasNext());
     }
 
-    public static List<ChatRoomRes.Detail> toChatRoomResDetails(List<ChatRoomDetail> details) {
+    public static List<ChatRoomRes.Detail> toChatRoomResDetails(Map<ChatRoomDetail, Long> details) {
         List<ChatRoomRes.Detail> responses = new ArrayList<>();
 
-        for (ChatRoomDetail detail : details) {
+        for (Map.Entry<ChatRoomDetail, Long> entry : details.entrySet()) {
+            ChatRoomDetail detail = entry.getKey();
             responses.add(
                     new ChatRoomRes.Detail(
                             detail.id(),
@@ -38,7 +53,8 @@ public final class ChatRoomMapper {
                             detail.password() != null,
                             detail.isAdmin(),
                             detail.participantCount(),
-                            detail.createdAt()
+                            detail.createdAt(),
+                            entry.getValue()
                     )
             );
         }
@@ -46,8 +62,8 @@ public final class ChatRoomMapper {
         return responses;
     }
 
-    public static ChatRoomRes.Detail toChatRoomResDetail(ChatRoom chatRoom, boolean isAdmin, int participantCount) {
-        return ChatRoomRes.Detail.from(chatRoom, isAdmin, participantCount);
+    public static ChatRoomRes.Detail toChatRoomResDetail(ChatRoom chatRoom, boolean isAdmin, int participantCount, long unreadMessageCount) {
+        return ChatRoomRes.Detail.of(chatRoom, isAdmin, participantCount, unreadMessageCount);
     }
 
     public static ChatRoomRes.RoomWithParticipants toChatRoomResRoomWithParticipants(ChatMember myInfo, List<ChatMember> recentParticipants, List<Long> otherMemberIds, List<ChatMessage> chatMessages) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
@@ -67,8 +67,8 @@ public final class ChatRoomMapper {
     }
 
     public static ChatRoomRes.RoomWithParticipants toChatRoomResRoomWithParticipants(ChatMember myInfo, List<ChatMember> recentParticipants, List<Long> otherMemberIds, List<ChatMessage> chatMessages) {
-        List<ChatMemberRes.Detail> recentParticipantsRes = recentParticipants.stream()
-                .map(participant -> ChatMemberRes.Detail.from(participant, false))
+        List<ChatMemberRes.MemberDetail> recentParticipantsRes = recentParticipants.stream()
+                .map(participant -> ChatMemberRes.MemberDetail.from(participant, false))
                 .toList();
 
         List<ChatRes.Detail> chatMessagesRes = chatMessages.stream()
@@ -76,7 +76,7 @@ public final class ChatRoomMapper {
                 .toList();
 
         return ChatRoomRes.RoomWithParticipants.builder()
-                .myInfo(ChatMemberRes.Detail.from(myInfo, true))
+                .myInfo(ChatMemberRes.MemberDetail.from(myInfo, true))
                 .recentParticipants(recentParticipantsRes)
                 .otherParticipantIds(otherMemberIds)
                 .recentMessages(chatMessagesRes)

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSearchService.java
@@ -1,7 +1,9 @@
 package kr.co.pennyway.api.apis.chat.service;
 
+import kr.co.pennyway.domain.common.redis.message.service.ChatMessageService;
 import kr.co.pennyway.domain.domains.chatroom.dto.ChatRoomDetail;
 import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomService;
+import kr.co.pennyway.domain.domains.chatstatus.service.ChatMessageStatusService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -9,17 +11,28 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatRoomSearchService {
     private final ChatRoomService chatRoomService;
+    private final ChatMessageStatusService chatMessageStatusService;
+    private final ChatMessageService chatMessageService;
 
+    /**
+     * 사용자 ID가 속한 채팅방 목록을 조회한다.
+     *
+     * @return 채팅방 목록 (채팅방 정보, 읽지 않은 메시지 수)
+     */
     @Transactional(readOnly = true)
-    public List<ChatRoomDetail> readChatRooms(Long userId) {
-        return chatRoomService.readChatRoomsByUserId(userId);
+    public Map<ChatRoomDetail, Long> readChatRooms(Long userId) {
+        return chatRoomService.readChatRoomsByUserId(userId).stream()
+                .collect(Collectors.toMap(chatRoom -> chatRoom, chatRoom -> chatMessageStatusService.readLastReadMessageId(userId, chatRoom.id())))
+                .entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> chatMessageService.countUnreadMessages(userId, entry.getValue())));
     }
 
     @Transactional(readOnly = true)

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -11,7 +11,7 @@ import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.List;
 import java.util.Set;
@@ -24,9 +24,9 @@ public class ChatMemberUseCase {
     private final ChatMemberSearchService chatMemberSearchService;
 
     public ChatRoomRes.Detail joinChatRoom(Long userId, Long chatRoomId, Integer password) {
-        Pair<ChatRoom, Integer> chatRoom = chatMemberJoinService.execute(userId, chatRoomId, password);
+        Triple<ChatRoom, Integer, Long> chatRoom = chatMemberJoinService.execute(userId, chatRoomId, password);
 
-        return ChatRoomMapper.toChatRoomResDetail(chatRoom.getLeft(), false, chatRoom.getRight());
+        return ChatRoomMapper.toChatRoomResDetail(chatRoom.getLeft(), false, chatRoom.getMiddle(), chatRoom.getRight());
     }
 
     public List<ChatMemberRes.Detail> readChatMembers(Long chatRoomId, Set<Long> chatMemberIds) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -29,7 +29,7 @@ public class ChatMemberUseCase {
         return ChatRoomMapper.toChatRoomResDetail(chatRoom.getLeft(), false, chatRoom.getMiddle(), chatRoom.getRight());
     }
 
-    public List<ChatMemberRes.Detail> readChatMembers(Long chatRoomId, Set<Long> chatMemberIds) {
+    public List<ChatMemberRes.MemberDetail> readChatMembers(Long chatRoomId, Set<Long> chatMemberIds) {
         List<ChatMember> chatMembers = chatMemberSearchService.readChatMembers(chatRoomId, chatMemberIds);
 
         return ChatMemberMapper.toChatMemberResDetail(chatMembers);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @UseCase
@@ -30,11 +31,11 @@ public class ChatRoomUseCase {
     public ChatRoomRes.Detail createChatRoom(ChatRoomReq.Create request, Long userId) {
         ChatRoom chatRoom = chatRoomSaveService.createChatRoom(request, userId);
 
-        return ChatRoomMapper.toChatRoomResDetail(chatRoom, true, 1);
+        return ChatRoomMapper.toChatRoomResDetail(chatRoom, true, 1, 0);
     }
 
     public List<ChatRoomRes.Detail> getChatRooms(Long userId) {
-        List<ChatRoomDetail> chatRooms = chatRoomSearchService.readChatRooms(userId);
+        Map<ChatRoomDetail, Long> chatRooms = chatRoomSearchService.readChatRooms(userId);
 
         return ChatRoomMapper.toChatRoomResDetails(chatRooms);
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberBathGetControllerTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberBathGetControllerTest.java
@@ -53,7 +53,7 @@ public class ChatMemberBathGetControllerTest {
         // given
         Long chatRoomId = 1L;
         Set<Long> memberIds = Set.of(1L, 2L, 3L);
-        List<ChatMemberRes.Detail> expectedResponse = createMockMemberDetails();
+        List<ChatMemberRes.MemberDetail> expectedResponse = createMockMemberDetails();
 
         given(chatMemberUseCase.readChatMembers(chatRoomId, memberIds)).willReturn(expectedResponse);
 
@@ -116,11 +116,11 @@ public class ChatMemberBathGetControllerTest {
                 .andDo(print());
     }
 
-    private List<ChatMemberRes.Detail> createMockMemberDetails() {
+    private List<ChatMemberRes.MemberDetail> createMockMemberDetails() {
         return List.of(
-                new ChatMemberRes.Detail(1L, "User1", ChatMemberRole.MEMBER, null, LocalDateTime.now()),
-                new ChatMemberRes.Detail(2L, "User2", ChatMemberRole.MEMBER, null, LocalDateTime.now()),
-                new ChatMemberRes.Detail(3L, "User3", ChatMemberRole.MEMBER, null, LocalDateTime.now())
+                new ChatMemberRes.MemberDetail(1L, "User1", ChatMemberRole.MEMBER, null, LocalDateTime.now()),
+                new ChatMemberRes.MemberDetail(2L, "User2", ChatMemberRole.MEMBER, null, LocalDateTime.now()),
+                new ChatMemberRes.MemberDetail(3L, "User3", ChatMemberRole.MEMBER, null, LocalDateTime.now())
         );
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomSaveControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomSaveControllerUnitTest.java
@@ -52,7 +52,7 @@ public class ChatRoomSaveControllerUnitTest {
         // given
         ChatRoom fixture = ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity(1L);
         ChatRoomReq.Create request = ChatRoomFixture.PRIVATE_CHAT_ROOM.toCreateRequest();
-        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.from(fixture, true, 1));
+        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.of(fixture, true, 1, 10));
 
         // when
         ResultActions result = performPostChatRoom(request);
@@ -70,7 +70,7 @@ public class ChatRoomSaveControllerUnitTest {
         ChatRoom fixture = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(1L);
         ChatRoomReq.Create request = ChatRoomFixture.PUBLIC_CHAT_ROOM.toCreateRequest();
 
-        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.from(fixture, true, 1));
+        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.of(fixture, true, 1, 10));
 
         // when
         ResultActions result = performPostChatRoom(request);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatMemberBatchGetIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatMemberBatchGetIntegrationTest.java
@@ -85,13 +85,13 @@ public class ChatMemberBatchGetIntegrationTest extends ExternalApiDBTestConfig {
                 HttpMethod.GET,
                 owner,
                 null,
-                new TypeReference<SuccessResponse<Map<String, List<ChatMemberRes.Detail>>>>() {
+                new TypeReference<SuccessResponse<Map<String, List<ChatMemberRes.MemberDetail>>>>() {
                 },
                 chatRoom.getId(),
                 String.join(",", memberIds.stream().map(String::valueOf).toList())
         );
-        SuccessResponse<Map<String, List<ChatMemberRes.Detail>>> body = (SuccessResponse<Map<String, List<ChatMemberRes.Detail>>>) response.getBody();
-        List<ChatMemberRes.Detail> payload = body.getData().get("chatMembers");
+        SuccessResponse<Map<String, List<ChatMemberRes.MemberDetail>>> body = (SuccessResponse<Map<String, List<ChatMemberRes.MemberDetail>>>) response.getBody();
+        List<ChatMemberRes.MemberDetail> payload = body.getData().get("chatMembers");
 
         // then
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSearchServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSearchServiceTest.java
@@ -1,0 +1,127 @@
+package kr.co.pennyway.api.apis.chat.service;
+
+import kr.co.pennyway.domain.common.redis.message.service.ChatMessageService;
+import kr.co.pennyway.domain.domains.chatroom.dto.ChatRoomDetail;
+import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomService;
+import kr.co.pennyway.domain.domains.chatstatus.service.ChatMessageStatusService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomSearchServiceTest {
+    @InjectMocks
+    private ChatRoomSearchService chatRoomSearchService;
+
+    @Mock
+    private ChatRoomService chatRoomService;
+    @Mock
+    private ChatMessageStatusService chatMessageStatusService;
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    @Test
+    @DisplayName("사용자의 채팅방 목록과 각 방의 읽지 않은 메시지 수를 정상적으로 조회한다")
+    void successReadChatRooms() {
+        // given
+        Long userId = 1L;
+        List<ChatRoomDetail> chatRooms = List.of(
+                new ChatRoomDetail(1L, "Room1", "", "", 123456, LocalDateTime.now(), true, 2),
+                new ChatRoomDetail(2L, "Room2", "", "", null, LocalDateTime.now(), false, 2)
+        );
+
+        given(chatRoomService.readChatRoomsByUserId(userId)).willReturn(chatRooms);
+
+        // room1: 마지막으로 읽은 메시지 ID 10, 읽지 않은 메시지 5개
+        given(chatMessageStatusService.readLastReadMessageId(userId, 1L)).willReturn(10L);
+        given(chatMessageService.countUnreadMessages(userId, 10L)).willReturn(5L);
+
+        // room2: 마지막으로 읽은 메시지 ID 20, 읽지 않은 메시지 3개
+        given(chatMessageStatusService.readLastReadMessageId(userId, 2L)).willReturn(20L);
+        given(chatMessageService.countUnreadMessages(userId, 20L)).willReturn(3L);
+
+        // when
+        Map<ChatRoomDetail, Long> result = chatRoomSearchService.readChatRooms(userId);
+
+        // then
+        assertAll(
+                () -> assertEquals(2, result.size()),
+                () -> assertEquals(5L, result.get(chatRooms.get(0))),
+                () -> assertEquals(3L, result.get(chatRooms.get(1)))
+        );
+    }
+
+    @Test
+    @DisplayName("채팅방이 없는 경우 빈 Map을 반환한다")
+    void returnEmptyMapWhenNoRooms() {
+        // given
+        Long userId = 1L;
+        given(chatRoomService.readChatRoomsByUserId(userId)).willReturn(Collections.emptyList());
+
+        // when
+        Map<ChatRoomDetail, Long> result = chatRoomSearchService.readChatRooms(userId);
+
+        // then
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("읽지 않은 메시지 수 조회 중, 모든 조회가 실패한다.")
+    void continueProcessingOnError() {
+        // given
+        Long userId = 1L;
+        List<ChatRoomDetail> chatRooms = List.of(
+                new ChatRoomDetail(1L, "Room1", "", "", 123456, LocalDateTime.now(), true, 2),
+                new ChatRoomDetail(2L, "Room2", "", "", null, LocalDateTime.now(), false, 2)
+        );
+
+        given(chatRoomService.readChatRoomsByUserId(userId)).willReturn(chatRooms);
+
+        // room1: 정상 처리
+        given(chatMessageStatusService.readLastReadMessageId(userId, 1L)).willReturn(10L);
+
+        // room2: 오류 발생
+        given(chatMessageStatusService.readLastReadMessageId(userId, 2L))
+                .willThrow(new RuntimeException("Failed to get last read message id"));
+
+        // when - then
+        assertThrows(RuntimeException.class, () -> chatRoomSearchService.readChatRooms(userId));
+    }
+
+    @Test
+    @DisplayName("각 서비스 호출이 정해진 순서대로 실행된다")
+    void verifyServiceCallOrder() {
+        // given
+        Long userId = 1L;
+        List<ChatRoomDetail> chatRooms = List.of(
+                new ChatRoomDetail(1L, "Room1", "", "", 123456, LocalDateTime.now(), true, 2)
+        );
+
+        InOrder inOrder = inOrder(chatRoomService, chatMessageStatusService, chatMessageService);
+
+        given(chatRoomService.readChatRoomsByUserId(userId)).willReturn(chatRooms);
+        given(chatMessageStatusService.readLastReadMessageId(userId, 1L)).willReturn(10L);
+        given(chatMessageService.countUnreadMessages(userId, 10L)).willReturn(5L);
+
+        // when
+        chatRoomSearchService.readChatRooms(userId);
+
+        // then
+        inOrder.verify(chatRoomService).readChatRoomsByUserId(userId);
+        inOrder.verify(chatMessageStatusService).readLastReadMessageId(userId, 1L);
+        inOrder.verify(chatMessageService).countUnreadMessages(userId, 10L);
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSearchServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSearchServiceTest.java
@@ -47,11 +47,11 @@ class ChatRoomSearchServiceTest {
 
         // room1: 마지막으로 읽은 메시지 ID 10, 읽지 않은 메시지 5개
         given(chatMessageStatusService.readLastReadMessageId(userId, 1L)).willReturn(10L);
-        given(chatMessageService.countUnreadMessages(userId, 10L)).willReturn(5L);
+        given(chatMessageService.countUnreadMessages(1L, 10L)).willReturn(5L);
 
         // room2: 마지막으로 읽은 메시지 ID 20, 읽지 않은 메시지 3개
         given(chatMessageStatusService.readLastReadMessageId(userId, 2L)).willReturn(20L);
-        given(chatMessageService.countUnreadMessages(userId, 20L)).willReturn(3L);
+        given(chatMessageService.countUnreadMessages(2L, 20L)).willReturn(3L);
 
         // when
         Map<ChatRoomDetail, Long> result = chatRoomSearchService.readChatRooms(userId);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/TestJpaConfig.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/TestJpaConfig.java
@@ -8,6 +8,7 @@ import jakarta.persistence.PersistenceContext;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.RedisTemplate;
 
 @TestConfiguration
 public class TestJpaConfig {
@@ -24,5 +25,11 @@ public class TestJpaConfig {
     @ConditionalOnMissingBean
     public SQLTemplates testSqlTemplates() {
         return new MySQLTemplates();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public RedisTemplate<String, ?> testRedisTemplate() {
+        return null;
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/domain/ChatMessageStatus.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/domain/ChatMessageStatus.java
@@ -10,7 +10,13 @@ import java.util.Objects;
 
 @Entity
 @Getter
-@Table(name = "chat_message_status")
+@Table(name = "chat_message_status",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_chat_message_status",
+                        columnNames = {"user_id", "chat_room_id"}
+                )
+        })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessageStatus {
     @Id

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/domain/ChatMessageStatus.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/domain/ChatMessageStatus.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -20,6 +21,13 @@ public class ChatMessageStatus {
     private Long chatRoomId;
     private Long lastReadMessageId;
     private LocalDateTime updatedAt;
+
+    public ChatMessageStatus(Long userId, Long chatRoomId, Long lastReadMessageId) {
+        this.userId = Objects.requireNonNull(userId, "userId must not be null");
+        this.chatRoomId = Objects.requireNonNull(chatRoomId, "chatRoomId must not be null");
+        this.lastReadMessageId = Objects.requireNonNull(lastReadMessageId, "lastReadMessageId must not be null");
+        this.updatedAt = LocalDateTime.now();
+    }
 
     @PrePersist
     @PreUpdate

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/domain/ChatMessageStatus.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/domain/ChatMessageStatus.java
@@ -1,0 +1,35 @@
+package kr.co.pennyway.domain.domains.chatstatus.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "chat_message_status")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageStatus {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private Long chatRoomId;
+    private Long lastReadMessageId;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateLastReadMessageId(Long messageId) {
+        if (this.lastReadMessageId == null || messageId > this.lastReadMessageId) {
+            this.lastReadMessageId = messageId;
+        }
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusCacheCustomRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusCacheCustomRepository.java
@@ -2,7 +2,7 @@ package kr.co.pennyway.domain.domains.chatstatus.repository;
 
 import java.util.Optional;
 
-public interface ChatMessageStatusCacheRepository {
+public interface ChatMessageStatusCacheCustomRepository {
     /**
      * 캐시 데이터에서 마지막으로 읽은 메시지 ID를 조회합니다.
      */

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusCacheCustomRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusCacheCustomRepositoryImpl.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 @Slf4j
 @Repository
 @RequiredArgsConstructor
-public class ChatMessageStatusRedisRepository implements ChatMessageStatusCacheRepository {
+public class ChatMessageStatusCacheCustomRepositoryImpl implements ChatMessageStatusCacheCustomRepository {
     private static final String CACHE_KEY_PREFIX = "chat:last_read:";
     private static final Duration CACHE_TTL = Duration.ofHours(1);
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusCacheRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusCacheRepository.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.domain.domains.chatstatus.repository;
+
+import java.util.Optional;
+
+public interface ChatMessageStatusCacheRepository {
+    /**
+     * 캐시 데이터에서 마지막으로 읽은 메시지 ID를 조회합니다.
+     */
+    Optional<Long> findLastReadMessageId(Long userId, Long chatRoomId);
+
+    /**
+     * 캐시 데이터에 마지막으로 읽은 메시지 ID를 저장합니다.
+     */
+    void saveLastReadMessageId(Long userId, Long chatRoomId, Long messageId);
+
+    /**
+     * 캐시 데이터를 삭제합니다.
+     */
+    void deleteLastReadMessageId(Long userId, Long chatRoomId);
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRedisRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRedisRepository.java
@@ -1,0 +1,51 @@
+package kr.co.pennyway.domain.domains.chatstatus.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageStatusRedisRepository implements ChatMessageStatusCacheRepository {
+    private static final String CACHE_KEY_PREFIX = "chat:last_read:";
+    private static final Duration CACHE_TTL = Duration.ofHours(1);
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public Optional<Long> findLastReadMessageId(Long userId, Long chatRoomId) {
+        String value = redisTemplate.opsForValue().get(formatCacheKey(userId, chatRoomId));
+        return Optional.ofNullable(value).map(Long::parseLong);
+    }
+
+    @Override
+    public void saveLastReadMessageId(Long userId, Long chatRoomId, Long messageId) {
+        try {
+            String key = formatCacheKey(userId, chatRoomId);
+            String currentValue = redisTemplate.opsForValue().get(key);
+
+            if (currentValue != null && Long.parseLong(currentValue) >= messageId) {
+                return;
+            }
+
+            redisTemplate.opsForValue().set(key, messageId.toString());
+            redisTemplate.expire(key, CACHE_TTL);
+        } catch (Exception e) {
+            log.error("Failed to cache message status: userId={}, roomId={}, messageId={}", userId, chatRoomId, messageId, e);
+        }
+    }
+
+    @Override
+    public void deleteLastReadMessageId(Long userId, Long chatRoomId) {
+        redisTemplate.delete(formatCacheKey(userId, chatRoomId));
+    }
+
+    private String formatCacheKey(Long userId, Long chatRoomId) {
+        return CACHE_KEY_PREFIX + chatRoomId + ":" + userId;
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-public interface ChatMessageStatusRepository extends JpaRepository<ChatMessageStatus, Long>, ChatMessageStatusCacheRepository {
+public interface ChatMessageStatusRepository extends JpaRepository<ChatMessageStatus, Long>, ChatMessageStatusCacheCustomRepository {
     Optional<ChatMessageStatus> findByUserIdAndChatRoomId(Long userId, Long chatRoomId);
 
     @Query("SELECT c FROM ChatMessageStatus c WHERE c.userId = :userId AND c.chatRoomId IN :roomIds")

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-public interface ChatMessageStatusRepository extends JpaRepository<ChatMessageStatus, Long> {
+public interface ChatMessageStatusRepository extends JpaRepository<ChatMessageStatus, Long>, ChatMessageStatusCacheRepository {
     Optional<ChatMessageStatus> findByUserIdAndChatRoomId(Long userId, Long chatRoomId);
 
     @Query("SELECT c FROM ChatMessageStatus c WHERE c.userId = :userId AND c.chatRoomId IN :roomIds")

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
@@ -17,7 +17,7 @@ public interface ChatMessageStatusRepository extends JpaRepository<ChatMessageSt
 
     @Modifying
     @Query(value = """
-            INSERT INTO chat_member_read (user_id, chat_room_id, last_read_message_id, updated_at)
+            INSERT INTO chat_message_status (user_id, chat_room_id, last_read_message_id, updated_at)
             VALUES (:userId, :roomId, :messageId, NOW())
             ON DUPLICATE KEY UPDATE
             last_read_message_id = GREATEST(last_read_message_id, :messageId),

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
@@ -1,0 +1,27 @@
+package kr.co.pennyway.domain.domains.chatstatus.repository;
+
+import kr.co.pennyway.domain.domains.chatstatus.domain.ChatMessageStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatMessageStatusRepository extends JpaRepository<ChatMessageStatus, Long> {
+    Optional<ChatMessageStatus> findByUserIdAndChatRoomId(Long userId, Long chatRoomId);
+
+    @Query("SELECT c FROM ChatMessageStatus c WHERE c.userId = :userId AND c.chatRoomId IN :roomIds")
+    List<ChatMessageStatus> findAllByUserIdAndChatRoomIdIn(Long userId, Collection<Long> roomIds);
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO chat_member_read (user_id, chat_room_id, last_read_message_id, updated_at)
+            VALUES (:userId, :roomId, :messageId, NOW())
+            ON DUPLICATE KEY UPDATE
+            last_read_message_id = GREATEST(last_read_message_id, :messageId),
+            updated_at = NOW()
+            """, nativeQuery = true)
+    void upsertLastReadMessageId(Long userId, Long roomId, Long messageId);
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
@@ -23,5 +23,5 @@ public interface ChatMessageStatusRepository extends JpaRepository<ChatMessageSt
             last_read_message_id = GREATEST(last_read_message_id, :messageId),
             updated_at = NOW()
             """, nativeQuery = true)
-    void upsertLastReadMessageId(Long userId, Long roomId, Long messageId);
+    void saveLastReadMessageId(Long userId, Long roomId, Long messageId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/repository/ChatMessageStatusRepository.java
@@ -23,5 +23,5 @@ public interface ChatMessageStatusRepository extends JpaRepository<ChatMessageSt
             last_read_message_id = GREATEST(last_read_message_id, :messageId),
             updated_at = NOW()
             """, nativeQuery = true)
-    void saveLastReadMessageId(Long userId, Long roomId, Long messageId);
+    void saveLastReadMessageIdInBulk(Long userId, Long roomId, Long messageId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/service/ChatMessageStatusService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/service/ChatMessageStatusService.java
@@ -16,8 +16,11 @@ public class ChatMessageStatusService {
 
     /**
      * 마지막으로 읽은 메시지 ID를 저장합니다.
+     *
+     * @throws IllegalArgumentException 사용자 ID, 채팅방 ID, 메시지 ID가 null이거나 0보다 작을 경우
      */
     public void saveLastReadMessageId(Long userId, Long roomId, Long messageId) {
+        validateInputs(userId, roomId, messageId);
         chatMessageStatusRepository.saveLastReadMessageId(userId, roomId, messageId);
     }
 
@@ -44,13 +47,26 @@ public class ChatMessageStatusService {
      *
      * @param updates 사용자별 읽은 메시지 ID 목록 (사용자 ID -> (채팅방 ID -> 메시지 ID))
      */
+    // TODO: 이 메서드는 임시로 사용되는 메서드이며, 성능 평가 이후 개선될 여지가 있습니다.
     @Transactional
     public void bulkUpdateReadStatus(Map<Long, Map<Long, Long>> updates) {
         updates.forEach((userId, roomUpdates) ->
                 roomUpdates.forEach((roomId, messageId) -> {
-                    chatMessageStatusRepository.saveLastReadMessageId(userId, roomId, messageId);
+                    chatMessageStatusRepository.saveLastReadMessageIdInBulk(userId, roomId, messageId);
                     chatMessageStatusRepository.deleteLastReadMessageId(userId, roomId);
                 })
         );
+    }
+
+    private void validateInputs(Long userId, Long chatRoomId, Long lastReadMessageId) {
+        if (userId == null || userId <= 0) {
+            throw new IllegalArgumentException("Invalid userId: " + userId);
+        }
+        if (chatRoomId == null || chatRoomId <= 0) {
+            throw new IllegalArgumentException("Invalid chatRoomId: " + chatRoomId);
+        }
+        if (lastReadMessageId == null || lastReadMessageId <= 0) {
+            throw new IllegalArgumentException("Invalid lastReadMessageId: " + lastReadMessageId);
+        }
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/service/ChatMessageStatusService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/service/ChatMessageStatusService.java
@@ -23,6 +23,8 @@ public class ChatMessageStatusService {
 
     /**
      * 마지막으로 읽은 메시지 ID를 조회합니다.
+     *
+     * @return 마지막으로 읽은 메시지 ID가 없을 경우 0을 반환합니다.
      */
     @Transactional(readOnly = true)
     public Long readLastReadMessageId(Long userId, Long chatRoomId) {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/service/ChatMessageStatusService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/chatstatus/service/ChatMessageStatusService.java
@@ -1,0 +1,54 @@
+package kr.co.pennyway.domain.domains.chatstatus.service;
+
+import kr.co.pennyway.common.annotation.DomainService;
+import kr.co.pennyway.domain.domains.chatstatus.repository.ChatMessageStatusRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Slf4j
+@DomainService
+@RequiredArgsConstructor
+public class ChatMessageStatusService {
+    private final ChatMessageStatusRepository chatMessageStatusRepository;
+
+    /**
+     * 마지막으로 읽은 메시지 ID를 저장합니다.
+     */
+    public void saveLastReadMessageId(Long userId, Long roomId, Long messageId) {
+        chatMessageStatusRepository.saveLastReadMessageId(userId, roomId, messageId);
+    }
+
+    /**
+     * 마지막으로 읽은 메시지 ID를 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    public Long readLastReadMessageId(Long userId, Long chatRoomId) {
+        return chatMessageStatusRepository.findLastReadMessageId(userId, chatRoomId)
+                .orElseGet(() -> chatMessageStatusRepository
+                        .findByUserIdAndChatRoomId(userId, chatRoomId)
+                        .map(status -> {
+                            Long lastReadId = status.getLastReadMessageId();
+                            chatMessageStatusRepository.saveLastReadMessageId(userId, chatRoomId, lastReadId);
+                            return lastReadId;
+                        })
+                        .orElse(0L));
+    }
+
+    /**
+     * 여러 사용자의 읽은 메시지 ID를 일괄 업데이트합니다.
+     *
+     * @param updates 사용자별 읽은 메시지 ID 목록 (사용자 ID -> (채팅방 ID -> 메시지 ID))
+     */
+    @Transactional
+    public void bulkUpdateReadStatus(Map<Long, Map<Long, Long>> updates) {
+        updates.forEach((userId, roomUpdates) ->
+                roomUpdates.forEach((roomId, messageId) -> {
+                    chatMessageStatusRepository.saveLastReadMessageId(userId, roomId, messageId);
+                    chatMessageStatusRepository.deleteLastReadMessageId(userId, roomId);
+                })
+        );
+    }
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/config/TestJpaConfig.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/config/TestJpaConfig.java
@@ -8,6 +8,7 @@ import jakarta.persistence.PersistenceContext;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.RedisTemplate;
 
 @TestConfiguration
 public class TestJpaConfig {
@@ -24,5 +25,11 @@ public class TestJpaConfig {
     @ConditionalOnMissingBean
     public SQLTemplates testSqlTemplates() {
         return new MySQLTemplates();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public RedisTemplate<String, ?> testRedisTemplate() {
+        return null;
     }
 }

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/chatstatus/service/ChatMessageStatusServiceIntegrationTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/chatstatus/service/ChatMessageStatusServiceIntegrationTest.java
@@ -1,0 +1,125 @@
+package kr.co.pennyway.domain.domains.chatstatus.service;
+
+import kr.co.pennyway.domain.config.ContainerDBTestConfig;
+import kr.co.pennyway.domain.config.DomainIntegrationTest;
+import kr.co.pennyway.domain.config.TestJpaConfig;
+import kr.co.pennyway.domain.domains.chatstatus.domain.ChatMessageStatus;
+import kr.co.pennyway.domain.domains.chatstatus.repository.ChatMessageStatusRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+@DomainIntegrationTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({TestJpaConfig.class})
+public class ChatMessageStatusServiceIntegrationTest extends ContainerDBTestConfig {
+    @Autowired
+    private ChatMessageStatusRepository chatMessageStatusRepository;
+
+    @Autowired
+    private ChatMessageStatusService chatMessageStatusService;
+
+    @Test
+    @DisplayName("메시지 읽음 상태를 정상적으로 저장하고 조회한다")
+    void saveAndReadMessageStatus() {
+        // given
+        Long userId = 1L;
+        Long chatRoomId = 1L;
+        Long messageId = 100L;
+
+        // when
+        chatMessageStatusService.saveLastReadMessageId(userId, chatRoomId, messageId);
+        Long lastReadId = chatMessageStatusService.readLastReadMessageId(userId, chatRoomId);
+
+        // then
+        assertEquals(messageId, lastReadId);
+    }
+
+    @Test
+    @DisplayName("여러 메시지 읽음 상태를 벌크로 저장한다")
+    void bulkSaveMessageStatus() {
+        // given
+        Map<Long, Map<Long, Long>> updates = new HashMap<>();
+
+        // user1의 업데이트
+        Map<Long, Long> user1Updates = new HashMap<>();
+        user1Updates.put(1L, 100L);  // user1은 1번 방에서 100번 메시지까지 읽음
+        user1Updates.put(2L, 200L);  // user1은 2번 방에서 200번 메시지까지 읽음
+        updates.put(1L, user1Updates);
+
+        // user2의 업데이트
+        Map<Long, Long> user2Updates = new HashMap<>();
+        user2Updates.put(1L, 150L);  // user2는 1번 방에서 150번 메시지까지 읽음
+        updates.put(2L, user2Updates);
+
+        // when
+        chatMessageStatusService.bulkUpdateReadStatus(updates);
+
+        // then
+        assertAll(
+                () -> assertEquals(100L, chatMessageStatusService.readLastReadMessageId(1L, 1L)),
+                () -> assertEquals(200L, chatMessageStatusService.readLastReadMessageId(1L, 2L)),
+                () -> assertEquals(150L, chatMessageStatusService.readLastReadMessageId(2L, 1L))
+        );
+    }
+
+    @Test
+    @DisplayName("더 작은 메시지 ID로 업데이트를 시도하면 무시된다")
+    void ignoresSmallerMessageId() {
+        // given
+        Long userId = 1L;
+        Long chatRoomId = 1L;
+
+        // when
+        chatMessageStatusService.saveLastReadMessageId(userId, chatRoomId, 100L);
+        chatMessageStatusService.saveLastReadMessageId(userId, chatRoomId, 50L);
+
+        // then
+        assertEquals(100L, chatMessageStatusService.readLastReadMessageId(userId, chatRoomId));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 읽음 상태 조회 시 0을 반환한다")
+    void returnsZeroForNonExistentStatus() {
+        // when
+        Long result = chatMessageStatusService.readLastReadMessageId(999L, 999L);
+
+        // then
+        assertEquals(0L, result);
+    }
+
+    @Test
+    @DisplayName("벌크 업데이트 시 기존 값보다 작은 메시지 ID는 업데이트되지 않는다")
+    void bulkUpdateRespectsMessageIdOrder() {
+        // given
+        Long userId = 1L;
+        Long chatRoomId = 1L;
+
+        chatMessageStatusRepository.save(new ChatMessageStatus(userId, chatRoomId, 200L));
+
+        Map<Long, Map<Long, Long>> updates = new HashMap<>();
+        updates.put(userId, Map.of(chatRoomId, 100L)); // 1번 사용자가 1번 방에서 100번 메시지까지 읽음
+
+        // when
+        chatMessageStatusService.bulkUpdateReadStatus(updates);
+
+        // then
+        assertEquals(200L, chatMessageStatusService.readLastReadMessageId(userId, chatRoomId));
+    }
+
+    @AfterEach
+    void tearDown() {
+        chatMessageStatusRepository.deleteAll();
+    }
+}

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/chatstatus/service/ChatMessageStatusServiceTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/chatstatus/service/ChatMessageStatusServiceTest.java
@@ -1,0 +1,175 @@
+package kr.co.pennyway.domain.domains.chatstatus.service;
+
+import kr.co.pennyway.domain.domains.chatstatus.domain.ChatMessageStatus;
+import kr.co.pennyway.domain.domains.chatstatus.repository.ChatMessageStatusRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatMessageStatusServiceTest {
+    @InjectMocks
+    private ChatMessageStatusService chatMessageStatusService;
+
+    @Mock
+    private ChatMessageStatusRepository chatMessageStatusRepository;
+
+    private static Stream<Arguments> provideInvalidInputs() {
+        return Stream.of(
+                Arguments.of(null, 1L, 1L),
+                Arguments.of(1L, null, 1L),
+                Arguments.of(1L, 1L, null),
+                Arguments.of(-1L, 1L, 1L),
+                Arguments.of(1L, -1L, 1L),
+                Arguments.of(1L, 1L, -1L)
+        );
+    }
+
+    @Test
+    @DisplayName("캐시에서 마지막 읽은 메시지 ID를 조회한다")
+    void getLastReadMessageIdFromCache() {
+        // given
+        Long userId = 1L;
+        Long chatRoomId = 1L;
+        Long messageId = 100L;
+
+        given(chatMessageStatusRepository.findLastReadMessageId(userId, chatRoomId)).willReturn(Optional.of(messageId));
+
+        // when
+        Long result = chatMessageStatusService.readLastReadMessageId(userId, chatRoomId);
+
+        // then
+        assertEquals(messageId, result);
+        verify(chatMessageStatusRepository).findLastReadMessageId(userId, chatRoomId);
+        verifyNoMoreInteractions(chatMessageStatusRepository);
+    }
+
+    @Test
+    @DisplayName("캐시 미스 시 DB에서 조회하고 캐시를 갱신한다")
+    void getLastReadMessageIdFromDB() {
+        // given
+        Long userId = 1L;
+        Long chatRoomId = 1L;
+        Long messageId = 100L;
+
+        ChatMessageStatus status = new ChatMessageStatus(userId, chatRoomId, messageId);
+
+        given(chatMessageStatusRepository.findLastReadMessageId(userId, chatRoomId)).willReturn(Optional.empty());
+        given(chatMessageStatusRepository.findByUserIdAndChatRoomId(userId, chatRoomId)).willReturn(Optional.of(status));
+
+        // when
+        Long result = chatMessageStatusService.readLastReadMessageId(userId, chatRoomId);
+
+        // then
+        assertEquals(messageId, result);
+        verify(chatMessageStatusRepository).findLastReadMessageId(userId, chatRoomId);
+        verify(chatMessageStatusRepository).findByUserIdAndChatRoomId(userId, chatRoomId);
+        verify(chatMessageStatusRepository).saveLastReadMessageId(userId, chatRoomId, messageId);
+    }
+
+    @Test
+    @DisplayName("DB에도 데이터가 없는 경우 0을 반환한다")
+    void returnZeroWhenNoDataExists() {
+        // given
+        Long userId = 1L;
+        Long chatRoomId = 1L;
+
+        given(chatMessageStatusRepository.findLastReadMessageId(userId, chatRoomId))
+                .willReturn(Optional.empty());
+        given(chatMessageStatusRepository.findByUserIdAndChatRoomId(userId, chatRoomId))
+                .willReturn(Optional.empty());
+
+        // when
+        Long result = chatMessageStatusService.readLastReadMessageId(userId, chatRoomId);
+
+        // then
+        assertEquals(0L, result);
+        verify(chatMessageStatusRepository).findLastReadMessageId(userId, chatRoomId);
+        verify(chatMessageStatusRepository).findByUserIdAndChatRoomId(userId, chatRoomId);
+        verifyNoMoreInteractions(chatMessageStatusRepository);
+    }
+
+    @Test
+    @DisplayName("벌크 업데이트 시 모든 항목이 정상적으로 처리된다")
+    void bulkUpdateProcessesAllItems() {
+        // given
+        Map<Long, Map<Long, Long>> updates = new HashMap<>();
+        Map<Long, Long> user1Updates = new HashMap<>();
+        user1Updates.put(1L, 100L);
+        user1Updates.put(2L, 200L);
+
+        Map<Long, Long> user2Updates = new HashMap<>();
+        user2Updates.put(1L, 150L);
+
+        updates.put(1L, user1Updates);
+        updates.put(2L, user2Updates);
+
+        // when
+        chatMessageStatusService.bulkUpdateReadStatus(updates);
+
+        // then
+        verify(chatMessageStatusRepository).saveLastReadMessageIdInBulk(1L, 1L, 100L);
+        verify(chatMessageStatusRepository).saveLastReadMessageIdInBulk(1L, 2L, 200L);
+        verify(chatMessageStatusRepository).saveLastReadMessageIdInBulk(2L, 1L, 150L);
+        verify(chatMessageStatusRepository).deleteLastReadMessageId(1L, 1L);
+        verify(chatMessageStatusRepository).deleteLastReadMessageId(1L, 2L);
+        verify(chatMessageStatusRepository).deleteLastReadMessageId(2L, 1L);
+    }
+
+    @Test
+    @DisplayName("새 메시지 저장 시 정상적으로 처리된다")
+    void saveNewMessageStatus() {
+        // given
+        Long userId = 1L;
+        Long chatRoomId = 1L;
+        Long messageId = 100L;
+
+        // when
+        chatMessageStatusService.saveLastReadMessageId(userId, chatRoomId, messageId);
+
+        // then
+        verify(chatMessageStatusRepository).saveLastReadMessageId(userId, chatRoomId, messageId);
+        verifyNoMoreInteractions(chatMessageStatusRepository);
+    }
+
+    @Test
+    @DisplayName("cache repository에서 예외 발생 시 적절히 처리된다 (현재는 예외를 던짐)")
+    void handleRepositoryException() {
+        // given
+        Long userId = 1L;
+        Long chatRoomId = 1L;
+
+        given(chatMessageStatusRepository.findLastReadMessageId(userId, chatRoomId)).willThrow(new RuntimeException("Redis connection failed"));
+
+        // when - then
+        assertThrows(RuntimeException.class, () ->
+                chatMessageStatusService.readLastReadMessageId(userId, chatRoomId)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidInputs")
+    @DisplayName("잘못된 입력값이 들어올 경우 적절히 처리된다")
+    void handleInvalidInputs(Long userId, Long chatRoomId, Long messageId) {
+        assertThrows(IllegalArgumentException.class, () ->
+                chatMessageStatusService.saveLastReadMessageId(userId, chatRoomId, messageId)
+        );
+    }
+}


### PR DESCRIPTION
## 작업 이유
![image](https://github.com/user-attachments/assets/0a9287c4-74a1-4356-ba38-eacc89a1ba95)
![image](https://github.com/user-attachments/assets/8bead398-eee2-4cc5-a412-8a095fcd9195)

- User can receive unreadMessageCount. 

<br/>

## 작업 사항
### 1️⃣ Total Check List
- [X] Implemented domain business logic in Domain Module.
- [X] API: Added `unread-message-count` field in response.
- [ ] Socket: Implement lastMessageId save logic.
- [ ] Batch: Schedule cache-to-RDB synchronization.

Remaining tasks will be completed in other branches.

<br/>

### 2️⃣ Flow
1. When the client confirms messages in a chatroom, it sends the last read message ID to the socket server
   - `SEND pub/message.read`
      ```json
      {
          "chatRoomId": , // for authorization
          "messageId":     // for caching user's last read message id
      }
      ```
2. Cache data is saved for 1 hour in Redis.
3. A batch synchronizes cache data with RDB every 10 minutes.
4. When the client requests unreadMessageId from the API server::
    - If data exists in Redis, it will be returned.
    - Otherwise, it checks RDB and caches the result.
    - If no data is found, it returns 0.
5. Updating the additional unread message count in real-time is handled by the client, based on messages received via the socket.

<br/>

### 3️⃣ Entity
```sql
CREATE TABLE chat_message_status (
    id BIGINT AUTO_INCREMENT PRIMARY KEY,
    user_id BIGINT NOT NULL,
    chat_room_id BIGINT NOT NULL,
    last_read_message_id BIGINT NOT NULL,
    updated_at DATETIME NOT NULL,

    CONSTRAINT uk_chat_message_status UNIQUE (user_id, chat_room_id),
    INDEX idx_chat_message_status_user (user_id),
    INDEX idx_chat_message_status_chat_room (chat_room_id)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```
- only constratined on `user_id` and `chat_room_id`, with no foreign key.
- This table has frequent CRU operations, and join queries are unnecessary.

<br/>

### 4️⃣ Unread Message Counting Mechanism
```java
public Long countUnreadMessages(Long roomId, Long lastReadMessageId) {
    String chatRoomKey = getChatRoomKey(roomId);

    return redisTemplate.opsForZSet().count( // ZCOUNT
        chatRoomKey,
        lastReadMessageId + 1,  // Minimum (messages after lastReadMessageId)
        Double.POSITIVE_INFINITY  // Maximum
    );
}
```
- Currently, sorted sets are used for saving chat history.
- Using the `ZCOUNT` command, unread message counts are retrieved.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- When counting unread messages, Redis reads all data. (Even if the client only wants to know if the count exceeds 100.)
- For now, this has been left as-is, considering further optimization unnecessary.

