### PR TITLE
Api: ✨ Chat History Search API (redis score system changed)

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatApi.java
@@ -1,0 +1,31 @@
+package kr.co.pennyway.api.apis.chat.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.pennyway.api.common.response.SliceResponseTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "[채팅 API]")
+public interface ChatApi {
+    @Operation(summary = "채팅 조회", description = "채팅방의 채팅 이력을 무한스크롤 조회합니다. 결과는 최신순으로 정렬되며, `lastMessageId`를 포함하지 않은 이전 메시지들을 조회합니다.<br/> content는 채팅방 조회의 `recentMessages` 필드와 동일합니다.")
+    @Parameters({
+            @Parameter(name = "chatRoomId", description = "채팅방 ID", required = true, in = ParameterIn.PATH),
+            @Parameter(name = "lastMessageId", description = "마지막으로 읽은 메시지 ID", required = true, in = ParameterIn.QUERY),
+            @Parameter(name = "size", description = "조회할 채팅 수(default: 30)", example = "30", required = false, in = ParameterIn.QUERY)
+    })
+    @ApiResponse(responseCode = "200", description = "채팅 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chats", schema = @Schema(implementation = SliceResponseTemplate.class))))
+    ResponseEntity<?> readChats(
+            @PathVariable("chatRoomId") Long chatRoomId,
+            @RequestParam(value = "lastMessageId") Long lastMessageId,
+            @RequestParam(value = "size", defaultValue = "30") int size
+    );
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatController.java
@@ -1,0 +1,29 @@
+package kr.co.pennyway.api.apis.chat.controller;
+
+import kr.co.pennyway.api.apis.chat.usecase.ChatUseCase;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/chat-rooms/{chatRoomId}/chats")
+public class ChatController {
+    private static final String CHATS = "chats";
+
+    private final ChatUseCase chatUseCase;
+
+    @GetMapping("")
+    @PreAuthorize("isAuthenticated() and @chatRoomManager.hasPermission(principal.userId, #chatRoomId)")
+    public ResponseEntity<?> readChats(
+            @PathVariable("chatRoomId") Long chatRoomId,
+            @RequestParam(value = "lastMessageId") Long lastMessageId,
+            @RequestParam(value = "size", defaultValue = "30") int size
+    ) {
+        return ResponseEntity.ok(SuccessResponse.from(CHATS, chatUseCase.readChats(chatRoomId, lastMessageId, size)));
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatController.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.api.apis.chat.controller;
 
+import kr.co.pennyway.api.apis.chat.api.ChatApi;
 import kr.co.pennyway.api.apis.chat.usecase.ChatUseCase;
 import kr.co.pennyway.api.common.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -12,11 +13,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v2/chat-rooms/{chatRoomId}/chats")
-public class ChatController {
+public class ChatController implements ChatApi {
     private static final String CHATS = "chats";
 
     private final ChatUseCase chatUseCase;
 
+    @Override
     @GetMapping("")
     @PreAuthorize("isAuthenticated() and @chatRoomManager.hasPermission(principal.userId, #chatRoomId)")
     public ResponseEntity<?> readChats(

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatMapper.java
@@ -1,0 +1,20 @@
+package kr.co.pennyway.api.apis.chat.mapper;
+
+import kr.co.pennyway.api.apis.chat.dto.ChatRes;
+import kr.co.pennyway.api.common.response.SliceResponseTemplate;
+import kr.co.pennyway.common.annotation.Mapper;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Mapper
+public class ChatMapper {
+    public static SliceResponseTemplate<ChatRes.ChatDetail> toChatDetails(Slice<ChatMessage> chatMessages) {
+        List<ChatRes.ChatDetail> details = chatMessages.getContent().stream()
+                .map(ChatRes.ChatDetail::from)
+                .toList();
+
+        return SliceResponseTemplate.of(details, chatMessages.getPageable(), chatMessages.getNumberOfElements(), chatMessages.hasNext());
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatSearchService.java
@@ -1,0 +1,19 @@
+package kr.co.pennyway.api.apis.chat.service;
+
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
+import kr.co.pennyway.domain.common.redis.message.service.ChatMessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatSearchService {
+    private final ChatMessageService chatMessageService;
+
+    public Slice<ChatMessage> readChats(Long chatRoomId, Long lastMessageId, int size) {
+        return chatMessageService.readMessagesBefore(chatRoomId, lastMessageId, size);
+    }
+}

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatUseCase.java
@@ -1,0 +1,24 @@
+package kr.co.pennyway.api.apis.chat.usecase;
+
+import kr.co.pennyway.api.apis.chat.dto.ChatRes;
+import kr.co.pennyway.api.apis.chat.mapper.ChatMapper;
+import kr.co.pennyway.api.apis.chat.service.ChatSearchService;
+import kr.co.pennyway.api.common.response.SliceResponseTemplate;
+import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class ChatUseCase {
+    private final ChatSearchService chatSearchService;
+
+    public SliceResponseTemplate<ChatRes.ChatDetail> readChats(Long chatRoomId, Long lastMessageId, int size) {
+        Slice<ChatMessage> chatMessages = chatSearchService.readChats(chatRoomId, lastMessageId, size);
+
+        return ChatMapper.toChatDetails(chatMessages);
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatPaginationGetIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatPaginationGetIntegrationTest.java
@@ -122,10 +122,7 @@ public class ChatPaginationGetIntegrationTest extends ExternalApiDBTestConfig {
     private ResponseEntity<?> performRequest(User user, Long chatRoomId, Long lastMessageId, int size) {
         RequestParameters parameters = RequestParameters.defaultGet(BASE_URL)
                 .user(user)
-                .queryParams(RequestParameters.createQueryParams(
-                        "lastMessageId", 1000L,
-                        "size", 30
-                ))
+                .queryParams(RequestParameters.createQueryParams("lastMessageId", lastMessageId, "size", size))
                 .uriVariables(new Object[]{chatRoomId})
                 .build();
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatPaginationGetIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatPaginationGetIntegrationTest.java
@@ -1,0 +1,185 @@
+package kr.co.pennyway.api.apis.chat.integration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.chat.dto.ChatRes;
+import kr.co.pennyway.api.common.response.SliceResponseTemplate;
+import kr.co.pennyway.api.common.response.SuccessResponse;
+import kr.co.pennyway.api.common.util.ApiTestHelper;
+import kr.co.pennyway.api.common.util.RequestParameters;
+import kr.co.pennyway.api.config.ExternalApiDBTestConfig;
+import kr.co.pennyway.api.config.ExternalApiIntegrationTest;
+import kr.co.pennyway.api.config.fixture.ChatMemberFixture;
+import kr.co.pennyway.api.config.fixture.ChatRoomFixture;
+import kr.co.pennyway.api.config.fixture.UserFixture;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
+import kr.co.pennyway.domain.common.redis.message.domain.ChatMessageBuilder;
+import kr.co.pennyway.domain.common.redis.message.repository.ChatMessageRepository;
+import kr.co.pennyway.domain.common.redis.message.type.MessageCategoryType;
+import kr.co.pennyway.domain.common.redis.message.type.MessageContentType;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.repository.ChatRoomRepository;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.repository.ChatMemberRepository;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.repository.UserRepository;
+import kr.co.pennyway.infra.client.guid.IdGenerator;
+import kr.co.pennyway.infra.common.jwt.JwtProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Slf4j
+@ExternalApiIntegrationTest
+public class ChatPaginationGetIntegrationTest extends ExternalApiDBTestConfig {
+    private static final String BASE_URL = "/v2/chat-rooms/{chatRoomId}/chats";
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private ChatMemberRepository chatMemberRepository;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private JwtProvider accessTokenProvider;
+
+    @Autowired
+    private IdGenerator<Long> idGenerator;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private ApiTestHelper apiTestHelper;
+
+    @BeforeEach
+    void setUp() {
+        apiTestHelper = new ApiTestHelper(restTemplate, objectMapper, accessTokenProvider);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Set<String> keys = redisTemplate.keys("chatroom:*:message");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    @Test
+    @DisplayName("채팅방의 이전 메시지들을 정상적으로 페이징하여 조회할 수 있다")
+    void successReadChats() {
+        // given
+        User user = createUser();
+        ChatRoom chatRoom = createChatRoom();
+        createChatMember(user, chatRoom, ChatMemberRole.ADMIN);
+        List<ChatMessage> messages = setupTestMessages(chatRoom.getId(), user.getId(), 50);
+
+        log.info("saved messages: {}", chatMessageRepository.findRecentMessages(chatRoom.getId(), 50));
+
+        // when
+        ResponseEntity<?> response = performRequest(user, chatRoom.getId(), messages.get(49).getChatId(), 30);
+
+        // then
+        assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> {
+                    SliceResponseTemplate<ChatRes.ChatDetail> slice = extractChatDetail(response);
+
+                    assertThat(slice.contents()).hasSize(30);
+                    assertThat(slice.hasNext()).isTrue();
+                }
+        );
+    }
+
+    private ResponseEntity<?> performRequest(User user, Long chatRoomId, Long lastMessageId, int size) {
+        RequestParameters parameters = RequestParameters.defaultGet(BASE_URL)
+                .user(user)
+                .queryParams(RequestParameters.createQueryParams(
+                        "lastMessageId", 1000L,
+                        "size", 30
+                ))
+                .uriVariables(new Object[]{chatRoomId})
+                .build();
+
+        return apiTestHelper.callApi(
+                parameters,
+                new TypeReference<SuccessResponse<Map<String, SliceResponseTemplate<ChatRes.ChatDetail>>>>() {
+                }
+        );
+    }
+
+    private User createUser() {
+        return userRepository.save(UserFixture.GENERAL_USER.toUser());
+    }
+
+    private ChatRoom createChatRoom() {
+        return chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(idGenerator.generate()));
+    }
+
+    private ChatMember createChatMember(User user, ChatRoom chatRoom, ChatMemberRole role) {
+        return switch (role) {
+            case ADMIN -> chatMemberRepository.save(ChatMemberFixture.ADMIN.toEntity(user, chatRoom));
+            case MEMBER -> chatMemberRepository.save(ChatMemberFixture.MEMBER.toEntity(user, chatRoom));
+        };
+    }
+
+    private List<ChatMessage> setupTestMessages(Long chatRoomId, Long senderId, int count) {
+        List<ChatMessage> messages = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+            ChatMessage message = ChatMessageBuilder.builder()
+                    .chatRoomId(chatRoomId)
+                    .chatId(idGenerator.generate())
+                    .content("Test message " + i)
+                    .contentType(MessageContentType.TEXT)
+                    .categoryType(MessageCategoryType.NORMAL)
+                    .sender(senderId)
+                    .build();
+
+            messages.add(chatMessageRepository.save(message));
+        }
+
+        return messages;
+    }
+
+    private SliceResponseTemplate<ChatRes.ChatDetail> extractChatDetail(ResponseEntity<?> response) {
+        SliceResponseTemplate<ChatRes.ChatDetail> slice = null;
+
+        try {
+            SuccessResponse<Map<String, SliceResponseTemplate<ChatRes.ChatDetail>>> successResponse = (SuccessResponse<Map<String, SliceResponseTemplate<ChatRes.ChatDetail>>>) response.getBody();
+            slice = successResponse.getData().get("chats");
+        } catch (Exception e) {
+            fail("응답 데이터 추출에 실패했습니다.", e);
+        }
+
+        return slice;
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatPaginationGetIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatPaginationGetIntegrationTest.java
@@ -104,7 +104,7 @@ public class ChatPaginationGetIntegrationTest extends ExternalApiDBTestConfig {
         List<ChatMessage> messages = setupTestMessages(chatRoom.getId(), user.getId(), 50);
 
         // when
-        ResponseEntity<?> response = performRequest(user, chatRoom.getId(), messages.get(49).getChatId() + 100, 30); // 마지막 메시지를 포함하여 요청
+        ResponseEntity<?> response = performRequest(user, chatRoom.getId(), messages.get(49).getChatId(), 30);
 
         // then
         assertAll(
@@ -112,7 +112,7 @@ public class ChatPaginationGetIntegrationTest extends ExternalApiDBTestConfig {
                 () -> {
                     SliceResponseTemplate<ChatRes.ChatDetail> slice = extractChatDetail(response);
 
-                    assertEquals(messages.get(49).getChatId(), slice.contents().get(0).chatId());
+                    assertEquals(messages.get(48).getChatId(), slice.contents().get(0).chatId(), "lastMessageId에 해당하는 메시지는 포함되지 않아야 합니다");
                     assertThat(slice.contents()).hasSize(30);
                     assertThat(slice.hasNext()).isTrue();
                 }
@@ -155,7 +155,6 @@ public class ChatPaginationGetIntegrationTest extends ExternalApiDBTestConfig {
         ChatRoom chatRoom = createChatRoom();
         createChatMember(user, chatRoom, ChatMemberRole.ADMIN);
         List<ChatMessage> messages = setupTestMessages(chatRoom.getId(), user.getId(), 10);
-        log.info("messages: {}", messages);
 
         // when
         ResponseEntity<?> response = performRequest(user, chatRoom.getId(), messages.get(0).getChatId(), 10);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatRoomDetailIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatRoomDetailIntegrationTest.java
@@ -22,6 +22,7 @@ import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
 import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.service.UserService;
+import kr.co.pennyway.infra.client.guid.IdGenerator;
 import kr.co.pennyway.infra.common.jwt.JwtProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
@@ -72,6 +73,9 @@ public class ChatRoomDetailIntegrationTest extends ExternalApiDBTestConfig {
 
     @Autowired
     private ChatMessageRepositoryImpl chatMessageRepository;
+
+    @Autowired
+    private IdGenerator<Long> idGenerator;
 
     private ApiTestHelper apiTestHelper;
 
@@ -191,11 +195,11 @@ public class ChatRoomDetailIntegrationTest extends ExternalApiDBTestConfig {
         );
     }
 
-    private ChatMessage createTestMessage(Long chatRoomId, Long chatId, Long senderId) {
+    private ChatMessage createTestMessage(Long chatRoomId, Long idx, Long senderId) {
         return ChatMessageBuilder.builder()
                 .chatRoomId(chatRoomId)
-                .chatId(chatId)
-                .content("Test message " + chatId)
+                .chatId(idGenerator.generate())
+                .content("Test message " + idx)
                 .contentType(MessageContentType.TEXT)
                 .categoryType(MessageCategoryType.NORMAL)
                 .sender(senderId)

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/common/util/RequestParameters.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/common/util/RequestParameters.java
@@ -1,0 +1,118 @@
+package kr.co.pennyway.api.common.util;
+
+import kr.co.pennyway.domain.domains.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+@Builder
+public class RequestParameters {
+    private final String url;
+    private final HttpMethod method;
+    private final User user;
+    private final Object request;
+    private final Map<String, String> queryParams;
+    private final Object[] uriVariables;
+
+    private RequestParameters(String url, HttpMethod method, User user,
+                              Object request, Map<String, String> queryParams, Object[] uriVariables) {
+        validateRequired(url, "URL must not be null");
+        validateRequired(method, "HTTP method must not be null");
+        validateRequired(user, "User must not be null");
+
+        this.url = url;
+        this.method = method;
+        this.user = user;
+        this.request = request;
+        this.queryParams = queryParams;
+        this.uriVariables = uriVariables;
+    }
+
+    /**
+     * RequestParameters 생성을 위한 편의 메서드
+     * GET 메서드를 사용하는 경우에 사용합니다.
+     */
+    public static RequestParametersBuilder defaultGet(String url) {
+        return RequestParameters.builder()
+                .url(url)
+                .method(HttpMethod.GET);
+    }
+
+    /**
+     * RequestParameters 생성을 위한 편의 메서드
+     * POST 메서드를 사용하는 경우에 사용합니다.
+     */
+    public static RequestParametersBuilder defaultPost(String url) {
+        return RequestParameters.builder()
+                .url(url)
+                .method(HttpMethod.POST);
+    }
+
+    /**
+     * RequestParameters 생성을 위한 편의 메서드
+     * PUT 메서드를 사용하는 경우에 사용합니다.
+     */
+    public static RequestParametersBuilder defaultPut(String url) {
+        return RequestParameters.builder()
+                .url(url)
+                .method(HttpMethod.PUT);
+    }
+
+    /**
+     * RequestParameters 생성을 위한 편의 메서드
+     * DELETE 메서드를 사용하는 경우에 사용합니다.
+     */
+    public static RequestParametersBuilder defaultDelete(String url) {
+        return RequestParameters.builder()
+                .url(url)
+                .method(HttpMethod.DELETE);
+    }
+
+    /**
+     * 쿼리 파라미터 추가를 위한 편의 메서드
+     * key-value 쌍으로 쿼리 파라미터를 생성합니다.
+     *
+     * @throws IllegalArgumentException key-value 쌍이 제대로 제공되지 않은 경우
+     */
+    public static Map<String, String> createQueryParams(Object... keyValues) {
+        if (keyValues.length % 2 != 0) {
+            throw new IllegalArgumentException("Key-value pairs must be provided");
+        }
+
+        Map<String, String> params = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            params.put(String.valueOf(keyValues[i]), String.valueOf(keyValues[i + 1]));
+        }
+        return params;
+    }
+
+    private void validateRequired(Object value, String message) {
+        if (value == null) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    /**
+     * URI를 생성합니다.
+     * 쿼리 파라미터와 URI 변수를 적용합니다.
+     */
+    public URI createUri() {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(url);
+
+        // 쿼리 파라미터 적용
+        if (queryParams != null && !queryParams.isEmpty()) {
+            queryParams.forEach(builder::queryParam);
+        }
+
+        // URI 변수 적용
+        return (uriVariables != null && uriVariables.length > 0)
+                ? builder.buildAndExpand(uriVariables).toUri()
+                : builder.build().toUri();
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepository.java
@@ -42,8 +42,9 @@ public interface ChatMessageRepository {
      * 사용자가 마지막으로 읽은 메시지 이후의 안 읽은 메시지 개수를 조회합니다.
      *
      * @param roomId            채팅방 ID
-     * @param lastReadMessageId 사용자가 마지막으로 읽은 메시지의 TSID
+     * @param lastReadMessageId 사용자가 마지막으로 읽은 메시지의 TSID. 이 값이 0일 경우 모든 메시지 개수를 조회합니다.
      * @return 안 읽은 메시지 개수
+     * @throws IllegalArgumentException lastReadMessageId가 null이거나 음수인 경우
      */
     Long countUnreadMessages(Long roomId, Long lastReadMessageId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryImpl.java
@@ -61,12 +61,12 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepository {
         Set<String> messageJsonSet = redisTemplate.opsForZSet().reverseRangeByScore( // ZREVRANGEBYSCORE
                 chatRoomKey,
                 0, // 최소값
-                lastMessageId - 1, // 마지막으로 조회한 메시지 이전까지
+                lastMessageId, // 마지막으로 조회한 메시지 이전까지
                 0, // offset
                 size + 1 // size + 1 만큼 조회하여 다음 페이지 존재 여부 확인
         );
-
         List<ChatMessage> messages = convertToMessages(messageJsonSet);
+
         boolean hasNext = messages.size() > size;
 
         if (hasNext) {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryImpl.java
@@ -61,7 +61,7 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepository {
         Set<String> messageJsonSet = redisTemplate.opsForZSet().reverseRangeByScore( // ZREVRANGEBYSCORE
                 chatRoomKey,
                 0, // 최소값
-                lastMessageId, // 마지막으로 조회한 메시지 이전까지
+                lastMessageId - 100, // 마지막으로 조회한 메시지 이전까지
                 0, // offset
                 size + 1 // size + 1 만큼 조회하여 다음 페이지 존재 여부 확인
         );

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/repository/ChatMessageRepositoryImpl.java
@@ -75,6 +75,14 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepository {
 
     @Override
     public Long countUnreadMessages(Long roomId, Long lastReadMessageId) {
+        if (lastReadMessageId == null || lastReadMessageId < 0) {
+            throw new IllegalArgumentException("lastReadMessageId must not be null");
+        }
+
+        if (lastReadMessageId == 0L) {
+            return redisTemplate.opsForZSet().zCard(getChatRoomKey(roomId));
+        }
+
         String chatRoomKey = getChatRoomKey(roomId);
         String tsidKey = formatTsidKey(lastReadMessageId);
 

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/service/ChatMessageService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/message/service/ChatMessageService.java
@@ -2,7 +2,7 @@ package kr.co.pennyway.domain.common.redis.message.service;
 
 import kr.co.pennyway.common.annotation.DomainService;
 import kr.co.pennyway.domain.common.redis.message.domain.ChatMessage;
-import kr.co.pennyway.domain.common.redis.message.repository.ChatMessageRepositoryImpl;
+import kr.co.pennyway.domain.common.redis.message.repository.ChatMessageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
@@ -13,10 +13,10 @@ import java.util.List;
 @DomainService
 @RequiredArgsConstructor
 public class ChatMessageService {
-    private final ChatMessageRepositoryImpl chatMessageRepositoryImpl;
+    private final ChatMessageRepository chatMessageRepository;
 
     public ChatMessage create(ChatMessage chatMessage) {
-        return chatMessageRepositoryImpl.save(chatMessage);
+        return chatMessageRepository.save(chatMessage);
     }
 
     /**
@@ -27,7 +27,7 @@ public class ChatMessageService {
      * @return 최근 시간 순으로 정렬된 최근 메시지 목록
      */
     public List<ChatMessage> readRecentMessages(Long roomId, int limit) {
-        return chatMessageRepositoryImpl.findRecentMessages(roomId, limit);
+        return chatMessageRepository.findRecentMessages(roomId, limit);
     }
 
     /**
@@ -41,7 +41,7 @@ public class ChatMessageService {
      * @return 페이징된 메시지 목록
      */
     public Slice<ChatMessage> readMessagesBefore(Long roomId, Long lastMessageId, int size) {
-        return chatMessageRepositoryImpl.findMessagesBefore(roomId, lastMessageId, size);
+        return chatMessageRepository.findMessagesBefore(roomId, lastMessageId, size);
     }
 
     /**
@@ -52,6 +52,6 @@ public class ChatMessageService {
      * @return 안 읽은 메시지 개수
      */
     public Long countUnreadMessages(Long roomId, Long lastReadMessageId) {
-        return chatMessageRepositoryImpl.countUnreadMessages(roomId, lastReadMessageId);
+        return chatMessageRepository.countUnreadMessages(roomId, lastReadMessageId);
     }
 }


### PR DESCRIPTION
## 작업 이유
- Implement a Chat History Retrieval API by Chat Room
- Modify the storage method for chat history in Redis.

<br/>

## 작업 사항
### 1️⃣ Api Specification
- request
  - url: `GET /v2/chat-rooms/{chatRoomId}/chats?chatRoomId=&lastMessageId=&size=`
     - pre-condition: authenticated user, chat room accessible by `userId`
     - parameter
        - chatRoomId
        - lastMessageId: oldest message ID read by the client
        - size: content size (Optional)
- response
    ```json
    {
      "code": ""
      "data": {
        "chats": {
          "contents": [
            {
              "chatRoomId": 0,
              "chatId": 0,
              "content": "string",
              "contentType": "TEXT",
              "categoryType": "NORMAL",
              "createdAt": "2024-11-10 14:05:10",
              "senderId": 0
            },
          ],
          "currentPageNumber": 0,
          "pageSize": 0,
          "numberOfElements": 0,
          "hasNext": true
      }
    }
    ```

<br/>

### 2️⃣ Redis Sorted Set Score Type Problem
![image](https://github.com/user-attachments/assets/85174910-053e-4862-a7d5-3797ba7c87a9)

The issue was first discovered during integration testing.  
With `N` data entries saved and querying the oldest message ID as `lastMessageId`, it should return 0.

![image](https://github.com/user-attachments/assets/4e1a36c0-ab4f-4808-a45e-2f112e5659e4)

However, the same lastMessageId messages kept appearing.

![image](https://github.com/user-attachments/assets/ac5a03f2-c822-4b5c-9a22-87f0a40fc251)
![image](https://github.com/user-attachments/assets/556e8bd2-9d3c-4bae-a9ba-1e9a49eb2351)
![image](https://github.com/user-attachments/assets/6daaaf7e-6690-4152-996d-51ecd3131307)

Revealing that Redis' sorted set score type only supports `double` values, causing precision loss for the `long` type `chatId` used as a score.  
This was resolved by implementing `lexicographical sorting`, using a format of `{timestamp}:{counter}` as follows:

```java
/**
* TSID를 lexicographical sorting이 가능한 형태의 문자열로 변환
* format: {timestamp부분:16진수}:{counter부분:4자리}
*/
private String formatTsidKey(long tsid) {
    String tsidStr = String.valueOf(tsid);

    String timestamp = tsidStr.substring(0, tsidStr.length() - COUNTER_DIGITS);
    String counter = tsidStr.substring(tsidStr.length() - COUNTER_DIGITS);

    return timestamp + ":" + counter;
}
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- Potential performance degradation from the new method, but not critical given expected traffic.
- Code has seen many rapid changes; feedback on areas needing improvement is appreciated.

<br/>

## 발견한 이슈
- Many commands with REV are now deprecated in Redis, yet Data Redis still supports them, so no changes were made.
- Due to complexity, we have decided to clear existing chat history with the iOS team's consent.

