### PR TITLE
Ignore: ✏️ Append WHERE condition in readNotification Query

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/service/NotificationSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/service/NotificationSearchService.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.api.apis.notification.service;
 
 import kr.co.pennyway.domain.domains.notification.domain.Notification;
 import kr.co.pennyway.domain.domains.notification.service.NotificationService;
+import kr.co.pennyway.domain.domains.notification.type.NoticeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -18,13 +19,13 @@ public class NotificationSearchService {
     private final NotificationService notificationService;
 
     @Transactional(readOnly = true)
-    public Slice<Notification> getNotifications(Long userId, Pageable pageable) {
-        return notificationService.readNotificationsSlice(userId, pageable);
+    public Slice<Notification> getAnnounceNotifications(Long userId, Pageable pageable) {
+        return notificationService.readNotificationsSlice(userId, pageable, NoticeType.ANNOUNCEMENT);
     }
 
     @Transactional(readOnly = true)
-    public List<Notification> getUnreadNotifications(Long userId) {
-        return notificationService.readUnreadNotifications(userId);
+    public List<Notification> getAnnounceUnreadNotifications(Long userId) {
+        return notificationService.readUnreadNotifications(userId, NoticeType.ANNOUNCEMENT);
     }
 
     @Transactional(readOnly = true)

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/notification/usecase/NotificationUseCase.java
@@ -21,13 +21,13 @@ public class NotificationUseCase {
     private final NotificationSaveService notificationSaveService;
 
     public NotificationDto.SliceRes getReadNotifications(Long userId, Pageable pageable) {
-        Slice<Notification> notifications = notificationSearchService.getNotifications(userId, pageable);
+        Slice<Notification> notifications = notificationSearchService.getAnnounceNotifications(userId, pageable);
 
         return NotificationMapper.toSliceRes(notifications, pageable);
     }
 
     public List<NotificationDto.Info> getUnreadNotifications(Long userId) {
-        List<Notification> notifications = notificationSearchService.getUnreadNotifications(userId);
+        List<Notification> notifications = notificationSearchService.getAnnounceUnreadNotifications(userId);
 
         return NotificationMapper.toInfoList(notifications);
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/service/NotificationService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/notification/service/NotificationService.java
@@ -7,6 +7,7 @@ import kr.co.pennyway.domain.common.util.SliceUtil;
 import kr.co.pennyway.domain.domains.notification.domain.Notification;
 import kr.co.pennyway.domain.domains.notification.domain.QNotification;
 import kr.co.pennyway.domain.domains.notification.repository.NotificationRepository;
+import kr.co.pennyway.domain.domains.notification.type.NoticeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -25,8 +26,10 @@ public class NotificationService {
     private final QNotification notification = QNotification.notification;
 
     @Transactional(readOnly = true)
-    public Slice<Notification> readNotificationsSlice(Long userId, Pageable pageable) {
-        Predicate predicate = notification.receiver.id.eq(userId).and(notification.readAt.isNotNull());
+    public Slice<Notification> readNotificationsSlice(Long userId, Pageable pageable, NoticeType noticeType) {
+        Predicate predicate = notification.receiver.id.eq(userId)
+                .and(notification.readAt.isNotNull())
+                .and(notification.type.eq(noticeType));
 
         QueryHandler queryHandler = query -> query
                 .offset(pageable.getOffset())
@@ -38,8 +41,10 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
-    public List<Notification> readUnreadNotifications(Long userId) {
-        Predicate predicate = notification.receiver.id.eq(userId).and(notification.readAt.isNull());
+    public List<Notification> readUnreadNotifications(Long userId, NoticeType noticeType) {
+        Predicate predicate = notification.receiver.id.eq(userId)
+                .and(notification.readAt.isNull())
+                .and(notification.type.eq(noticeType));
 
         return notificationRepository.findList(predicate, null, null);
     }

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/notification/repository/ReadNotificationsSliceUnitTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/domains/notification/repository/ReadNotificationsSliceUnitTest.java
@@ -71,7 +71,7 @@ public class ReadNotificationsSliceUnitTest extends ContainerMySqlTestConfig {
         bulkInsertNotifications(notifications);
 
         // when
-        Slice<Notification> result = notificationService.readNotificationsSlice(user.getId(), pa);
+        Slice<Notification> result = notificationService.readNotificationsSlice(user.getId(), pa, NoticeType.ANNOUNCEMENT);
 
         // then
         assertEquals("Slice 데이터 개수는 5개여야 한다.", 5, result.getNumberOfElements());


### PR DESCRIPTION
## 작업 이유
![image](https://github.com/user-attachments/assets/bae256c7-976c-417b-a485-9388e4a8522e)

- We had three types of notices, but the designer wants to display only `Announce` type notifications.

<br/>

## 작업 사항
```java
@Transactional(readOnly = true)
public Slice<Notification> readNotificationsSlice(Long userId, Pageable pageable, NoticeType noticeType) {
    Predicate predicate = notification.receiver.id.eq(userId)
            .and(notification.readAt.isNotNull())
            .and(notification.type.eq(noticeType));

    QueryHandler queryHandler = query -> query
            .offset(pageable.getOffset())
            .limit(pageable.getPageSize() + 1);

    Sort sort = pageable.getSort();

    return SliceUtil.toSlice(notificationRepository.findList(predicate, queryHandler, sort), pageable);
}

@Transactional(readOnly = true)
public List<Notification> readUnreadNotifications(Long userId, NoticeType noticeType) {
    Predicate predicate = notification.receiver.id.eq(userId)
            .and(notification.readAt.isNull())
            .and(notification.type.eq(noticeType));

    return notificationRepository.findList(predicate, null, null);
}
```
- Add a `NoticeType` parameter to the domain service’s read method.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- none

