### PR TITLE
Api: ✏️ Append LastMessage Field in ChatRoomDetail Response

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.dto.ChatRoomDetail;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -13,6 +14,23 @@ import java.util.Objects;
 import java.util.Set;
 
 public final class ChatRoomRes {
+    /**
+     * 채팅방 정보를 담기 위한 DTO
+     *
+     * @param chatRoom           {@link ChatRoomDetail} : 채팅방 정보
+     * @param unreadMessageCount long : 읽지 않은 메시지 수
+     * @param lastMessage        {@link ChatRes.ChatDetail} : 가장 최근 메시지. 없을 경우 null
+     */
+    public record Info(
+            ChatRoomDetail chatRoom,
+            long unreadMessageCount,
+            ChatRes.ChatDetail lastMessage
+    ) {
+        public static Info of(ChatRoomDetail chatRoom, long unreadMessageCount, ChatRes.ChatDetail recentMessage) {
+            return new Info(chatRoom, unreadMessageCount, recentMessage);
+        }
+    }
+
     @Schema(description = "채팅방 상세 정보")
     public record Detail(
             @Schema(description = "채팅방 ID", type = "long")
@@ -33,10 +51,12 @@ public final class ChatRoomRes {
             @JsonSerialize(using = LocalDateTimeSerializer.class)
             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime createdAt,
+            @Schema(description = "마지막 메시지 정보. 없을 경우 null이 반환된다.")
+            ChatRes.ChatDetail lastMessage,
             @Schema(description = "읽지 않은 메시지 수. 100 이상의 값을 가지면, 100으로 표시된다.")
             long unreadMessageCount
     ) {
-        public Detail(Long id, String title, String description, String backgroundImageUrl, boolean isPrivate, boolean isAdmin, int participantCount, LocalDateTime createdAt, long unreadMessageCount) {
+        public Detail(Long id, String title, String description, String backgroundImageUrl, boolean isPrivate, boolean isAdmin, int participantCount, LocalDateTime createdAt, ChatRes.ChatDetail lastMessage, long unreadMessageCount) {
             this.id = id;
             this.title = title;
             this.description = Objects.toString(description, "");
@@ -45,10 +65,11 @@ public final class ChatRoomRes {
             this.isAdmin = isAdmin;
             this.participantCount = participantCount;
             this.createdAt = createdAt;
+            this.lastMessage = lastMessage;
             this.unreadMessageCount = (unreadMessageCount > 100) ? 100 : unreadMessageCount;
         }
 
-        public static Detail of(ChatRoom chatRoom, boolean isAdmin, int participantCount, long unreadMessageCount) {
+        public static Detail of(ChatRoom chatRoom, ChatRes.ChatDetail lastMessage, boolean isAdmin, int participantCount, long unreadMessageCount) {
             return new Detail(
                     chatRoom.getId(),
                     chatRoom.getTitle(),
@@ -58,7 +79,23 @@ public final class ChatRoomRes {
                     isAdmin,
                     participantCount,
                     chatRoom.getCreatedAt(),
+                    lastMessage,
                     unreadMessageCount
+            );
+        }
+
+        public static Detail from(ChatRoomRes.Info info) {
+            return new Detail(
+                    info.chatRoom().id(),
+                    info.chatRoom().title(),
+                    info.chatRoom().description(),
+                    info.chatRoom().backgroundImageUrl(),
+                    info.chatRoom().password() != null,
+                    info.chatRoom().isAdmin(),
+                    info.chatRoom().participantCount(),
+                    info.chatRoom().createdAt(),
+                    info.lastMessage(),
+                    info.unreadMessageCount()
             );
         }
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
@@ -14,10 +14,17 @@ import org.springframework.data.domain.Slice;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Mapper
 public final class ChatRoomMapper {
+    /**
+     * 채팅방 상세 정보를 SliceResponseTemplate 형태로 변환한다.
+     * 해당 메서드는 언제나 채팅방 검색 응답으로 사용되며, 마지막 메시지 정보는 null로 설정된다.
+     *
+     * @param details
+     * @param pageable
+     * @return
+     */
     public static SliceResponseTemplate<ChatRoomRes.Detail> toChatRoomResDetails(Slice<ChatRoomDetail> details, Pageable pageable) {
         List<ChatRoomRes.Detail> contents = new ArrayList<>();
         for (ChatRoomDetail detail : details.getContent()) {
@@ -31,6 +38,7 @@ public final class ChatRoomMapper {
                             detail.isAdmin(),
                             detail.participantCount(),
                             detail.createdAt(),
+                            null,
                             0
                     )
             );
@@ -39,22 +47,22 @@ public final class ChatRoomMapper {
         return SliceResponseTemplate.of(contents, pageable, contents.size(), details.hasNext());
     }
 
-    public static List<ChatRoomRes.Detail> toChatRoomResDetails(Map<ChatRoomDetail, Long> details) {
+    public static List<ChatRoomRes.Detail> toChatRoomResDetails(List<ChatRoomRes.Info> details) {
         List<ChatRoomRes.Detail> responses = new ArrayList<>();
 
-        for (Map.Entry<ChatRoomDetail, Long> entry : details.entrySet()) {
-            ChatRoomDetail detail = entry.getKey();
+        for (ChatRoomRes.Info info : details) {
             responses.add(
                     new ChatRoomRes.Detail(
-                            detail.id(),
-                            detail.title(),
-                            detail.description(),
-                            detail.backgroundImageUrl(),
-                            detail.password() != null,
-                            detail.isAdmin(),
-                            detail.participantCount(),
-                            detail.createdAt(),
-                            entry.getValue()
+                            info.chatRoom().id(),
+                            info.chatRoom().title(),
+                            info.chatRoom().description(),
+                            info.chatRoom().backgroundImageUrl(),
+                            info.chatRoom().password() != null,
+                            info.chatRoom().isAdmin(),
+                            info.chatRoom().participantCount(),
+                            info.chatRoom().createdAt(),
+                            info.lastMessage(),
+                            info.unreadMessageCount()
                     )
             );
         }
@@ -62,8 +70,8 @@ public final class ChatRoomMapper {
         return responses;
     }
 
-    public static ChatRoomRes.Detail toChatRoomResDetail(ChatRoom chatRoom, boolean isAdmin, int participantCount, long unreadMessageCount) {
-        return ChatRoomRes.Detail.of(chatRoom, isAdmin, participantCount, unreadMessageCount);
+    public static ChatRoomRes.Detail toChatRoomResDetail(ChatRoom chatRoom, ChatRes.ChatDetail lastMessage, boolean isAdmin, int participantCount, long unreadMessageCount) {
+        return ChatRoomRes.Detail.of(chatRoom, lastMessage, isAdmin, participantCount, unreadMessageCount);
     }
 
     public static ChatRoomRes.RoomWithParticipants toChatRoomResRoomWithParticipants(ChatMemberResult.Detail myInfo, List<ChatMemberResult.Detail> recentParticipants, List<ChatMemberResult.Summary> otherParticipants, List<ChatMessage> chatMessages) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -26,7 +26,7 @@ public class ChatMemberUseCase {
     public ChatRoomRes.Detail joinChatRoom(Long userId, Long chatRoomId, Integer password) {
         Triple<ChatRoom, Integer, Long> chatRoom = chatMemberJoinService.execute(userId, chatRoomId, password);
 
-        return ChatRoomMapper.toChatRoomResDetail(chatRoom.getLeft(), false, chatRoom.getMiddle(), chatRoom.getRight());
+        return ChatRoomMapper.toChatRoomResDetail(chatRoom.getLeft(), null, false, chatRoom.getMiddle(), chatRoom.getRight());
     }
 
     public List<ChatMemberRes.MemberDetail> readChatMembers(Long chatRoomId, Set<Long> chatMemberIds) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
@@ -16,7 +16,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 @UseCase
@@ -31,11 +30,11 @@ public class ChatRoomUseCase {
     public ChatRoomRes.Detail createChatRoom(ChatRoomReq.Create request, Long userId) {
         ChatRoom chatRoom = chatRoomSaveService.createChatRoom(request, userId);
 
-        return ChatRoomMapper.toChatRoomResDetail(chatRoom, true, 1, 0);
+        return ChatRoomMapper.toChatRoomResDetail(chatRoom, null, true, 1, 0);
     }
 
     public List<ChatRoomRes.Detail> getChatRooms(Long userId) {
-        Map<ChatRoomDetail, Long> chatRooms = chatRoomSearchService.readChatRooms(userId);
+        List<ChatRoomRes.Info> chatRooms = chatRoomSearchService.readChatRooms(userId);
 
         return ChatRoomMapper.toChatRoomResDetails(chatRooms);
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomSaveControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomSaveControllerUnitTest.java
@@ -52,7 +52,7 @@ public class ChatRoomSaveControllerUnitTest {
         // given
         ChatRoom fixture = ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity(1L);
         ChatRoomReq.Create request = ChatRoomFixture.PRIVATE_CHAT_ROOM.toCreateRequest();
-        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.of(fixture, true, 1, 10));
+        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.of(fixture, null, true, 1, 10));
 
         // when
         ResultActions result = performPostChatRoom(request);
@@ -70,7 +70,7 @@ public class ChatRoomSaveControllerUnitTest {
         ChatRoom fixture = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(1L);
         ChatRoomReq.Create request = ChatRoomFixture.PUBLIC_CHAT_ROOM.toCreateRequest();
 
-        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.of(fixture, true, 1, 10));
+        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.of(fixture, null, true, 1, 10));
 
         // when
         ResultActions result = performPostChatRoom(request);


### PR DESCRIPTION
## 작업 이유
![image](https://github.com/user-attachments/assets/8293a5c0-162a-40a9-8022-5ddead9a34e4)
- When client requests `ChatRoomDetail`, the server must include the `lastMessage` field.
- However, this data doesn't need to be highly reliable compared to `unreadMessageCount`. Since any user in the chatroom can send message simultaneously, even if the server retrieves an earlier message, the client will replace the `lastMessage` component with the latest message from the the socket server.

<br/>

## 작업 사항
```json
{
  "chatRooms": [
    {
      "id": 0,
      "title": "string",
      "description": "string",
      "backgroundImageUrl": "string",
      "isPrivate": true,
      "isAdmin": true,
      "participantCount": 0,
      "createdAt": "2024-11-11T05:29:12.715Z",
      "lastMessage": { // Append this field 
        "chatRoomId": 0,
        "chatId": 0,
        "content": "string",
        "contentType": "TEXT",
        "categoryType": "NORMAL",
        "createdAt": "2024-11-11T05:29:12.715Z",
        "senderId": 0
      },
      "unreadMessageCount": 0
    }
  ]
}
```
- if the server can't find the `lastMessage`, this field will be `null`
  - I want to replace `{}`, but this work is so hard...
- APIs that share this response DTO will also be updated accordingly, but the rule is straightforward.
   - Search Chatroom: The `lastMessage` field isn't required and is always `null`
   - Join Chatroom: When the client joins a chatroom, it will enter the chatroom, so this field isn't necessary.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- I’m not entirely sure why my tests are passing 😂. Plz check this.

<br/>

## 발견한 이슈
- none

