### PR TITLE
API: ✏️ 채팅방 정보 조회 응답 수정

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatMemberRes.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
-import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
 import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
 
 import java.time.LocalDateTime;
@@ -15,6 +15,8 @@ public final class ChatMemberRes {
     public record MemberDetail(
             @Schema(description = "채팅방 참여자 ID", type = "long")
             Long id,
+            @Schema(description = "채팅방 사용자의 애플리케이션 내 고유 식별자 (userId)")
+            Long userId,
             @Schema(description = "채팅방 참여자 이름")
             String name,
             @Schema(description = "채팅방 참여자 역할")
@@ -27,13 +29,29 @@ public final class ChatMemberRes {
             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime createdAt
     ) {
-        public static MemberDetail from(ChatMember chatMember, boolean isContainNotifyEnabled) {
+        public static MemberDetail from(ChatMemberResult.Detail chatMember, boolean isContainNotifyEnabled) {
             return new MemberDetail(
-                    chatMember.getId(),
-                    chatMember.getName(),
-                    chatMember.getRole(),
-                    isContainNotifyEnabled ? chatMember.isNotifyEnabled() : null,
-                    chatMember.getCreatedAt()
+                    chatMember.id(),
+                    chatMember.userId(),
+                    chatMember.name(),
+                    chatMember.role(),
+                    isContainNotifyEnabled ? chatMember.notifyEnabled() : null,
+                    chatMember.createdAt()
+            );
+        }
+    }
+
+    @Schema(description = "채팅방 참여자 요약 정보")
+    public record MemberSummary(
+            @Schema(description = "채팅방 참여자 ID", type = "long")
+            Long id,
+            @Schema(description = "채팅방 참여자 이름")
+            String name
+    ) {
+        public static MemberSummary from(ChatMemberResult.Summary chatMember) {
+            return new MemberSummary(
+                    chatMember.id(),
+                    String.valueOf(chatMember.name())
             );
         }
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -75,10 +75,10 @@ public final class ChatRoomRes {
     public record RoomWithParticipants(
             @Schema(description = "채팅방에서 내 정보")
             ChatMemberRes.MemberDetail myInfo,
-            @Schema(description = "최근에 채팅 메시지를 보낸 참여자의 상세 정보 목록")
+            @Schema(description = "최근에 채팅 메시지를 보낸 참여자의 상세 정보 목록. 내가 방장이 아니라면, 최근에 활동 내역이 없어도 방장 정보가 포함된다.")
             List<ChatMemberRes.MemberDetail> recentParticipants,
-            @Schema(description = "채팅방에서 내 정보와 최근 활동자를 제외한 참여자 ID 목록")
-            List<ChatMemberRes.MemberSummary> otherParticipantIds,
+            @Schema(description = "채팅방에서 내 정보와 최근 활동자를 제외한 참여자 ID, Name 목록")
+            List<ChatMemberRes.MemberSummary> otherParticipants,
             @Schema(description = "최근 채팅 이력. 메시지는 최신순으로 정렬되어 반환.")
             List<ChatRes.ChatDetail> recentMessages
     ) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -78,7 +78,7 @@ public final class ChatRoomRes {
             @Schema(description = "최근에 채팅 메시지를 보낸 참여자의 상세 정보 목록")
             List<ChatMemberRes.MemberDetail> recentParticipants,
             @Schema(description = "채팅방에서 내 정보와 최근 활동자를 제외한 참여자 ID 목록")
-            List<Long> otherParticipantIds,
+            List<ChatMemberRes.MemberSummary> otherParticipantIds,
             @Schema(description = "최근 채팅 이력. 메시지는 최신순으로 정렬되어 반환.")
             List<ChatRes.ChatDetail> recentMessages
     ) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatMemberMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatMemberMapper.java
@@ -2,13 +2,13 @@ package kr.co.pennyway.api.apis.chat.mapper;
 
 import kr.co.pennyway.api.apis.chat.dto.ChatMemberRes;
 import kr.co.pennyway.common.annotation.Mapper;
-import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
 
 import java.util.List;
 
 @Mapper
 public final class ChatMemberMapper {
-    public static List<ChatMemberRes.MemberDetail> toChatMemberResDetail(List<ChatMember> chatMembers) {
+    public static List<ChatMemberRes.MemberDetail> toChatMemberResDetail(List<ChatMemberResult.Detail> chatMembers) {
         return chatMembers.stream()
                 .map(chatMember -> ChatMemberRes.MemberDetail.from(chatMember, false))
                 .toList();

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
@@ -81,7 +81,7 @@ public final class ChatRoomMapper {
         return ChatRoomRes.RoomWithParticipants.builder()
                 .myInfo(ChatMemberRes.MemberDetail.from(myInfo, true))
                 .recentParticipants(recentParticipantsRes)
-                .otherParticipantIds(otherParticipantsRes)
+                .otherParticipants(otherParticipantsRes)
                 .recentMessages(chatMessagesRes)
                 .build();
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
@@ -8,7 +8,7 @@ import kr.co.pennyway.common.annotation.Mapper;
 import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.chatroom.dto.ChatRoomDetail;
-import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -66,9 +66,12 @@ public final class ChatRoomMapper {
         return ChatRoomRes.Detail.of(chatRoom, isAdmin, participantCount, unreadMessageCount);
     }
 
-    public static ChatRoomRes.RoomWithParticipants toChatRoomResRoomWithParticipants(ChatMember myInfo, List<ChatMember> recentParticipants, List<Long> otherMemberIds, List<ChatMessage> chatMessages) {
+    public static ChatRoomRes.RoomWithParticipants toChatRoomResRoomWithParticipants(ChatMemberResult.Detail myInfo, List<ChatMemberResult.Detail> recentParticipants, List<ChatMemberResult.Summary> otherParticipants, List<ChatMessage> chatMessages) {
         List<ChatMemberRes.MemberDetail> recentParticipantsRes = recentParticipants.stream()
                 .map(participant -> ChatMemberRes.MemberDetail.from(participant, false))
+                .toList();
+        List<ChatMemberRes.MemberSummary> otherParticipantsRes = otherParticipants.stream()
+                .map(ChatMemberRes.MemberSummary::from)
                 .toList();
 
         List<ChatRes.ChatDetail> chatMessagesRes = chatMessages.stream()
@@ -78,7 +81,7 @@ public final class ChatRoomMapper {
         return ChatRoomRes.RoomWithParticipants.builder()
                 .myInfo(ChatMemberRes.MemberDetail.from(myInfo, true))
                 .recentParticipants(recentParticipantsRes)
-                .otherParticipantIds(otherMemberIds)
+                .otherParticipantIds(otherParticipantsRes)
                 .recentMessages(chatMessagesRes)
                 .build();
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberSearchService.java
@@ -1,6 +1,6 @@
 package kr.co.pennyway.api.apis.chat.service;
 
-import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
 import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +19,7 @@ public class ChatMemberSearchService {
         return chatMemberService.readChatRoomIdsByUserId(userId);
     }
 
-    public List<ChatMember> readChatMembers(Long chatRoomId, Set<Long> chatMemberIds) {
+    public List<ChatMemberResult.Detail> readChatMembers(Long chatRoomId, Set<Long> chatMemberIds) {
         return chatMemberService.readChatMembersByIdIn(chatRoomId, chatMemberIds);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
@@ -51,7 +51,7 @@ public class ChatRoomWithParticipantsSearchService {
         );
 
         // 내가 관리자가 아니거나, 최근 활동자에 관리자가 없다면 관리자 정보 조회
-        if (!myInfo.getRole().equals(ChatMemberRole.ADMIN) || recentParticipants.stream().noneMatch(participant -> participant.role().equals(ChatMemberRole.ADMIN))) {
+        if (!myInfo.getRole().equals(ChatMemberRole.ADMIN) && recentParticipants.stream().noneMatch(participant -> participant.role().equals(ChatMemberRole.ADMIN))) {
             ChatMemberResult.Detail admin = chatMemberService.readAdmin(chatRoomId)
                     .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
             recentParticipantIds.add(admin.userId());

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
@@ -5,9 +5,11 @@ import kr.co.pennyway.api.apis.chat.mapper.ChatRoomMapper;
 import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
 import kr.co.pennyway.domain.common.redis.message.service.ChatMessageService;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
 import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,21 +30,35 @@ public class ChatRoomWithParticipantsSearchService {
 
     @Transactional(readOnly = true)
     public ChatRoomRes.RoomWithParticipants execute(Long userId, Long chatRoomId) {
+        // 내 정보 조회
         ChatMember myInfo = chatMemberService.readChatMember(userId, chatRoomId)
                 .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
+        ChatMemberResult.Detail myDetail = new ChatMemberResult.Detail(myInfo.getId(), myInfo.getName(), myInfo.getRole(), myInfo.isNotifyEnabled(), userId, myInfo.getCreatedAt());
 
+        // 최근 메시지 조회 (15건)
         List<ChatMessage> chatMessages = chatMessageService.readRecentMessages(chatRoomId, MESSAGE_LIMIT);
 
+        // 최근 메시지의 발신자 조회
         Set<Long> recentParticipantIds = chatMessages.stream()
                 .map(ChatMessage::getSender)
                 .filter(sender -> !sender.equals(userId))
                 .collect(Collectors.toSet());
 
-        List<ChatMember> recentParticipants = chatMemberService.readChatMembersByUserIdIn(chatRoomId, recentParticipantIds);
+        // 최근 메시지의 발신자 상세 정보 조회
+        List<ChatMemberResult.Detail> recentParticipants = chatMemberService.readChatMembersByUserIdIn(chatRoomId, recentParticipantIds);
 
+        // 내가 관리자가 아닌 경우, 관리자 정보 조회
+        if (!myInfo.getRole().equals(ChatMemberRole.ADMIN)) {
+            ChatMemberResult.Detail admin = chatMemberService.readAdmin(chatRoomId)
+                    .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
+            recentParticipantIds.add(admin.userId());
+            recentParticipants.add(admin);
+        }
         recentParticipantIds.add(userId);
-        List<Long> otherMemberIds = chatMemberService.readChatMemberIdsByUserIdNotIn(chatRoomId, recentParticipantIds);
 
-        return ChatRoomMapper.toChatRoomResRoomWithParticipants(myInfo, recentParticipants, otherMemberIds, chatMessages);
+        // 채팅방에 속한 다른 사용자 요약 정보 조회
+        List<ChatMemberResult.Summary> otherMemberIds = chatMemberService.readChatMemberIdsByUserIdNotIn(chatRoomId, recentParticipantIds);
+
+        return ChatRoomMapper.toChatRoomResRoomWithParticipants(myDetail, recentParticipants, otherMemberIds, chatMessages);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
@@ -50,8 +50,8 @@ public class ChatRoomWithParticipantsSearchService {
                 chatMemberService.readChatMembersByUserIdIn(chatRoomId, recentParticipantIds)
         );
 
-        // 내가 관리자가 아닌 경우, 관리자 정보 조회
-        if (!myInfo.getRole().equals(ChatMemberRole.ADMIN)) {
+        // 내가 관리자가 아니거나, 최근 활동자에 관리자가 없다면 관리자 정보 조회
+        if (!myInfo.getRole().equals(ChatMemberRole.ADMIN) || recentParticipants.stream().noneMatch(participant -> participant.role().equals(ChatMemberRole.ADMIN))) {
             ChatMemberResult.Detail admin = chatMemberService.readAdmin(chatRoomId)
                     .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
             recentParticipantIds.add(admin.userId());

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,7 +46,9 @@ public class ChatRoomWithParticipantsSearchService {
                 .collect(Collectors.toSet());
 
         // 최근 메시지의 발신자 상세 정보 조회
-        List<ChatMemberResult.Detail> recentParticipants = chatMemberService.readChatMembersByUserIdIn(chatRoomId, recentParticipantIds);
+        List<ChatMemberResult.Detail> recentParticipants = new ArrayList<>(
+                chatMemberService.readChatMembersByUserIdIn(chatRoomId, recentParticipantIds)
+        );
 
         // 내가 관리자가 아닌 경우, 관리자 정보 조회
         if (!myInfo.getRole().equals(ChatMemberRole.ADMIN)) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -8,7 +8,7 @@ import kr.co.pennyway.api.apis.chat.service.ChatMemberJoinService;
 import kr.co.pennyway.api.apis.chat.service.ChatMemberSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
-import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Triple;
@@ -30,7 +30,7 @@ public class ChatMemberUseCase {
     }
 
     public List<ChatMemberRes.MemberDetail> readChatMembers(Long chatRoomId, Set<Long> chatMemberIds) {
-        List<ChatMember> chatMembers = chatMemberSearchService.readChatMembers(chatRoomId, chatMemberIds);
+        List<ChatMemberResult.Detail> chatMembers = chatMemberSearchService.readChatMembers(chatRoomId, chatMemberIds);
 
         return ChatMemberMapper.toChatMemberResDetail(chatMembers);
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberBathGetControllerTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberBathGetControllerTest.java
@@ -118,9 +118,9 @@ public class ChatMemberBathGetControllerTest {
 
     private List<ChatMemberRes.MemberDetail> createMockMemberDetails() {
         return List.of(
-                new ChatMemberRes.MemberDetail(1L, "User1", ChatMemberRole.MEMBER, null, LocalDateTime.now()),
-                new ChatMemberRes.MemberDetail(2L, "User2", ChatMemberRole.MEMBER, null, LocalDateTime.now()),
-                new ChatMemberRes.MemberDetail(3L, "User3", ChatMemberRole.MEMBER, null, LocalDateTime.now())
+                new ChatMemberRes.MemberDetail(1L, 2L, "User1", ChatMemberRole.MEMBER, null, LocalDateTime.now()),
+                new ChatMemberRes.MemberDetail(2L, 3L, "User2", ChatMemberRole.MEMBER, null, LocalDateTime.now()),
+                new ChatMemberRes.MemberDetail(3L, 4L, "User3", ChatMemberRole.MEMBER, null, LocalDateTime.now())
         );
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatRoomDetailIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatRoomDetailIntegrationTest.java
@@ -130,7 +130,7 @@ public class ChatRoomDetailIntegrationTest extends ExternalApiDBTestConfig {
                     assertEquals(ownerMember.getRole(), ChatMemberRole.ADMIN, "나는 방장 권한이어야 한다");
                     assertEquals(expectedRecentParticipantCount, payload.recentParticipants().size(), "최근 참여자 개수가 일치해야 한다");
                     assertEquals(expectedMessageCount, payload.recentMessages().size(), "최근 메시지 개수가 일치해야 한다");
-                    assertTrue(payload.otherParticipantIds().isEmpty(), "다른 참여자가 없어야 한다");
+                    assertTrue(payload.otherParticipants().isEmpty(), "다른 참여자가 없어야 한다");
                 }
         );
     }
@@ -187,7 +187,7 @@ public class ChatRoomDetailIntegrationTest extends ExternalApiDBTestConfig {
         assertAll(
                 () -> assertNotNull(payload),
                 () -> assertEquals(payload.recentParticipants().size(), 2, "최근 참여자 개수가 일치해야 한다."),
-                () -> assertEquals(payload.otherParticipantIds().size(), expectedParticipantCount - 2, "다른 참여자 개수가 일치해야 한다.")
+                () -> assertEquals(payload.otherParticipants().size(), expectedParticipantCount - 2, "다른 참여자 개수가 일치해야 한다.")
         );
     }
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/dto/ChatMemberResult.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/dto/ChatMemberResult.java
@@ -1,0 +1,23 @@
+package kr.co.pennyway.domain.domains.member.dto;
+
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+
+import java.time.LocalDateTime;
+
+public final class ChatMemberResult {
+    public record Detail(
+            Long id,
+            String name,
+            ChatMemberRole role,
+            boolean notifyEnabled,
+            Long userId,
+            LocalDateTime createdAt
+    ) {
+    }
+
+    public record Summary(
+            Long id,
+            Long name
+    ) {
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/dto/ChatMemberResult.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/dto/ChatMemberResult.java
@@ -17,7 +17,7 @@ public final class ChatMemberResult {
 
     public record Summary(
             Long id,
-            Long name
+            String name
     ) {
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.domain.domains.member.repository;
 
 import kr.co.pennyway.domain.common.repository.ExtendedRepository;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +13,9 @@ import java.util.Set;
 public interface ChatMemberRepository extends ExtendedRepository<ChatMember, Long>, CustomChatMemberRepository {
     @Transactional(readOnly = true)
     Set<ChatMember> findByChatRoom_IdAndUser_Id(Long chatRoomId, Long userId);
+
+    @Transactional(readOnly = true)
+    Optional<ChatMember> findByChatRoom_IdAndRole(Long chatRoomId, ChatMemberRole role);
 
     @Transactional(readOnly = true)
     @Query("SELECT cm FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.id IN :chatMemberIds")

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
@@ -22,14 +22,6 @@ public interface ChatMemberRepository extends ExtendedRepository<ChatMember, Lon
     Optional<ChatMember> findActiveChatMember(Long chatRoomId, Long userId);
 
     @Transactional(readOnly = true)
-    @Query("SELECT cm FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.user.id IN :memberIds AND cm.deletedAt IS NULL")
-    List<ChatMember> findByChatRoom_IdAndUser_IdIn(Long chatRoomId, Set<Long> memberIds);
-
-    @Transactional(readOnly = true)
-    @Query("SELECT cm.user.id FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.user.id NOT IN :memberIds AND cm.deletedAt IS NULL")
-    List<Long> findByChatRoom_IdAndUser_IdNotIn(Long chatRoomId, Set<Long> memberIds);
-
-    @Transactional(readOnly = true)
     @Query("SELECT COUNT(*) FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.deletedAt IS NULL")
     long countByChatRoomIdAndActive(Long chatRoomId);
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepository.java
@@ -1,9 +1,18 @@
 package kr.co.pennyway.domain.domains.member.repository;
 
+import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
+
+import java.util.Optional;
+
 public interface CustomChatMemberRepository {
     /**
      * 채팅방에 해당 유저가 존재하는지 확인한다.
      * 이 때, 삭제된 사용자 데이터는 조회하지 않는다.
      */
     boolean existsByChatRoomIdAndUserId(Long chatRoomId, Long userId);
+
+    /**
+     * 채팅방의 관리자 정보를 조회한다.
+     */
+    Optional<ChatMemberResult.Detail> findAdminByChatRoomId(Long chatRoomId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepositoryImpl.java
@@ -1,10 +1,15 @@
 package kr.co.pennyway.domain.domains.member.repository;
 
 import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.pennyway.domain.domains.member.domain.QChatMember;
+import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,5 +26,28 @@ public class CustomChatMemberRepositoryImpl implements CustomChatMemberRepositor
                         .and(chatMember.user.id.eq(userId))
                         .and(chatMember.deletedAt.isNull()))
                 .fetchFirst() != null;
+    }
+
+    @Override
+    public Optional<ChatMemberResult.Detail> findAdminByChatRoomId(Long chatRoomId) {
+        ChatMemberResult.Detail result =
+                queryFactory.select(
+                                Projections.constructor(
+                                        ChatMemberResult.Detail.class,
+                                        chatMember.id,
+                                        chatMember.name,
+                                        chatMember.role,
+                                        chatMember.notifyEnabled,
+                                        chatMember.user.id,
+                                        chatMember.createdAt
+                                )
+                        )
+                        .from(chatMember)
+                        .where(chatMember.chatRoom.id.eq(chatRoomId)
+                                .and(chatMember.role.eq(ChatMemberRole.ADMIN))
+                                .and(chatMember.deletedAt.isNull()))
+                        .fetchFirst();
+
+        return Optional.ofNullable(result);
     }
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -60,6 +60,11 @@ public class ChatMemberService {
     }
 
     @Transactional(readOnly = true)
+    public Optional<ChatMember> readAdmin(Long chatRoomId) {
+        return chatMemberRepository.findByChatRoom_IdAndRole(chatRoomId, ChatMemberRole.ADMIN);
+    }
+
+    @Transactional(readOnly = true)
     public List<ChatMember> readChatMembersByIdIn(Long chatRoomId, Set<Long> chatMemberIds) {
         return chatMemberRepository.findByChatRoom_IdAndIdIn(chatRoomId, chatMemberIds);
     }


### PR DESCRIPTION
## 작업 이유
- iOS 측 요구 사항에 따른 API 스펙 수정

<br/>

## 작업 사항
1. 채팅방 정보 조회 시, `otherParticipants` 필드에 `name` 필드 추가
2. 최근 활동 이력에 admin이 없거나, 조회하는 클라이언트가 admin이 아니라면 조회 쿼리 추가.
3. 채팅방 멤버 상세 정보에서 `userId` 필드 추가.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- 머리가 안 돌아가서, 일단 동작하는 코드로 구현했는데 덕분에 코드가 심각하게 더럽습니다.

<br/>

## 발견한 이슈
- 채팅방 메시지 이력이 조회가 안 되는데, 소켓 서버 이미지가 최신화 반영이 안 된 듯. 일단 로컬로 이미지 올리겠습니다.

