### PR TITLE
Ignore: 🔧 Fix CD Pipeline

### DIFF
--- a/.github/workflows/deploy-batch.yml
+++ b/.github/workflows/deploy-batch.yml
@@ -74,4 +74,4 @@ jobs:
             docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             docker system prune -a -f
             docker pull pennyway/pennyway-batch
-            docker-compose up -d
+            docker-compose up -d batch

--- a/.github/workflows/deploy-socket-relay.yml
+++ b/.github/workflows/deploy-socket-relay.yml
@@ -74,4 +74,4 @@ jobs:
             docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             docker system prune -a -f
             docker pull pennyway/pennyway-socket-relay
-            docker-compose up -d
+            docker-compose up -d socket-relay

--- a/.github/workflows/deploy-socket.yml
+++ b/.github/workflows/deploy-socket.yml
@@ -74,4 +74,4 @@ jobs:
             docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             docker system prune -a -f
             docker pull pennyway/pennyway-socket
-            docker-compose up -d
+            docker-compose up -d socket


### PR DESCRIPTION
## 작업 이유
- Add specific service targets to the docker-compose up -d command in the CD pipeline.
- This ensures that when building the batch or socket application, both WAS services (blue/green) aren't deployed together.

<br/>

## 작업 사항
- Add service targets to the command, excluding the external API service.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- none

