### PR TITLE
Ignore: ✏️ Modification of Refresh Token Specification

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignInReq.java
@@ -11,7 +11,10 @@ public class SignInReq {
             String username,
             @Schema(description = "비밀번호", example = "pennyway1234")
             @NotBlank(message = "비밀번호를 입력해주세요")
-            String password
+            String password,
+            @Schema(description = "사용자 기기 고유 식별자", example = "AA-BBB-CCC")
+            @NotBlank(message = "사용자 기기 고유 식별자를 입력해주세요")
+            String deviceId
     ) {
     }
 
@@ -25,7 +28,10 @@ public class SignInReq {
             String idToken,
             @Schema(description = "OIDC nonce")
             @NotBlank(message = "OIDC nonce는 필수 입력값입니다.")
-            String nonce
+            String nonce,
+            @Schema(description = "사용자 기기 고유 식별자", example = "AA-BBB-CCC")
+            @NotBlank(message = "사용자 기기 고유 식별자를 입력해주세요")
+            String deviceId
     ) {
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
  * 일반 회원가입 시엔 General, 소셜 회원가입 시엔 Oauth를 사용합니다.
  */
 public class SignUpReq {
-    public record Info(String username, String name, String password, String phone, String code) {
+    public record Info(String username, String name, String password, String phone, String code, String deviceId) {
         public String password(PasswordEncoder passwordEncoder) {
             return passwordEncoder.encode(password);
         }
@@ -43,7 +43,7 @@ public class SignUpReq {
     }
 
     public record OauthInfo(String oauthId, String idToken, String nonce, String name, String username, String phone,
-                            String code) {
+                            String code, String deviceId) {
         public User toUser() {
             return User.builder()
                     .username(username)
@@ -77,10 +77,13 @@ public class SignUpReq {
             @Schema(description = "6자리 정수 인증번호", example = "123456")
             @NotBlank(message = "인증번호는 필수입니다.")
             @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
-            String code
+            String code,
+            @Schema(description = "사용자 기기 고유 식별자", example = "AA-BBB-CCC")
+            @NotBlank(message = "사용자 기기 고유 식별자를 입력해주세요")
+            String deviceId
     ) {
         public Info toInfo() {
-            return new Info(username, name, password, phone, code);
+            return new Info(username, name, password, phone, code, deviceId);
         }
     }
 
@@ -100,7 +103,7 @@ public class SignUpReq {
             String code
     ) {
         public Info toInfo() {
-            return new Info(null, null, password, phone, code);
+            return new Info(null, null, password, phone, code, null);
         }
     }
 
@@ -130,10 +133,13 @@ public class SignUpReq {
             @Schema(description = "6자리 정수 인증번호", example = "123456")
             @NotBlank(message = "인증번호는 필수입니다.")
             @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
-            String code
+            String code,
+            @Schema(description = "사용자 기기 고유 식별자", example = "AA-BBB-CCC")
+            @NotBlank(message = "사용자 기기 고유 식별자를 입력해주세요")
+            String deviceId
     ) {
         public OauthInfo toOauthInfo() {
-            return new OauthInfo(oauthId, idToken, nonce, name, username, phone, code);
+            return new OauthInfo(oauthId, idToken, nonce, name, username, phone, code, deviceId);
         }
     }
 
@@ -155,10 +161,13 @@ public class SignUpReq {
             @Schema(description = "6자리 정수 인증번호", example = "123456")
             @NotBlank(message = "인증번호는 필수입니다.")
             @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
-            String code
+            String code,
+            @Schema(description = "사용자 기기 고유 식별자", example = "AA-BBB-CCC")
+            @NotBlank(message = "사용자 기기 고유 식별자를 입력해주세요")
+            String deviceId
     ) {
         public OauthInfo toOauthInfo() {
-            return new OauthInfo(oauthId, idToken, nonce, null, null, phone, code);
+            return new OauthInfo(oauthId, idToken, nonce, null, null, phone, code, deviceId);
         }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/dto/SignUpReq.java
@@ -100,10 +100,13 @@ public class SignUpReq {
             @Schema(description = "6자리 정수 인증번호", example = "123456")
             @NotBlank(message = "인증번호는 필수입니다.")
             @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
-            String code
+            String code,
+            @Schema(description = "사용자 기기 고유 식별자", example = "AA-BBB-CCC")
+            @NotBlank(message = "사용자 기기 고유 식별자를 입력해주세요")
+            String deviceId
     ) {
         public Info toInfo() {
-            return new Info(null, null, password, phone, code, null);
+            return new Info(null, null, password, phone, code, deviceId);
         }
     }
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
@@ -120,7 +120,7 @@ public class JwtAuthHelper {
         }
 
         try {
-            refreshTokenService.delete(refreshTokenUserId, refreshTokenDeviceId);
+            refreshTokenService.deleteAll(refreshTokenUserId);
         } catch (IllegalArgumentException e) {
             log.warn("refresh token not found. id : {}", userId);
         }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelper.java
@@ -104,22 +104,23 @@ public class JwtAuthHelper {
         }
 
         if (jwtClaims != null) {
-            deleteRefreshToken(userId, jwtClaims, refreshToken);
+            deleteRefreshToken(userId, jwtClaims);
         }
 
         deleteAccessToken(userId, accessToken);
     }
 
-    private void deleteRefreshToken(Long userId, JwtClaims jwtClaims, String refreshToken) {
-        Long refreshTokenUserId = Long.parseLong((String) jwtClaims.getClaims().get(RefreshTokenClaimKeys.USER_ID.getValue()));
-        log.info("로그아웃 요청 refresh token id : {}", refreshTokenUserId);
+    private void deleteRefreshToken(Long userId, JwtClaims jwtClaims) {
+        Long refreshTokenUserId = JwtClaimsParserUtil.getClaimsValue(jwtClaims, RefreshTokenClaimKeys.USER_ID.getValue(), Long::parseLong);
+        String refreshTokenDeviceId = JwtClaimsParserUtil.getClaimsValue(jwtClaims, RefreshTokenClaimKeys.DEVICE_ID.getValue(), String.class);
+        log.info("로그아웃 요청 refresh token userId : {}, deviceId : {}", refreshTokenUserId, refreshTokenDeviceId);
 
         if (!userId.equals(refreshTokenUserId)) {
             throw new JwtErrorException(JwtErrorCode.WITHOUT_OWNERSHIP_REFRESH_TOKEN);
         }
 
         try {
-            refreshTokenService.delete(refreshTokenUserId, refreshToken);
+            refreshTokenService.delete(refreshTokenUserId, refreshTokenDeviceId);
         } catch (IllegalArgumentException e) {
             log.warn("refresh token not found. id : {}", userId);
         }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/AuthUseCase.java
@@ -46,14 +46,14 @@ public class AuthUseCase {
         UserSyncDto userSync = checkOauthUserNotGeneralSignUp(request.phone());
         User user = userGeneralSignService.saveUserWithEncryptedPassword(request, userSync);
 
-        return Pair.of(user.getId(), jwtAuthHelper.createToken(user));
+        return Pair.of(user.getId(), jwtAuthHelper.createToken(user, request.deviceId()));
     }
 
     @Transactional(readOnly = true)
     public Pair<Long, Jwts> signIn(SignInReq.General request) {
         User user = userGeneralSignService.readUserIfValid(request.username(), request.password());
 
-        return Pair.of(user.getId(), jwtAuthHelper.createToken(user));
+        return Pair.of(user.getId(), jwtAuthHelper.createToken(user, request.deviceId()));
     }
 
     public Pair<Long, Jwts> refresh(String refreshToken) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/auth/usecase/OauthUseCase.java
@@ -39,7 +39,7 @@ public class OauthUseCase {
 
         User user = userOauthSignService.readUser(request.oauthId(), provider);
 
-        return (user != null) ? Pair.of(user.getId(), jwtAuthHelper.createToken(user)) : Pair.of(-1L, null);
+        return (user != null) ? Pair.of(user.getId(), jwtAuthHelper.createToken(user, request.deviceId())) : Pair.of(-1L, null);
     }
 
     @Transactional(readOnly = true)
@@ -67,7 +67,7 @@ public class OauthUseCase {
         OidcDecodePayload payload = oauthOidcHelper.getPayload(provider, request.oauthId(), request.idToken(), request.nonce());
         User user = userOauthSignService.saveUser(request, userSync, provider, payload.sub());
 
-        return Pair.of(user.getId(), jwtAuthHelper.createToken(user));
+        return Pair.of(user.getId(), jwtAuthHelper.createToken(user, request.deviceId()));
     }
 
     /**

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/refresh/RefreshTokenClaim.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/refresh/RefreshTokenClaim.java
@@ -6,16 +6,16 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.Map;
 
-import static kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaimKeys.ROLE;
-import static kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaimKeys.USER_ID;
+import static kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaimKeys.*;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class RefreshTokenClaim implements JwtClaims {
     private final Map<String, ?> claims;
 
-    public static RefreshTokenClaim of(Long userId, String role) {
+    public static RefreshTokenClaim of(Long userId, String deviceToken, String role) {
         Map<String, Object> claims = Map.of(
                 USER_ID.getValue(), userId.toString(),
+                DEVICE_ID.getValue(), deviceToken,
                 ROLE.getValue(), role
         );
         return new RefreshTokenClaim(claims);

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/refresh/RefreshTokenClaimKeys.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/refresh/RefreshTokenClaimKeys.java
@@ -2,7 +2,8 @@ package kr.co.pennyway.api.common.security.jwt.refresh;
 
 public enum RefreshTokenClaimKeys {
     USER_ID("id"),
-    ROLE("role");
+    ROLE("role"),
+    DEVICE_ID("deviceId");
 
     private final String value;
 

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/refresh/RefreshTokenProvider.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/jwt/refresh/RefreshTokenProvider.java
@@ -22,8 +22,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 
-import static kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaimKeys.ROLE;
-import static kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaimKeys.USER_ID;
+import static kr.co.pennyway.api.common.security.jwt.refresh.RefreshTokenClaimKeys.*;
 
 @Slf4j
 @Component
@@ -56,7 +55,11 @@ public class RefreshTokenProvider implements JwtProvider {
     @Override
     public JwtClaims getJwtClaimsFromToken(String token) {
         Claims claims = getClaimsFromToken(token);
-        return RefreshTokenClaim.of(Long.parseLong(claims.get(USER_ID.getValue(), String.class)), claims.get(ROLE.getValue(), String.class));
+        return RefreshTokenClaim.of(
+                Long.parseLong(claims.get(USER_ID.getValue(), String.class)),
+                claims.get(DEVICE_ID.getValue(), String.class),
+                claims.get(ROLE.getValue(), String.class)
+        );
     }
 
     @Override

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthControllerValidationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/controller/AuthControllerValidationTest.java
@@ -52,11 +52,11 @@ public class AuthControllerValidationTest {
                 .build();
     }
 
-    @DisplayName("[1] 아이디, 이름, 비밀번호, 전화번호, 인증번호 필수 입력")
+    @DisplayName("[1] 아이디, 이름, 비밀번호, 전화번호, 인증번호, 디바이스 아이디 필수 입력")
     @Test
     void requiredInputError() throws Exception {
         // given
-        SignUpReq.General request = new SignUpReq.General("", "", "", "", "");
+        SignUpReq.General request = new SignUpReq.General("", "", "", "", "", "");
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -73,6 +73,7 @@ public class AuthControllerValidationTest {
                 .andExpect(jsonPath("$.fieldErrors.password").exists())
                 .andExpect(jsonPath("$.fieldErrors.phone").exists())
                 .andExpect(jsonPath("$.fieldErrors.code").exists())
+                .andExpect(jsonPath("$.fieldErrors.deviceId").exists())
                 .andDo(print());
     }
 
@@ -81,7 +82,7 @@ public class AuthControllerValidationTest {
     void idValidError() throws Exception {
         // given
         SignUpReq.General request = new SignUpReq.General("#pennyway", "페니웨이", "pennyway1234",
-                "010-1234-5678", "123456");
+                "010-1234-5678", "123456", "AA-BBB-CCC");
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -102,7 +103,7 @@ public class AuthControllerValidationTest {
     void nameValidError() throws Exception {
         // given
         SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이12345", "pennyway1234",
-                "010-1234-5678", "123456");
+                "010-1234-5678", "123456", "AA-BBB-CCC");
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -123,7 +124,7 @@ public class AuthControllerValidationTest {
     void passwordValidError() throws Exception {
         // given
         SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이", "pennyway",
-                "010-1234-5678", "123456");
+                "010-1234-5678", "123456", "AA-BBB-CCC");
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -145,7 +146,7 @@ public class AuthControllerValidationTest {
     void phoneValidError() throws Exception {
         // given
         SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이", "pennyway1234",
-                "01012345673", "123456");
+                "01012345673", "123456", "AA-BBB-CCC");
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -166,7 +167,7 @@ public class AuthControllerValidationTest {
     void codeValidError() throws Exception {
         // given
         SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이", "pennyway1234",
-                "010-1234-5678", "12345");
+                "010-1234-5678", "12345", "AA-BBB-CCC");
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -187,7 +188,7 @@ public class AuthControllerValidationTest {
     void someFieldMissingError() throws Exception {
         // given
         SignUpReq.General request = new SignUpReq.General("pennyway", "페니웨이", "pennyway1234",
-                "010-1234-5678", "123456");
+                "010-1234-5678", "123456", "AA-BBB-CCC");
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -210,7 +211,7 @@ public class AuthControllerValidationTest {
     void signUp() throws Exception {
         // given
         SignUpReq.General request = new SignUpReq.General("pennyway123", "페니웨이", "pennyway1234",
-                "010-1234-5678", "123456");
+                "010-1234-5678", "123456", "AA-BBB-CCC");
         ResponseCookie expectedCookie = ResponseCookie.from("refreshToken", "refreshToken")
                 .maxAge(Duration.ofDays(7).toSeconds()).httpOnly(true).path("/").build();
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelperTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/helper/JwtAuthHelperTest.java
@@ -61,11 +61,12 @@ public class JwtAuthHelperTest extends ExternalApiDBTestConfig {
         // given
         RefreshToken refreshToken = RefreshToken.builder()
                 .userId(1L)
+                .deviceId("AA-BBB-CC-DDD")
                 .token("refreshToken")
                 .ttl(1000L)
                 .build();
         refreshTokenRepository.save(refreshToken);
-        given(refreshTokenProvider.getJwtClaimsFromToken(refreshToken.getToken())).willReturn(RefreshTokenClaim.of(refreshToken.getUserId(), Role.USER.getType()));
+        given(refreshTokenProvider.getJwtClaimsFromToken(refreshToken.getToken())).willReturn(RefreshTokenClaim.of(refreshToken.getUserId(), refreshToken.getDeviceId(), Role.USER.getType()));
         given(accessTokenProvider.generateToken(any())).willReturn("newAccessToken");
         given(refreshTokenProvider.generateToken(any())).willReturn("newRefreshToken");
 
@@ -76,7 +77,7 @@ public class JwtAuthHelperTest extends ExternalApiDBTestConfig {
         assertEquals("사용자 아이디가 일치하지 않습니다.", refreshToken.getUserId(), jwts.getLeft());
         assertEquals("갱신된 액세스 토큰이 일치하지 않습니다.", "newAccessToken", jwts.getRight().accessToken());
         assertEquals("리프레시 토큰이 갱신되지 않았습니다.", "newRefreshToken", jwts.getRight().refreshToken());
-        log.info("갱신된 리프레시 토큰 정보 : {}", refreshTokenRepository.findById(refreshToken.getUserId()).orElse(null));
+        log.info("갱신된 리프레시 토큰 정보 : {}", refreshTokenRepository.findById(refreshToken.getId()).orElse(null));
     }
 
     @Test
@@ -85,12 +86,13 @@ public class JwtAuthHelperTest extends ExternalApiDBTestConfig {
         // given
         RefreshToken refreshToken = RefreshToken.builder()
                 .userId(1L)
+                .deviceId("AA-BBB-CC-DDD")
                 .token("refreshToken")
                 .ttl(1000L)
                 .build();
         refreshTokenRepository.save(refreshToken);
 
-        given(refreshTokenProvider.getJwtClaimsFromToken("anotherRefreshToken")).willReturn(RefreshTokenClaim.of(refreshToken.getUserId(), Role.USER.toString()));
+        given(refreshTokenProvider.getJwtClaimsFromToken("anotherRefreshToken")).willReturn(RefreshTokenClaim.of(refreshToken.getUserId(), refreshToken.getDeviceId(), Role.USER.toString()));
         given(refreshTokenProvider.generateToken(any())).willReturn("newRefreshToken");
 
         // when
@@ -98,6 +100,6 @@ public class JwtAuthHelperTest extends ExternalApiDBTestConfig {
 
         // then
         assertEquals("탈취 시나리오 예외가 발생하지 않았습니다.", JwtErrorCode.TAKEN_AWAY_TOKEN, jwtErrorException.getErrorCode());
-        assertFalse("리프레시 토큰이 삭제되지 않았습니다.", refreshTokenRepository.existsById(refreshToken.getUserId()));
+        assertFalse("리프레시 토큰이 삭제되지 않았습니다.", refreshTokenRepository.existsById(refreshToken.getId()));
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/AuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/AuthControllerIntegrationTest.java
@@ -43,6 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class AuthControllerIntegrationTest extends ExternalApiDBTestConfig {
     private final String expectedPhone = "010-1234-5678";
     private final String expectedCode = "123456";
+    private final String expectedDeviceId = "AA-BB-CC-DD";
 
     @Autowired
     private MockMvc mockMvc;
@@ -224,7 +225,7 @@ public class AuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         private ResultActions performGeneralSignUpRequest(String code) throws Exception {
-            SignUpReq.General request = new SignUpReq.General(UserFixture.GENERAL_USER.getUsername(), "pennyway", "dkssudgktpdy1", expectedPhone, code);
+            SignUpReq.General request = new SignUpReq.General(UserFixture.GENERAL_USER.getUsername(), "pennyway", "dkssudgktpdy1", expectedPhone, code, expectedDeviceId);
             return mockMvc.perform(
                     post("/v1/auth/sign-up")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -286,7 +287,7 @@ public class AuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         private ResultActions performSyncWithOauthSignUpRequest(String expectedPhone, String code) throws Exception {
-            SignUpReq.SyncWithOauth request = new SignUpReq.SyncWithOauth("dkssudgktpdy1", expectedPhone, code);
+            SignUpReq.SyncWithOauth request = new SignUpReq.SyncWithOauth("dkssudgktpdy1", expectedPhone, code, expectedDeviceId);
             return mockMvc.perform(
                     post("/v1/auth/link-oauth")
                             .contentType(MediaType.APPLICATION_JSON)

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/OAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/OAuthControllerIntegrationTest.java
@@ -64,6 +64,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
     private final String expectedNonce = "testNonce";
     private final String expectedPhone = "010-1234-5678";
     private final String expectedCode = "123456";
+    private final String expectedDeviceId = "testDeviceId";
     @Autowired
     private MockMvc mockMvc;
     @Autowired
@@ -226,7 +227,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         private ResultActions performOauthSignIn(Provider provider, String oauthId, String idToken, String nonce) throws Exception {
-            SignInReq.Oauth request = new SignInReq.Oauth(oauthId, idToken, expectedNonce);
+            SignInReq.Oauth request = new SignInReq.Oauth(oauthId, idToken, expectedNonce, expectedDeviceId);
 
             return mockMvc.perform(post("/v1/auth/oauth/sign-in")
                     .param("provider", provider.name())
@@ -557,7 +558,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         private ResultActions performOauthSignUpAccountLinking(Provider provider, String code, String oauthId) throws Exception {
-            SignUpReq.SyncWithAuth request = new SignUpReq.SyncWithAuth(oauthId, expectedIdToken, expectedNonce, expectedPhone, code);
+            SignUpReq.SyncWithAuth request = new SignUpReq.SyncWithAuth(oauthId, expectedIdToken, expectedNonce, expectedPhone, code, expectedDeviceId);
             return mockMvc.perform(post("/v1/auth/oauth/link-auth")
                     .param("provider", provider.name())
                     .contentType("application/json")
@@ -645,7 +646,7 @@ public class OAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
         }
 
         private ResultActions performOauthSignUp(Provider provider, String code) throws Exception {
-            SignUpReq.Oauth request = new SignUpReq.Oauth(expectedOauthId, expectedIdToken, expectedNonce, "jayang", expectedUsername, expectedPhone, code);
+            SignUpReq.Oauth request = new SignUpReq.Oauth(expectedOauthId, expectedIdToken, expectedNonce, "jayang", expectedUsername, expectedPhone, code, expectedDeviceId);
             return mockMvc.perform(post("/v1/auth/oauth/sign-up")
                     .param("provider", provider.name())
                     .contentType("application/json")

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
@@ -110,7 +110,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             // then
             result.andExpect(status().isOk()).andDo(print());
             assertTrue(forbiddenTokenService.isForbidden(expectedAccessToken));
-            assertThrows(IllegalArgumentException.class, () -> refreshTokenService.delete(userId, expectedRefreshToken));
+            assertThrows(IllegalArgumentException.class, () -> refreshTokenService.deleteAll(userId, expectedRefreshToken));
         }
 
         @Test
@@ -143,8 +143,8 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(jsonPath("$.code").value(JwtErrorCode.WITHOUT_OWNERSHIP_REFRESH_TOKEN.causedBy().getCode()))
                     .andExpect(jsonPath("$.message").value(JwtErrorCode.WITHOUT_OWNERSHIP_REFRESH_TOKEN.getExplainError()))
                     .andDo(print());
-            assertDoesNotThrow(() -> refreshTokenService.delete(userId, expectedDeviceId));
-            assertDoesNotThrow(() -> refreshTokenService.delete(1000L, otherDeviceId));
+            assertDoesNotThrow(() -> refreshTokenService.deleteAll(userId, expectedDeviceId));
+            assertDoesNotThrow(() -> refreshTokenService.deleteAll(1000L, otherDeviceId));
             assertFalse(forbiddenTokenService.isForbidden(expectedAccessToken));
         }
 
@@ -166,7 +166,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(jsonPath("$.code").value(JwtErrorCode.MALFORMED_TOKEN.causedBy().getCode()))
                     .andExpect(jsonPath("$.message").value(JwtErrorCode.MALFORMED_TOKEN.getExplainError()))
                     .andDo(print());
-            assertDoesNotThrow(() -> refreshTokenService.delete(userId, expectedDeviceId));
+            assertDoesNotThrow(() -> refreshTokenService.deleteAll(userId, expectedDeviceId));
             assertFalse(forbiddenTokenService.isForbidden(expectedAccessToken));
         }
 
@@ -187,8 +187,8 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(status().isOk())
                     .andExpect(header().exists(HttpHeaders.SET_COOKIE))
                     .andDo(print());
-            assertThrows(IllegalArgumentException.class, () -> refreshTokenService.delete(userId, oldRefreshToken));
-            assertThrows(IllegalArgumentException.class, () -> refreshTokenService.delete(userId, expectedRefreshToken));
+            assertThrows(IllegalArgumentException.class, () -> refreshTokenService.deleteAll(userId, oldRefreshToken));
+            assertThrows(IllegalArgumentException.class, () -> refreshTokenService.deleteAll(userId, expectedRefreshToken));
             assertTrue(forbiddenTokenService.isForbidden(expectedAccessToken));
         }
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/auth/integration/UserAuthControllerIntegrationTest.java
@@ -110,7 +110,7 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
             // then
             result.andExpect(status().isOk()).andDo(print());
             assertTrue(forbiddenTokenService.isForbidden(expectedAccessToken));
-            assertThrows(IllegalArgumentException.class, () -> refreshTokenService.deleteAll(userId, expectedRefreshToken));
+            refreshTokenService.deleteAll(userId);
         }
 
         @Test
@@ -143,9 +143,10 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(jsonPath("$.code").value(JwtErrorCode.WITHOUT_OWNERSHIP_REFRESH_TOKEN.causedBy().getCode()))
                     .andExpect(jsonPath("$.message").value(JwtErrorCode.WITHOUT_OWNERSHIP_REFRESH_TOKEN.getExplainError()))
                     .andDo(print());
-            assertDoesNotThrow(() -> refreshTokenService.deleteAll(userId, expectedDeviceId));
-            assertDoesNotThrow(() -> refreshTokenService.deleteAll(1000L, otherDeviceId));
             assertFalse(forbiddenTokenService.isForbidden(expectedAccessToken));
+
+            refreshTokenService.deleteAll(userId);
+            refreshTokenService.deleteAll(1000L);
         }
 
         @Test
@@ -166,8 +167,9 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(jsonPath("$.code").value(JwtErrorCode.MALFORMED_TOKEN.causedBy().getCode()))
                     .andExpect(jsonPath("$.message").value(JwtErrorCode.MALFORMED_TOKEN.getExplainError()))
                     .andDo(print());
-            assertDoesNotThrow(() -> refreshTokenService.deleteAll(userId, expectedDeviceId));
             assertFalse(forbiddenTokenService.isForbidden(expectedAccessToken));
+
+            refreshTokenService.deleteAll(userId);
         }
 
         @Test
@@ -187,9 +189,9 @@ public class UserAuthControllerIntegrationTest extends ExternalApiDBTestConfig {
                     .andExpect(status().isOk())
                     .andExpect(header().exists(HttpHeaders.SET_COOKIE))
                     .andDo(print());
-            assertThrows(IllegalArgumentException.class, () -> refreshTokenService.deleteAll(userId, oldRefreshToken));
-            assertThrows(IllegalArgumentException.class, () -> refreshTokenService.deleteAll(userId, expectedRefreshToken));
             assertTrue(forbiddenTokenService.isForbidden(expectedAccessToken));
+
+            refreshTokenService.deleteAll(userId);
         }
 
         @Test

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
@@ -13,23 +13,32 @@ import org.springframework.data.redis.core.RedisHash;
 @EqualsAndHashCode(of = {"userId", "token"})
 public class RefreshToken {
     @Id
+    private final String id;
     private final Long userId;
+    private final String deviceId;
     private final long ttl;
     private String token;
 
     @Builder
-    private RefreshToken(String token, Long userId, long ttl) {
-        this.token = token;
+    private RefreshToken(Long userId, String deviceId, String token, long ttl) {
+        this.id = createId(userId, deviceId);
         this.userId = userId;
+        this.deviceId = deviceId;
+        this.token = token;
         this.ttl = ttl;
     }
 
-    public static RefreshToken of(Long userId, String token, long ttl) {
+    public static RefreshToken of(Long userId, String deviceId, String token, long ttl) {
         return RefreshToken.builder()
                 .userId(userId)
+                .deviceId(deviceId)
                 .token(token)
                 .ttl(ttl)
                 .build();
+    }
+
+    public static String createId(Long userId, String deviceId) {
+        return userId + ":" + deviceId;
     }
 
     protected void rotation(String token) {

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshToken.java
@@ -1,9 +1,6 @@
 package kr.co.pennyway.domain.common.redis.refresh;
 
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
@@ -11,12 +8,13 @@ import org.springframework.data.redis.core.RedisHash;
 @Getter
 @ToString(of = {"userId", "token", "ttl"})
 @EqualsAndHashCode(of = {"userId", "token"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
     @Id
-    private final String id;
-    private final Long userId;
-    private final String deviceId;
-    private final long ttl;
+    private String id;
+    private Long userId;
+    private String deviceId;
+    private long ttl;
     private String token;
 
     @Builder

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenCustomRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenCustomRepository.java
@@ -1,0 +1,5 @@
+package kr.co.pennyway.domain.common.redis.refresh;
+
+public interface RefreshTokenCustomRepository {
+    void deleteAllByUserId(Long userId);
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenCustomRepositoryImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenCustomRepositoryImpl.java
@@ -1,0 +1,23 @@
+package kr.co.pennyway.domain.common.redis.refresh;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenCustomRepositoryImpl implements RefreshTokenCustomRepository {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        String pattern = "refreshToken:" + userId + ":*";
+        Set<String> keys = redisTemplate.keys(pattern);
+
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+}

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenRepository.java
@@ -2,5 +2,5 @@ package kr.co.pennyway.domain.common.redis.refresh;
 
 import org.springframework.data.repository.CrudRepository;
 
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenRepository.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenRepository.java
@@ -2,5 +2,5 @@ package kr.co.pennyway.domain.common.redis.refresh;
 
 import org.springframework.data.repository.CrudRepository;
 
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String>, RefreshTokenCustomRepository {
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenService.java
@@ -12,20 +12,21 @@ public interface RefreshTokenService {
      * 사용자가 보낸 refresh token으로 기존 refresh token과 비교 검증 후, 새로운 refresh token으로 저장한다.
      *
      * @param userId          : 토큰 주인 pk
+     * @param deviceId        : 토큰 발급한 디바이스
      * @param oldRefreshToken : 사용자가 보낸 refresh token
      * @param newRefreshToken : 교체할 refresh token
      * @return {@link RefreshToken}
      * @throws IllegalArgumentException : userId에 해당하는 refresh token이 없을 경우
      * @throws IllegalStateException    : 요청한 토큰과 저장된 토큰이 다르다면 토큰이 탈취되었다고 판단하여 값 삭제
      */
-    RefreshToken refresh(Long userId, String oldRefreshToken, String newRefreshToken) throws IllegalArgumentException, IllegalStateException;
+    RefreshToken refresh(Long userId, String deviceId, String oldRefreshToken, String newRefreshToken) throws IllegalArgumentException, IllegalStateException;
 
     /**
-     * access token 으로 refresh token을 찾아서 제거 (로그아웃)
+     * 사용자의 device에 해당하는 refresh token을 삭제한다.
      *
-     * @param userId       : 토큰 주인 pk
-     * @param refreshToken : 검증용 refresh token
+     * @param userId   : 토큰 주인 pk
+     * @param deviceId : 토큰 발급한 디바이스
      * @throws IllegalArgumentException : userId에 해당하는 refresh token이 없을 경우
      */
-    void delete(Long userId, String refreshToken) throws IllegalArgumentException;
+    void delete(Long userId, String deviceId) throws IllegalArgumentException;
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenService.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenService.java
@@ -22,11 +22,9 @@ public interface RefreshTokenService {
     RefreshToken refresh(Long userId, String deviceId, String oldRefreshToken, String newRefreshToken) throws IllegalArgumentException, IllegalStateException;
 
     /**
-     * 사용자의 device에 해당하는 refresh token을 삭제한다.
+     * 사용자에게 할당된 모든 Device의 refresh token을 삭제한다.
      *
-     * @param userId   : 토큰 주인 pk
-     * @param deviceId : 토큰 발급한 디바이스
-     * @throws IllegalArgumentException : userId에 해당하는 refresh token이 없을 경우
+     * @param userId : 토큰 주인 pk
      */
-    void delete(Long userId, String deviceId) throws IllegalArgumentException;
+    void deleteAll(Long userId);
 }

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceImpl.java
@@ -30,9 +30,8 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     }
 
     @Override
-    public void delete(Long userId, String deviceId) throws IllegalArgumentException {
-        RefreshToken token = findOrElseThrow(userId, deviceId);
-        refreshTokenRepository.delete(token);
+    public void deleteAll(Long userId) {
+        refreshTokenRepository.deleteAllByUserId(userId);
         log.info("사용자 {}의 리프레시 토큰 삭제", userId);
     }
 
@@ -49,7 +48,7 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     private void validateToken(String requestRefreshToken, RefreshToken expectedRefreshToken) throws IllegalStateException {
         if (isTakenAway(requestRefreshToken, expectedRefreshToken.getToken())) {
             log.warn("리프레시 토큰 불일치(탈취). expected : {}, actual : {}", requestRefreshToken, expectedRefreshToken.getToken());
-            refreshTokenRepository.delete(expectedRefreshToken);
+            refreshTokenRepository.deleteAllByUserId(expectedRefreshToken.getUserId());
             log.info("사용자 {}의 리프레시 토큰 삭제", expectedRefreshToken.getUserId());
 
             throw new IllegalStateException("refresh token mismatched");

--- a/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceImpl.java
+++ b/pennyway-domain/src/main/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceImpl.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RefreshTokenServiceImpl implements RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
-    
+
     @Override
     public void save(RefreshToken refreshToken) {
         refreshTokenRepository.save(refreshToken);
@@ -17,8 +17,8 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     }
 
     @Override
-    public RefreshToken refresh(Long userId, String oldRefreshToken, String newRefreshToken) throws IllegalArgumentException, IllegalStateException {
-        RefreshToken refreshToken = findOrElseThrow(userId);
+    public RefreshToken refresh(Long userId, String deviceId, String oldRefreshToken, String newRefreshToken) throws IllegalArgumentException, IllegalStateException {
+        RefreshToken refreshToken = findOrElseThrow(userId, deviceId);
 
         validateToken(oldRefreshToken, refreshToken);
 
@@ -30,14 +30,14 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     }
 
     @Override
-    public void delete(Long userId, String refreshToken) throws IllegalArgumentException {
-        RefreshToken token = findOrElseThrow(userId);
+    public void delete(Long userId, String deviceId) throws IllegalArgumentException {
+        RefreshToken token = findOrElseThrow(userId, deviceId);
         refreshTokenRepository.delete(token);
         log.info("사용자 {}의 리프레시 토큰 삭제", userId);
     }
 
-    private RefreshToken findOrElseThrow(Long userId) {
-        return refreshTokenRepository.findById(userId)
+    private RefreshToken findOrElseThrow(Long userId, String deviceId) {
+        return refreshTokenRepository.findById(RefreshToken.createId(userId, deviceId))
                 .orElseThrow(() -> new IllegalArgumentException("refresh token not found"));
     }
 

--- a/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceIntegrationTest.java
+++ b/pennyway-domain/src/test/java/kr/co/pennyway/domain/common/redis/refresh/RefreshTokenServiceIntegrationTest.java
@@ -35,6 +35,7 @@ public class RefreshTokenServiceIntegrationTest extends ContainerRedisTestConfig
         // given
         RefreshToken refreshToken = RefreshToken.builder()
                 .userId(1L)
+                .deviceId("AA-BBB-CC-DDD")
                 .token("refreshToken")
                 .ttl(1000L)
                 .build();
@@ -43,7 +44,7 @@ public class RefreshTokenServiceIntegrationTest extends ContainerRedisTestConfig
         refreshTokenService.save(refreshToken);
 
         // then
-        RefreshToken savedRefreshToken = refreshTokenRepository.findById(1L).orElse(null);
+        RefreshToken savedRefreshToken = refreshTokenRepository.findById(refreshToken.getId()).orElse(null);
         assertEquals("저장된 리프레시 토큰이 일치하지 않습니다.", refreshToken, savedRefreshToken);
         log.info("저장된 리프레시 토큰 정보 : {}", savedRefreshToken);
     }
@@ -54,16 +55,17 @@ public class RefreshTokenServiceIntegrationTest extends ContainerRedisTestConfig
         // given
         RefreshToken refreshToken = RefreshToken.builder()
                 .userId(1L)
+                .deviceId("AA-BBB-CC-DDD")
                 .token("refreshToken")
                 .ttl(1000L)
                 .build();
         refreshTokenService.save(refreshToken);
 
         // when
-        refreshTokenService.refresh(1L, "refreshToken", "newRefreshToken");
+        refreshTokenService.refresh(refreshToken.getUserId(), refreshToken.getDeviceId(), refreshToken.getToken(), "newRefreshToken");
 
         // then
-        RefreshToken savedRefreshToken = refreshTokenRepository.findById(1L).orElse(null);
+        RefreshToken savedRefreshToken = refreshTokenRepository.findById(refreshToken.getId()).orElse(null);
         assertEquals("갱신된 리프레시 토큰이 일치하지 않습니다.", "newRefreshToken", savedRefreshToken.getToken());
         log.info("갱신된 리프레시 토큰 정보 : {}", savedRefreshToken);
     }
@@ -74,16 +76,17 @@ public class RefreshTokenServiceIntegrationTest extends ContainerRedisTestConfig
         // given
         RefreshToken refreshToken = RefreshToken.builder()
                 .userId(1L)
+                .deviceId("AA-BBB-CC-DDD")
                 .token("refreshToken")
                 .ttl(1000L)
                 .build();
         refreshTokenService.save(refreshToken);
 
         // when
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> refreshTokenService.refresh(1L, "anotherRefreshToken", "newRefreshToken"));
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> refreshTokenService.refresh(refreshToken.getUserId(), refreshToken.getDeviceId(), "anotherRefreshToken", "newRefreshToken"));
 
         // then
         assertEquals("리프레시 토큰이 탈취되었을 때 예외가 발생해야 합니다.", "refresh token mismatched", exception.getMessage());
-        assertFalse("리프레시 토큰이 탈취되었을 때 저장된 리프레시 토큰이 삭제되어야 합니다.", refreshTokenRepository.existsById(1L));
+        assertFalse("리프레시 토큰이 탈취되었을 때 저장된 리프레시 토큰이 삭제되어야 합니다.", refreshTokenRepository.existsById(refreshToken.getId()));
     }
 }


### PR DESCRIPTION
## 작업 이유
- We had a problem:
   - To handle the stolen refresh token scenario, we apply the `RTR` technique (saving the user's `valid refresh token` in Redis).
   - However, if a client accesses the application from multiple devices, the server mistakenly considers the token stolen because the user's valid refresh token in Redis gets overwritten.
- Therefore, we need to include `device_id` when creating a refresh token and save it in Redis.

<br/>

## 작업 사항
### 1️⃣  API Specification
- The client must send device_id in the following scenarios:
   - general & oauth signup
   - general & oauth signin
   - synchronize general with oauth (2 cases)
- These APIs will now accept additional data.

<br/>

### 2️⃣ Append `Device Id` Field to Refresh Token Entity
```java
@RedisHash("refreshToken")
@Getter
public class RefreshToken {
    @Id
    private String id;
    private Long userId;
    private String deviceId;
    ...
}
```
- The `RefreshToken` entity now includes a `deviceId` field.
- To uniquely identify a refresh token, the `id` is combination of `userId` and `deviceId`.

<br/>

### 3️⃣ Modify Delete Method in `RefreshTokenService`
```java
@Repository
@RequiredArgsConstructor
public class RefreshTokenCustomRepositoryImpl implements RefreshTokenCustomRepository {
    private final RedisTemplate<String, String> redisTemplate;

    @Override
    public void deleteAllByUserId(Long userId) {
        String pattern = "refreshToken:" + userId + ":*";
        Set<String> keys = redisTemplate.keys(pattern);

        if (keys != null && !keys.isEmpty()) {
            redisTemplate.delete(keys);
        }
    }
}
```
- Previously, we assumed a single refresh token per user.
- Now, since users can have multiple refresh tokens, all tokens are deleted from Redis when the server detects a stolen token.
- Although Redis recommends using `SCAN` for reading multiple values, the number of `deviceId` matches for a given `userId` is typically one or two at most.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- none

