### PR TITLE
Ignore: ✏️ Fix Entity By ChatMember's Name Domain Rule 

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatMemberJoinService.java
@@ -62,7 +62,7 @@ public class ChatMemberJoinService {
         ChatMember member = chatMemberService.createMember(user, chatRoom);
         Long unreadMessageCount = chatMessageService.countUnreadMessages(chatRoomId, 0L);
 
-        eventPublisher.publishEvent(ChatRoomJoinEvent.of(chatRoomId, member.getName()));
+        eventPublisher.publishEvent(ChatRoomJoinEvent.of(chatRoomId, user.getName()));
 
         return ImmutableTriple.of(chatRoom, currentMemberCount.intValue() + 1, unreadMessageCount);
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchServiceTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomWithParticipantsSearchServiceTest.java
@@ -4,6 +4,7 @@ import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
 import kr.co.pennyway.api.config.fixture.ChatMemberFixture;
 import kr.co.pennyway.api.config.fixture.ChatRoomFixture;
 import kr.co.pennyway.api.config.fixture.UserFixture;
+import kr.co.pennyway.domain.context.account.service.UserService;
 import kr.co.pennyway.domain.context.chat.service.ChatMemberService;
 import kr.co.pennyway.domain.context.chat.service.ChatMessageService;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
@@ -45,6 +46,8 @@ public class ChatRoomWithParticipantsSearchServiceTest {
     @InjectMocks
     private ChatRoomWithParticipantsSearchService service;
     @Mock
+    private UserService userService;
+    @Mock
     private ChatMemberService chatMemberService;
     @Mock
     private ChatMessageService chatMessageService;
@@ -63,6 +66,7 @@ public class ChatRoomWithParticipantsSearchServiceTest {
         List<ChatMemberResult.Detail> recentParticipants = createRecentParticipantDetails();
         List<ChatMemberResult.Summary> otherParticipants = createOtherParticipantSummaries();
 
+        given(userService.readUser(userId)).willReturn(Optional.of(UserFixture.GENERAL_USER.toUser()));
         given(chatMemberService.readChatMember(userId, chatRoom.getId())).willReturn(Optional.of(myInfo));
         given(chatMessageService.readRecentMessages(eq(chatRoom.getId()), anyInt())).willReturn(recentMessages);
         given(chatMemberService.readChatMembersByUserIds(eq(chatRoom.getId()), anySet())).willReturn(recentParticipants);
@@ -82,6 +86,7 @@ public class ChatRoomWithParticipantsSearchServiceTest {
         );
 
         // verify
+        verify(userService).readUser(userId);
         verify(chatMemberService).readChatMember(userId, chatRoom.getId());
         verify(chatMessageService).readRecentMessages(eq(chatRoom.getId()), anyInt());
         verify(chatMemberService).readChatMembersByUserIds(eq(chatRoom.getId()), anySet());
@@ -99,6 +104,7 @@ public class ChatRoomWithParticipantsSearchServiceTest {
         List<ChatMemberResult.Detail> recentParticipants = createRecentParticipantDetails();
         List<ChatMemberResult.Summary> otherParticipants = createOtherParticipantSummaries();
 
+        given(userService.readUser(userId)).willReturn(Optional.of(UserFixture.GENERAL_USER.toUser()));
         given(chatMemberService.readChatMember(userId, chatRoom.getId())).willReturn(Optional.of(myInfo));
         given(chatMessageService.readRecentMessages(eq(chatRoom.getId()), eq(15))).willReturn(recentMessages);
         given(chatMemberService.readChatMembersByUserIds(eq(chatRoom.getId()), anySet())).willReturn(recentParticipants);
@@ -127,6 +133,7 @@ public class ChatRoomWithParticipantsSearchServiceTest {
     @DisplayName("존재하지 않는 채팅방 멤버 조회 시 예외가 발생한다")
     void throwExceptionWhenChatMemberNotFound() {
         // given
+        given(userService.readUser(userId)).willReturn(Optional.of(UserFixture.GENERAL_USER.toUser()));
         given(chatMemberService.readChatMember(userId, chatRoom.getId())).willReturn(Optional.empty());
 
         // when

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLDelete;
-import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -28,8 +27,6 @@ public class ChatMember extends DateAuditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    private String name;
 
     @Convert(converter = ChatMemberRoleConverter.class)
     private ChatMemberRole role;
@@ -51,10 +48,9 @@ public class ChatMember extends DateAuditable {
     private ChatRoom chatRoom;
 
     @Builder
-    protected ChatMember(String name, User user, ChatRoom chatRoom, ChatMemberRole role) {
-        validate(name, user, chatRoom, role);
+    protected ChatMember(User user, ChatRoom chatRoom, ChatMemberRole role) {
+        validate(user, chatRoom, role);
 
-        this.name = name;
         this.user = user;
         this.chatRoom = chatRoom;
         this.role = role;
@@ -63,18 +59,13 @@ public class ChatMember extends DateAuditable {
 
     public static ChatMember of(User user, ChatRoom chatRoom, ChatMemberRole role) {
         return ChatMember.builder()
-                .name(user.getName())
                 .user(user)
                 .chatRoom(chatRoom)
                 .role(role)
                 .build();
     }
 
-    private void validate(String name, User user, ChatRoom chatRoom, ChatMemberRole role) {
-        if (!StringUtils.hasText(name)) {
-            throw new IllegalArgumentException("name은 null이거나 빈 문자열이 될 수 없습니다.");
-        }
-
+    private void validate(User user, ChatRoom chatRoom, ChatMemberRole role) {
         Objects.requireNonNull(user, "user는 null이 될 수 없습니다.");
         Objects.requireNonNull(chatRoom, "chatRoom은 null이 될 수 없습니다.");
         Objects.requireNonNull(role, "role은 null이 될 수 없습니다.");
@@ -115,7 +106,6 @@ public class ChatMember extends DateAuditable {
     public String toString() {
         return "ChatMember{" +
                 "id=" + id +
-                ", name='" + name + '\'' +
                 ", banned=" + banned +
                 ", notifyEnabled=" + notifyEnabled +
                 ", deletedAt=" + deletedAt +

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepositoryImpl.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepositoryImpl.java
@@ -45,7 +45,7 @@ public class CustomChatMemberRepositoryImpl implements CustomChatMemberRepositor
                                 Projections.constructor(
                                         ChatMemberResult.Detail.class,
                                         chatMember.id,
-                                        chatMember.name,
+                                        chatMember.user.name,
                                         chatMember.role,
                                         chatMember.notifyEnabled,
                                         chatMember.user.id,

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
@@ -70,7 +70,7 @@ public class ChatMemberRdbService {
 
         Map<String, Expression<?>> bindings = new LinkedHashMap<>();
         bindings.put("id", qChatMember.id);
-        bindings.put("name", qChatMember.name);
+        bindings.put("name", qChatMember.user.name);
         bindings.put("role", qChatMember.role);
         bindings.put("notification", qChatMember.notifyEnabled);
         bindings.put("userId", qChatMember.user.id);
@@ -87,7 +87,7 @@ public class ChatMemberRdbService {
 
         Map<String, Expression<?>> bindings = new LinkedHashMap<>();
         bindings.put("id", qChatMember.id);
-        bindings.put("name", qChatMember.name);
+        bindings.put("name", qChatMember.user.name);
         bindings.put("role", qChatMember.role);
         bindings.put("notification", qChatMember.notifyEnabled);
         bindings.put("userId", qChatMember.user.id);
@@ -104,7 +104,7 @@ public class ChatMemberRdbService {
 
         Map<String, Expression<?>> bindings = new LinkedHashMap<>();
         bindings.put("id", qChatMember.id);
-        bindings.put("name", qChatMember.name);
+        bindings.put("name", qChatMember.user.name);
 
         return chatMemberRepository.selectList(predicate, ChatMemberResult.Summary.class, bindings, null, null);
     }

--- a/pennyway-domain/domain-rdb/src/test/java/kr/co/pennyway/domain/member/service/ChatMemberNameSearchTest.java
+++ b/pennyway-domain/domain-rdb/src/test/java/kr/co/pennyway/domain/member/service/ChatMemberNameSearchTest.java
@@ -1,0 +1,133 @@
+package kr.co.pennyway.domain.member.service;
+
+import kr.co.pennyway.domain.common.fixture.ChatRoomFixture;
+import kr.co.pennyway.domain.common.fixture.UserFixture;
+import kr.co.pennyway.domain.config.ContainerMySqlTestConfig;
+import kr.co.pennyway.domain.config.JpaConfig;
+import kr.co.pennyway.domain.config.JpaTestConfig;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.repository.ChatRoomRepository;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
+import kr.co.pennyway.domain.domains.member.repository.ChatMemberRepository;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberRdbService;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Slf4j
+@DataJpaTest(properties = {"spring.jpa.hibernate.ddl-auto=create"})
+@ContextConfiguration(classes = {JpaConfig.class, ChatMemberRdbService.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import({JpaTestConfig.class})
+public class ChatMemberNameSearchTest extends ContainerMySqlTestConfig {
+    @Autowired
+    private ChatMemberRdbService chatMemberRdbService;
+
+    @Autowired
+    private ChatMemberRepository chatMemberRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Test
+    @Transactional
+    @DisplayName("채팅방 멤버 단일 조회에 성공한다.")
+    public void successReadChatMember() {
+        // given
+        User user = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity());
+        ChatMember chatMember = chatMemberRepository.save(ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER));
+
+        // when
+        Optional<ChatMember> result = chatMemberRdbService.readChatMember(user.getId(), chatRoom.getId());
+
+        // then
+        log.debug("result: {}", result);
+        assertNotNull(result.get());
+        assertEquals(chatMember.getId(), result.get().getId());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("채팅방 관리자 조회에 성공한다.")
+    public void successReadAdmin() {
+        // given
+        User user = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity());
+        ChatMember chatMember = chatMemberRepository.save(ChatMember.of(user, chatRoom, ChatMemberRole.ADMIN));
+
+        // when
+        Optional<ChatMemberResult.Detail> result = chatMemberRdbService.readAdmin(chatRoom.getId());
+
+        // then
+        log.debug("result: {}", result);
+        assertNotNull(result.get());
+        assertEquals(chatMember.getId(), result.get().id());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("멤버 아이디 리스트로 멤버 조회에 성공한다.")
+    public void successReadChatMembersByIdIn() {
+        // given
+        User user = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity());
+        ChatMember chatMember1 = chatMemberRepository.save(ChatMember.of(user, chatRoom, ChatMemberRole.ADMIN));
+
+        User user2 = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatMember chatMember2 = chatMemberRepository.save(ChatMember.of(user2, chatRoom, ChatMemberRole.MEMBER));
+
+        Set<Long> chatMemberIds = Set.of(chatMember1.getId(), chatMember2.getId());
+
+        // when
+        List<ChatMemberResult.Detail> result = chatMemberRdbService.readChatMembersByIdIn(chatRoom.getId(), chatMemberIds);
+
+        // then
+        log.debug("result: {}", result);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("사용자 아이디 리스트로 멤버 조회에 성공한다.")
+    public void successReadChatMembersByUserIds() {
+        // given
+        User user = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity());
+        ChatMember chatMember1 = chatMemberRepository.save(ChatMember.of(user, chatRoom, ChatMemberRole.ADMIN));
+
+        User user2 = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatMember chatMember2 = chatMemberRepository.save(ChatMember.of(user2, chatRoom, ChatMemberRole.MEMBER));
+
+        Set<Long> userIds = Set.of(user.getId(), user2.getId());
+
+        // when
+        List<ChatMemberResult.Detail> result = chatMemberRdbService.readChatMembersByUserIdIn(chatRoom.getId(), userIds);
+
+        // then
+        log.debug("result: {}", result);
+        assertEquals(2, result.size());
+    }
+}


### PR DESCRIPTION
## 작업 이유
- The designer requested aligning chat members' names with users' names for consistency.

<br/>

## 작업 사항
- Removed the `name` field from the `chat_member` table.
- Implemented a database join with the `user` table to fetch names when retrieving chat member data.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- none

