### PR TITLE
Ignore: 🐛 Issue with Detecting Push Notification Events

### DIFF
--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/FcmNotificationEventHandler.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/event/FcmNotificationEventHandler.java
@@ -21,7 +21,7 @@ public class FcmNotificationEventHandler implements NotificationEventHandler {
     @Override
     @TransactionalEventListener
     public void handleEvent(NotificationEvent event) {
-        log.debug("handleEvent: {}", event);
+        log.info("handleEvent: {}", event);
         ApiFuture<?> response = fcmManager.sendMessage(event);
 
         if (response == null) {

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/InfraConfig.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/InfraConfig.java
@@ -7,7 +7,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnablePennywayInfraConfig({
         PennywayInfraConfigGroup.MESSAGE_BROKER_CONFIG,
-        PennywayInfraConfigGroup.GUID_GENERATOR_CONFIG
+        PennywayInfraConfigGroup.GUID_GENERATOR_CONFIG,
+        PennywayInfraConfigGroup.FCM
 })
 public class InfraConfig {
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/relay/ChatMessageRelayEventListener.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/relay/ChatMessageRelayEventListener.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.socket.relay;
 
+import kr.co.pennyway.domain.common.redis.message.type.MessageCategoryType;
 import kr.co.pennyway.socket.dto.ChatMessageDto;
 import kr.co.pennyway.socket.service.ChatMessageRelayService;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,10 @@ public class ChatMessageRelayEventListener {
     )
     public void handleSendEvent(ChatMessageDto.Response event) {
         log.info("ChatMessageSendEventListener.handleSendEvent: {}", event);
+
+        if (MessageCategoryType.SYSTEM.equals(event.categoryType())) {
+            return;
+        }
 
         chatMessageRelayService.execute(event.senderId(), event.chatRoomId(), event.content());
     }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/relay/ChatMessageRelayEventListener.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/relay/ChatMessageRelayEventListener.java
@@ -23,7 +23,6 @@ public class ChatMessageRelayEventListener {
                     exchange = @Exchange(value = "${pennyway.rabbitmq.chat.exchange}", type = "topic"),
                     key = "${pennyway.rabbitmq.chat.routing-key}"
             ),
-            exclusive = true,
             concurrency = "1"
     )
     public void handleSendEvent(ChatMessageDto.Response event) {

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageRelayService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageRelayService.java
@@ -30,6 +30,7 @@ public class ChatMessageRelayService {
      */
     public void execute(Long senderId, Long chatRoomId, String content) {
         ChatPushNotificationContext context = executeInTransaction(() -> chatNotificationCoordinatorService.determineRecipients(senderId, chatRoomId));
+        log.info("채팅 메시지 알림 전송 컨텍스트: {}", context);
 
         NotificationEvent notificationEvent = NotificationEvent.of(
                 context.senderName(),

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageRelayService.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageRelayService.java
@@ -28,6 +28,7 @@ public class ChatMessageRelayService {
      * @param content    String 채팅 내용
      * @apiNote push notification 전송 실패에 대한 재시도를 수행하고 있지 않습니다.
      */
+    @Transactional(readOnly = true)
     public void execute(Long senderId, Long chatRoomId, String content) {
         ChatPushNotificationContext context = executeInTransaction(() -> chatNotificationCoordinatorService.determineRecipients(senderId, chatRoomId));
         log.info("채팅 메시지 알림 전송 컨텍스트: {}", context);


### PR DESCRIPTION
## 작업 이유
- Push notifications are not being sent after chat messages are delivered.
- RabbitMQ connection configuration issues identified.

<br/>

## 작업 사항
- The Tx event handler setting caused events to not trigger after the bounded context ended.
   - Instead of modifying the event listener annotation (which could cause other issues), declarative Tx logic was temporarily added to the service layer.
- Removed exclusive configuration in RabbitMQ as it was causing errors.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- It seems setting Push Notifications as a Tx event listener was a mistake. Do you agree that a revision is needed?

<br/>

## 발견한 이슈
- 없음

