### PR TITLE
Ignore: ✏️ Users are unable to delete their accounts while they hold ownership of any chatrooms

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserDeleteService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/users/service/UserDeleteService.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.users.service;
 
 import kr.co.pennyway.domain.domains.device.service.DeviceTokenService;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberService;
 import kr.co.pennyway.domain.domains.oauth.service.OauthService;
 import kr.co.pennyway.domain.domains.spending.service.SpendingCustomCategoryService;
 import kr.co.pennyway.domain.domains.spending.service.SpendingService;
@@ -27,6 +28,8 @@ public class UserDeleteService {
     private final OauthService oauthService;
     private final DeviceTokenService deviceTokenService;
 
+    private final ChatMemberService chatMemberService;
+
     private final SpendingService spendingService;
     private final SpendingCustomCategoryService spendingCustomCategoryService;
 
@@ -36,13 +39,14 @@ public class UserDeleteService {
      * hard delete가 수행되어야 할 데이터는 삭제하지 않으며, 사용자 데이터 유지 기간이 만료될 때 DBA가 수행한다.
      *
      * @param userId
-     * @todo [2024-05-03] 채팅 기능이 추가되는 경우 채팅방장 탈퇴를 제한해야 하며, 추가로 삭제될 엔티티 삭제 로직을 추가해야 한다.
      */
     @Transactional
     public void execute(Long userId) {
         if (!userService.isExistUser(userId)) throw new UserErrorException(UserErrorCode.NOT_FOUND);
 
-        // TODO: [2024-05-03] 하나라도 채팅방의 방장으로 참여하는 경우 삭제 불가능 처리
+        if (chatMemberService.hasUserChatRoomOwnership(userId)) {
+            throw new UserErrorException(UserErrorCode.HAS_OWNERSHIP_CHAT_ROOM);
+        }
 
         oauthService.deleteOauthsByUserIdInQuery(userId);
         deviceTokenService.deleteDevicesByUserIdInQuery(userId);

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepository.java
@@ -12,6 +12,11 @@ public interface CustomChatMemberRepository {
     boolean existsByChatRoomIdAndUserId(Long chatRoomId, Long userId);
 
     /**
+     * 해당 유저가 채팅방장으로 가입한 채팅방이 존재하는지 확인한다.
+     */
+    boolean existsOwnershipChatRoomByUserId(Long userId);
+
+    /**
      * 채팅방의 관리자 정보를 조회한다.
      */
     Optional<ChatMemberResult.Detail> findAdminByChatRoomId(Long chatRoomId);

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepositoryImpl.java
@@ -29,6 +29,16 @@ public class CustomChatMemberRepositoryImpl implements CustomChatMemberRepositor
     }
 
     @Override
+    public boolean existsOwnershipChatRoomByUserId(Long userId) {
+        return queryFactory.select(ConstantImpl.create(1))
+                .from(chatMember)
+                .where(chatMember.user.id.eq(userId)
+                        .and(chatMember.role.eq(ChatMemberRole.ADMIN))
+                        .and(chatMember.deletedAt.isNull()))
+                .fetchFirst() != null;
+    }
+
+    @Override
     public Optional<ChatMemberResult.Detail> findAdminByChatRoomId(Long chatRoomId) {
         ChatMemberResult.Detail result =
                 queryFactory.select(

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberService.java
@@ -124,6 +124,11 @@ public class ChatMemberService {
     }
 
     @Transactional(readOnly = true)
+    public boolean hasUserChatRoomOwnership(Long userId) {
+        return chatMemberRepository.existsOwnershipChatRoomByUserId(userId);
+    }
+
+    @Transactional(readOnly = true)
     public long countActiveMembers(Long chatRoomId) {
         return chatMemberRepository.countByChatRoomIdAndActive(chatRoomId);
     }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/domains/user/exception/UserErrorCode.java
@@ -26,6 +26,7 @@ public enum UserErrorCode implements BaseErrorCode {
     ALREADY_SIGNUP(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 회원가입한 유저입니다."),
     ALREADY_EXIST_USERNAME(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 존재하는 아이디입니다."),
     ALREADY_EXIST_PHONE(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 존재하는 휴대폰 번호입니다."),
+    HAS_OWNERSHIP_CHAT_ROOM(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "채팅방의 방장으로 참여하고 있는 경우 삭제할 수 없습니다."),
 
     /* 404 NOT_FOUND */
     NOT_FOUND(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "유저를 찾을 수 없습니다."),


### PR DESCRIPTION
## 작업 이유
- Add a restriction in the sign-out process to prevent users from signing out if they hold ownership of any chatrooms.

<br/>

## 작업 사항
```java
@Slf4j
@Service
@RequiredArgsConstructor
public class UserDeleteService {
    ...

    private final ChatMemberService chatMemberService;

    /**
     * 사용자와 관련한 모든 데이터를 삭제(soft delete)하는 메서드
     * <p>
     * hard delete가 수행되어야 할 데이터는 삭제하지 않으며, 사용자 데이터 유지 기간이 만료될 때 DBA가 수행한다.
     *
     * @param userId
     */
    @Transactional
    public void execute(Long userId) {
        if (!userService.isExistUser(userId)) throw new UserErrorException(UserErrorCode.NOT_FOUND);

        if (chatMemberService.hasUserChatRoomOwnership(userId)) {
            throw new UserErrorException(UserErrorCode.HAS_OWNERSHIP_CHAT_ROOM);
        }

        // .. delete process
    }
}
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- It should be appended deletion processes related user data

