### PR TITLE
Socket: ✨ Path to Retrieve Last Message ID

### DIFF
--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/WebSocketMessageBrokerConfig.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/WebSocketMessageBrokerConfig.java
@@ -73,7 +73,7 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
             @Override
             public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
                 StompHeaderAccessor accessor = StompHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-                log.info("Outbound message: {}", accessor);
+                log.debug("Outbound message: {}", accessor);
                 return message;
             }
         });

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.java
@@ -1,10 +1,12 @@
 package kr.co.pennyway.socket.controller;
 
+import jakarta.validation.constraints.NotNull;
 import kr.co.pennyway.socket.command.SendMessageCommand;
 import kr.co.pennyway.socket.common.annotation.PreAuthorize;
 import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal;
 import kr.co.pennyway.socket.dto.ChatMessageDto;
 import kr.co.pennyway.socket.service.ChatMessageSendService;
+import kr.co.pennyway.socket.service.LastMessageIdSaveService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -17,10 +19,20 @@ import org.springframework.validation.annotation.Validated;
 @RequiredArgsConstructor
 public class ChatMessageController {
     private final ChatMessageSendService chatMessageSendService;
+    private final LastMessageIdSaveService lastMessageIdSaveService;
 
     @MessageMapping("chat.message.{chatRoomId}")
     @PreAuthorize("#isAuthenticated(#principal) and @chatRoomAccessChecker.hasPermission(#chatRoomId, #principal)")
     public void sendMessage(@DestinationVariable Long chatRoomId, @Validated ChatMessageDto.Request payload, UserPrincipal principal) {
         chatMessageSendService.execute(SendMessageCommand.createUserMessage(chatRoomId, payload.content(), payload.contentType(), principal.getUserId()));
+    }
+
+    @MessageMapping("chat.message.{chatRoomId}.read.{chatRoomId}")
+    @PreAuthorize("#isAuthenticated(#principal) and @chatRoomAccessChecker.hasPermission(#chatRoomId, #principal)")
+    public void readMessage(@DestinationVariable(value = "chatRoomId") @Validated @NotNull Long chatRoomId,
+                            @DestinationVariable(value = "lastReadMessageId") @Validated @NotNull Long lastReadMessageId,
+                            UserPrincipal principal
+    ) {
+        lastMessageIdSaveService.execute(principal.getUserId(), chatRoomId, lastReadMessageId);
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.java
@@ -27,7 +27,7 @@ public class ChatMessageController {
         chatMessageSendService.execute(SendMessageCommand.createUserMessage(chatRoomId, payload.content(), payload.contentType(), principal.getUserId()));
     }
 
-    @MessageMapping("chat.message.{chatRoomId}.read.{chatRoomId}")
+    @MessageMapping("chat.message.{chatRoomId}.read.{lastReadMessageId}")
     @PreAuthorize("#isAuthenticated(#principal) and @chatRoomAccessChecker.hasPermission(#chatRoomId, #principal)")
     public void readMessage(@DestinationVariable(value = "chatRoomId") @Validated @NotNull Long chatRoomId,
                             @DestinationVariable(value = "lastReadMessageId") @Validated @NotNull Long lastReadMessageId,

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/LastMessageIdSaveService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/LastMessageIdSaveService.java
@@ -1,0 +1,15 @@
+package kr.co.pennyway.socket.service;
+
+import kr.co.pennyway.domain.domains.chatstatus.service.ChatMessageStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LastMessageIdSaveService {
+    private final ChatMessageStatusService chatMessageStatusService;
+
+    public void execute(Long userId, Long chatRoomId, Long lastReadMessageId) {
+        chatMessageStatusService.saveLastReadMessageId(userId, chatRoomId, lastReadMessageId);
+    }
+}


### PR DESCRIPTION
## 작업 이유
- Continuing from task #190.
- The client will send its last read message ID, which the socket server will retrieve and cache in Redis.

<br/>

## 작업 사항
- Added message path: `chat.message.{chatRoomId}.read.{lastReadMessageId}`

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- none

