### PR TITLE
Ignore: 🔧 Seperate Business Logic From DeviceTokenRegisterService

### DIFF
--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenCollection.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenCollection.java
@@ -1,0 +1,10 @@
+package kr.co.pennyway.domain.context.account.collection;
+
+import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
+import kr.co.pennyway.domain.domains.user.domain.User;
+
+public class DeviceTokenCollection {
+    public DeviceToken register(User user, String deviceId, String deviceName, String deviceToken) {
+        return DeviceToken.of(deviceToken, deviceId, deviceName, user);
+    }
+}

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenCollection.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenCollection.java
@@ -4,7 +4,32 @@ import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
 import kr.co.pennyway.domain.domains.user.domain.User;
 
 public class DeviceTokenCollection {
-    public DeviceToken register(User user, String deviceId, String deviceName, String deviceToken) {
-        return DeviceToken.of(deviceToken, deviceId, deviceName, user);
+    private final DeviceToken deviceToken;
+
+    public DeviceTokenCollection() {
+        this.deviceToken = null;
+    }
+
+    public DeviceTokenCollection(DeviceToken deviceToken) {
+        this.deviceToken = deviceToken;
+    }
+
+    public DeviceToken register(User user, String deviceId, String deviceName, String token) {
+        DeviceToken existingDeviceToken = this.getDeviceTokenByToken(token);
+
+        if (existingDeviceToken != null) {
+            existingDeviceToken.handleOwner(user, deviceId);
+            return existingDeviceToken;
+        }
+
+        return DeviceToken.of(token, deviceId, deviceName, user);
+    }
+
+    private DeviceToken getDeviceTokenByToken(String token) {
+        if (this.deviceToken != null && this.deviceToken.getToken().equals(token)) {
+            return this.deviceToken;
+        }
+
+        return null;
     }
 }

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenRegisterCollection.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenRegisterCollection.java
@@ -6,10 +6,12 @@ import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.NonNull;
 
 import java.util.List;
 
+@Slf4j
 public class DeviceTokenRegisterCollection {
     private final List<DeviceToken> userDeviceTokens;
     private DeviceToken deviceToken;
@@ -53,6 +55,7 @@ public class DeviceTokenRegisterCollection {
      */
     public DeviceToken register(User owner, @NonNull String deviceId, @NonNull String deviceName, @NonNull String token) {
         if (owner == null) {
+            log.error("디바이스 토큰을 등록할 사용자 정보가 없습니다.");
             throw new UserErrorException(UserErrorCode.NOT_FOUND);
         }
 
@@ -73,10 +76,12 @@ public class DeviceTokenRegisterCollection {
 
     private DeviceToken updateDevice(User user, String deviceId, DeviceToken originalDeviceToken) {
         if (isDuplicatedDeviceToken(deviceId, originalDeviceToken)) {
+            log.error("활성화된 토큰을 다른 디바이스에서 사용 중입니다.");
             throw new DeviceTokenErrorException(DeviceTokenErrorCode.DUPLICATED_DEVICE_TOKEN);
         }
 
         originalDeviceToken.handleOwner(user, deviceId);
+        log.info("디바이스 토큰이 갱신되었습니다. deviceId: {}, token: {}", deviceId, originalDeviceToken.getToken());
 
         return originalDeviceToken;
     }
@@ -87,6 +92,7 @@ public class DeviceTokenRegisterCollection {
 
     private DeviceToken createDevice(User user, String deviceId, String deviceName, String token) {
         this.deviceToken = DeviceToken.of(token, deviceId, deviceName, user);
+        log.info("새로운 디바이스 토큰이 생성되었습니다. deviceId: {}, token: {}", deviceId, token);
 
         deactivateExistingTokens();
 

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenRegisterCollection.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenRegisterCollection.java
@@ -4,31 +4,63 @@ import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
 import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorCode;
 import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
 import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
+import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
+import org.springframework.lang.NonNull;
 
-public class DeviceTokenCollection {
-    private final DeviceToken deviceToken;
+import java.util.List;
 
-    public DeviceTokenCollection() {
+public class DeviceTokenRegisterCollection {
+    private final List<DeviceToken> userDeviceTokens;
+    private DeviceToken deviceToken;
+
+    public DeviceTokenRegisterCollection() {
         this.deviceToken = null;
+        this.userDeviceTokens = List.of();
     }
 
-    public DeviceTokenCollection(DeviceToken deviceToken) {
+    public DeviceTokenRegisterCollection(DeviceToken deviceToken) {
         this.deviceToken = deviceToken;
+        this.userDeviceTokens = List.of();
     }
 
-    public DeviceToken register(User user, String deviceId, String deviceName, String token) {
-        DeviceToken existingDeviceToken = this.getDeviceTokenByToken(token);
+    /**
+     * @param userDeviceTokens :
+     */
+    public DeviceTokenRegisterCollection(DeviceToken deviceToken, List<DeviceToken> userDeviceTokens) {
+        this.deviceToken = deviceToken;
+        this.userDeviceTokens = userDeviceTokens;
+    }
 
-        if (existingDeviceToken != null) {
-            if (!existingDeviceToken.getDeviceId().equals(deviceId) && existingDeviceToken.isActivated()) {
-                throw new DeviceTokenErrorException(DeviceTokenErrorCode.DUPLICATED_DEVICE_TOKEN);
-            }
-
-            existingDeviceToken.handleOwner(user, deviceId);
-            return existingDeviceToken;
+    /**
+     * 사용자의 디바이스 토큰을 생성하거나 갱신한다.
+     *
+     * <pre>
+     * [비즈니스 규칙]
+     * - 같은 {userId, deviceId}에 대해 새로운 토큰이 발급될 수 있지만, 활성화된 토큰은 하나여야 합니다.
+     * - {deviceId, token} 조합은 시스템 전체에서 유일해야 합니다.
+     * - device token이 이미 등록된 경우, 소유자 정보를 갱신하고 마지막 로그인 시간을 갱신한다.
+     * - device token이 등록되지 않은 경우, 새로운 device token을 생성한다.
+     * </pre>
+     *
+     * @param owner      User :   사용자 정보
+     * @param deviceId   String: 디바이스 식별자
+     * @param deviceName String: 디바이스 이름
+     * @param token      String: 디바이스 토큰
+     * @return {@link DeviceToken} 사용자의 기기로 등록된 Device 정보
+     * @throws UserErrorException        {@link UserErrorCode#NOT_FOUND} : 사용자 파라미터가 null인 경우
+     * @throws DeviceTokenErrorException {@link DeviceTokenErrorCode#DUPLICATED_DEVICE_TOKEN} : 이미 등록된 활성화 디바이스 토큰의 deviceId와 다른 deviceId가 들어온 경우
+     */
+    public DeviceToken register(User owner, @NonNull String deviceId, @NonNull String deviceName, @NonNull String token) {
+        if (owner == null) {
+            throw new UserErrorException(UserErrorCode.NOT_FOUND);
         }
 
-        return DeviceToken.of(token, deviceId, deviceName, user);
+        DeviceToken existingDeviceToken = this.getDeviceTokenByToken(token);
+
+        return (existingDeviceToken != null)
+                ? this.updateDevice(owner, deviceId, existingDeviceToken)
+                : this.createDevice(owner, deviceId, deviceName, token);
     }
 
     private DeviceToken getDeviceTokenByToken(String token) {
@@ -37,5 +69,38 @@ public class DeviceTokenCollection {
         }
 
         return null;
+    }
+
+    private DeviceToken updateDevice(User user, String deviceId, DeviceToken originalDeviceToken) {
+        if (isDuplicatedDeviceToken(deviceId, originalDeviceToken)) {
+            throw new DeviceTokenErrorException(DeviceTokenErrorCode.DUPLICATED_DEVICE_TOKEN);
+        }
+
+        originalDeviceToken.handleOwner(user, deviceId);
+
+        return originalDeviceToken;
+    }
+
+    private boolean isDuplicatedDeviceToken(String deviceId, DeviceToken originalDeviceToken) {
+        return !originalDeviceToken.getDeviceId().equals(deviceId) && originalDeviceToken.isActivated();
+    }
+
+    private DeviceToken createDevice(User user, String deviceId, String deviceName, String token) {
+        this.deviceToken = DeviceToken.of(token, deviceId, deviceName, user);
+
+        deactivateExistingTokens();
+
+        return this.deviceToken;
+    }
+
+    /**
+     * 특정 사용자의 디바이스에 대한 기존 활성 토큰들을 비활성화합니다.
+     * 새로운 토큰 등록 시 호출되어 하나의 디바이스에 하나의 활성 토큰만 존재하도록 보장합니다.
+     */
+    private void deactivateExistingTokens() {
+        userDeviceTokens.stream()
+                .filter(token -> token.getDeviceId().equals(deviceToken.getDeviceId()))
+                .filter(DeviceToken::isActivated)
+                .forEach(DeviceToken::deactivate);
     }
 }

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenRegisterCollection.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenRegisterCollection.java
@@ -1,6 +1,8 @@
 package kr.co.pennyway.domain.context.account.collection;
 
 import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
+import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorCode;
+import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
 import kr.co.pennyway.domain.domains.user.domain.User;
 
 public class DeviceTokenCollection {
@@ -18,6 +20,10 @@ public class DeviceTokenCollection {
         DeviceToken existingDeviceToken = this.getDeviceTokenByToken(token);
 
         if (existingDeviceToken != null) {
+            if (!existingDeviceToken.getDeviceId().equals(deviceId) && existingDeviceToken.isActivated()) {
+                throw new DeviceTokenErrorException(DeviceTokenErrorCode.DUPLICATED_DEVICE_TOKEN);
+            }
+
             existingDeviceToken.handleOwner(user, deviceId);
             return existingDeviceToken;
         }

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterService.java
@@ -35,9 +35,11 @@ public class DeviceTokenRegisterService {
         Optional<DeviceToken> existingDeviceToken = deviceTokenRdbService.readDeviceByToken(deviceToken);
         List<DeviceToken> userDeviceTokens = deviceTokenRdbService.readByUserIdAndDeviceId(userId, deviceId);
 
-        return new DeviceTokenRegisterCollection(
+        DeviceToken newDeviceToken = new DeviceTokenRegisterCollection(
                 existingDeviceToken.orElse(null),
                 userDeviceTokens
         ).register(user.orElse(null), deviceId, deviceName, deviceToken);
+
+        return deviceTokenRdbService.createDevice(newDeviceToken);
     }
 }

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterService.java
@@ -23,14 +23,6 @@ public class DeviceTokenRegisterService {
     /**
      * 사용자의 디바이스 토큰을 생성하거나 갱신한다.
      *
-     * <pre>
-     * [비즈니스 규칙]
-     * - 같은 {userId, deviceId}에 대해 새로운 토큰이 발급될 수 있지만, 활성화된 토큰은 하나여야 합니다.
-     * - {deviceId, token} 조합은 시스템 전체에서 유일해야 합니다.
-     * - device token이 이미 등록된 경우, 소유자 정보를 갱신하고 마지막 로그인 시간을 갱신한다.
-     * - device token이 등록되지 않은 경우, 새로운 device token을 생성한다.
-     * </pre>
-     *
      * @param userId      사용자 식별자
      * @param deviceId    디바이스 식별자
      * @param deviceName  디바이스 이름

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterService.java
@@ -1,19 +1,17 @@
 package kr.co.pennyway.domain.context.account.service;
 
 import kr.co.pennyway.common.annotation.DomainService;
+import kr.co.pennyway.domain.context.account.collection.DeviceTokenRegisterCollection;
 import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
-import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorCode;
-import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
 import kr.co.pennyway.domain.domains.device.service.DeviceTokenRdbService;
 import kr.co.pennyway.domain.domains.user.domain.User;
-import kr.co.pennyway.domain.domains.user.exception.UserErrorCode;
-import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
 import kr.co.pennyway.domain.domains.user.service.UserRdbService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @DomainService
@@ -41,47 +39,13 @@ public class DeviceTokenRegisterService {
      */
     @Transactional
     public DeviceToken execute(Long userId, String deviceId, String deviceName, String deviceToken) {
-        User user = userRdbService.readUser(userId).orElseThrow(() -> new UserErrorException(UserErrorCode.NOT_FOUND));
-
-        return getOrCreateDevice(user, deviceId, deviceName, deviceToken);
-    }
-
-    /**
-     * 사용자의 디바이스 토큰을 생성합니다.
-     * 만약, 이미 등록된 디바이스 토큰이 존재한다면, 해당 토큰을 갱신하고 반환합니다.
-     */
-    private DeviceToken getOrCreateDevice(User user, String deviceId, String deviceName, String deviceToken) {
-        return deviceTokenRdbService.readDeviceByToken(deviceToken)
-                .map(originalDeviceToken -> updateDevice(user, deviceId, originalDeviceToken))
-                .orElseGet(() -> createDevice(user, deviceId, deviceName, deviceToken));
-    }
-
-    private DeviceToken updateDevice(User user, String deviceId, DeviceToken originalDeviceToken) {
-        if (!originalDeviceToken.getDeviceId().equals(deviceId) && originalDeviceToken.isActivated()) {
-            throw new DeviceTokenErrorException(DeviceTokenErrorCode.DUPLICATED_DEVICE_TOKEN);
-        }
-
-        originalDeviceToken.handleOwner(user, deviceId);
-        return originalDeviceToken;
-    }
-
-    private DeviceToken createDevice(User user, String deviceId, String deviceName, String deviceToken) {
-        deactivateExistingTokens(user.getId(), deviceId);
-
-        DeviceToken newDeviceToken = DeviceToken.of(deviceToken, deviceId, deviceName, user);
-
-        return deviceTokenRdbService.createDevice(newDeviceToken);
-    }
-
-    /**
-     * 특정 사용자의 디바이스에 대한 기존 활성 토큰들을 비활성화합니다.
-     * 새로운 토큰 등록 시 호출되어 하나의 디바이스에 하나의 활성 토큰만 존재하도록 보장합니다.
-     */
-    private void deactivateExistingTokens(Long userId, String deviceId) {
+        Optional<User> user = userRdbService.readUser(userId);
+        Optional<DeviceToken> existingDeviceToken = deviceTokenRdbService.readDeviceByToken(deviceToken);
         List<DeviceToken> userDeviceTokens = deviceTokenRdbService.readByUserIdAndDeviceId(userId, deviceId);
 
-        userDeviceTokens.stream()
-                .filter(DeviceToken::isActivated)
-                .forEach(DeviceToken::deactivate);
+        return new DeviceTokenRegisterCollection(
+                existingDeviceToken.orElse(null),
+                userDeviceTokens
+        ).register(user.orElse(null), deviceId, deviceName, deviceToken);
     }
 }

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/integration/DeviceTokenRegisterServiceIntegrationTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/integration/DeviceTokenRegisterServiceIntegrationTest.java
@@ -27,6 +27,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
@@ -54,28 +56,61 @@ public class DeviceTokenRegisterServiceIntegrationTest extends DomainServiceTest
     }
 
     @Test
-    @Transactional
-    @DisplayName("디바이스 토큰 등록 시 기존 활성 토큰은 비활성화됩니다")
-    void shouldDeactivateExistingTokensWhenRegisteringNew() {
+    @DisplayName("새로운 토큰 등록 요청 시 디바이스 토큰이 정상적으로 저장됩니다")
+    void when_registering_new_token_then_save_successfully() {
         // given
-        String deviceId = "device1";
+        String deviceId = "newDevice";
+        String token = "newToken";
 
         // when
-        DeviceToken firstToken = deviceTokenRegisterService.execute(savedUser.getId(), deviceId, "Android", "token1");
+        DeviceToken result = deviceTokenRegisterService.execute(savedUser.getId(), deviceId, "Android", token);
+
+        // then
+        // 1. 반환된 결과 검증
+        assertEquals(token, result.getToken());
+        assertEquals(deviceId, result.getDeviceId());
+        assertEquals(savedUser.getId(), result.getUser().getId());
+        assertTrue(result.isActivated());
+
+        // 2. 실제 DB 저장 여부 검증
+        DeviceToken savedToken = deviceTokenRepository.findById(result.getId())
+                .orElseThrow(() -> new IllegalStateException("저장된 토큰을 찾을 수 없습니다."));
+
+        assertEquals(token, savedToken.getToken());
+        assertEquals(deviceId, savedToken.getDeviceId());
+        assertEquals(savedUser.getId(), savedToken.getUser().getId());
+        assertTrue(savedToken.isActivated());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("사용자가 동일한 디바이스에 새로운 토큰을 등록하면 기존 토큰이 비활성화됩니다")
+    void when_registering_new_token_for_same_device_then_deactivate_existing_token() {
+        // given
+        String deviceId = "device1";
+        DeviceToken firstToken = deviceTokenRepository.save(DeviceToken.of("token1", deviceId, "Android", savedUser));
+
+        // when
         DeviceToken secondToken = deviceTokenRegisterService.execute(savedUser.getId(), deviceId, "Android", "token2");
 
         // then
         assertFalse(firstToken.isActivated());
         assertTrue(secondToken.isActivated());
+        assertEquals(deviceId, secondToken.getDeviceId());
+
+        // DB에 실제로 저장되었는지 확인
+        List<DeviceToken> savedTokens = deviceTokenRepository.findAllByUser_Id(savedUser.getId());
+        assertEquals(2, savedTokens.size());
+        assertTrue(savedTokens.stream().filter(DeviceToken::isActivated).count() == 1);
     }
 
     @Test
     @Transactional
-    @DisplayName("활성화된 토큰이 다른 디바이스에서 사용되면 예외가 발생합니다")
-    void shouldThrowExceptionWhenActiveTokenIsUsedOnDifferentDevice() {
+    @DisplayName("활성화된 토큰을 다른 디바이스에서 사용하려고 하면 예외가 발생합니다")
+    void when_using_active_token_on_different_device_then_throw_exception() {
         // given
         String token = "token1";
-        deviceTokenRegisterService.execute(savedUser.getId(), "device1", "Android", token);
+        deviceTokenRepository.save(DeviceToken.of(token, "device1", "iPhone", savedUser));
 
         // when & then
         DeviceTokenErrorException exception = assertThrowsExactly(
@@ -86,6 +121,7 @@ public class DeviceTokenRegisterServiceIntegrationTest extends DomainServiceTest
     }
 
     @Test
+    @Transactional
     @DisplayName("같은 deviceId, token / 다른 사용자 갱신 요청이라면, 디바이스 토큰의 소유권이 다른 사용자에게 이전됩니다")
     void shouldTransferTokenOwnership() {
         // given
@@ -94,13 +130,39 @@ public class DeviceTokenRegisterServiceIntegrationTest extends DomainServiceTest
         String deviceId = "device1";
         String token = "token1";
 
+        DeviceToken firstUserToken = deviceTokenRepository.save(DeviceToken.of(token, deviceId, "Android", savedUser));
+
         // when
-        DeviceToken firstUserToken = deviceTokenRegisterService.execute(savedUser.getId(), deviceId, "Android", token);
         DeviceToken secondUserToken = deviceTokenRegisterService.execute(anotherUser.getId(), deviceId, "Android", token);
 
         // then
         assertEquals(firstUserToken.getId(), secondUserToken.getId());
         assertEquals(anotherUser.getId(), secondUserToken.getUser().getId());
         assertTrue(secondUserToken.isActivated());
+    }
+
+    @Test
+    @DisplayName("사용자는 여러 기기에 서로 다른 토큰을 등록할 수 있습니다")
+    void when_user_registers_multiple_devices_then_allow_different_tokens() {
+        // given
+        String device1Token = "token1";
+        String device2Token = "token2";
+
+        // when
+        DeviceToken result1 = deviceTokenRegisterService.execute(savedUser.getId(), "device1", "Android", device1Token);
+        DeviceToken result2 = deviceTokenRegisterService.execute(savedUser.getId(), "device2", "iPhone", device2Token);
+
+        // then
+        assertTrue(result1.isActivated());
+        assertTrue(result2.isActivated());
+        assertNotEquals(result1.getDeviceId(), result2.getDeviceId());
+        assertNotEquals(result1.getToken(), result2.getToken());
+
+        // DB에 실제로 저장되었는지 확인
+        List<DeviceToken> savedTokens = deviceTokenRepository.findAllByUser_Id(savedUser.getId());
+        assertEquals(2, savedTokens.size());
+        assertTrue(savedTokens.stream().allMatch(DeviceToken::isActivated));
+
+        deviceTokenRepository.deleteAll(savedTokens);
     }
 }

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/integration/DeviceTokenRegisterServiceIntegrationTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/integration/DeviceTokenRegisterServiceIntegrationTest.java
@@ -101,7 +101,7 @@ public class DeviceTokenRegisterServiceIntegrationTest extends DomainServiceTest
         // DB에 실제로 저장되었는지 확인
         List<DeviceToken> savedTokens = deviceTokenRepository.findAllByUser_Id(savedUser.getId());
         assertEquals(2, savedTokens.size());
-        assertTrue(savedTokens.stream().filter(DeviceToken::isActivated).count() == 1);
+        assertEquals(1L, savedTokens.stream().filter(DeviceToken::isActivated).count(), "활성화된 토큰은 1개여야 합니다");
     }
 
     @Test
@@ -139,6 +139,12 @@ public class DeviceTokenRegisterServiceIntegrationTest extends DomainServiceTest
         assertEquals(firstUserToken.getId(), secondUserToken.getId());
         assertEquals(anotherUser.getId(), secondUserToken.getUser().getId());
         assertTrue(secondUserToken.isActivated());
+
+        List<DeviceToken> firstUserTokens = deviceTokenRepository.findAllByUser_Id(savedUser.getId());
+        List<DeviceToken> secondUserTokens = deviceTokenRepository.findAllByUser_Id(anotherUser.getId());
+
+        assertTrue(firstUserTokens.isEmpty(), "첫 번째 사용자의 토큰이 없어야 합니다");
+        assertEquals(1, secondUserTokens.size(), "두 번째 사용자의 토큰이 1개 있어야 합니다");
     }
 
     @Test

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterServiceTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterServiceTest.java
@@ -1,5 +1,6 @@
 package kr.co.pennyway.domain.context.account.service;
 
+import kr.co.pennyway.domain.context.account.collection.DeviceTokenCollection;
 import kr.co.pennyway.domain.context.common.fixture.UserFixture;
 import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
 import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
@@ -95,26 +96,23 @@ public class DeviceTokenRegisterServiceTest {
 
     @Test
     @DisplayName("새로운 토큰 등록 시 올바른 정보로 생성됩니다")
-    void shouldCreateNewTokenWithCorrectInformation() {
+    void when_user_has_no_token_should_create_new_token() {
         // given
+        DeviceTokenCollection deviceTokenCollection = new DeviceTokenCollection();
+
         User user = UserFixture.GENERAL_USER.toUserWithCustomSetting(1L, "jayang", "Yang", UserFixture.GENERAL_USER.getNotifySetting());
         String expectedToken = "token1";
-        String expectedDeviceId = "device1";
-        String expectedDeviceName = "Android";
-
-        given(userRdbService.readUser(user.getId())).willReturn(Optional.of(user));
-        given(deviceTokenRdbService.readDeviceByToken(expectedToken)).willReturn(Optional.empty());
-        given(deviceTokenRdbService.readByUserIdAndDeviceId(user.getId(), expectedDeviceId)).willReturn(List.of());
-        given(deviceTokenRdbService.createDevice(any())).willAnswer(invocation -> invocation.getArgument(0));
+        String expectedDeviceId = "재서의 까리한 플립";
+        String expectedDeviceName = "Galaxy Flip 6";
 
         // when
-        DeviceToken result = deviceTokenRegisterService.execute(user.getId(), expectedDeviceId, expectedDeviceName, expectedToken);
+        DeviceToken actual = deviceTokenCollection.register(user, expectedDeviceId, expectedDeviceName, expectedToken);
 
         // then
-        assertEquals(expectedToken, result.getToken());
-        assertEquals(expectedDeviceId, result.getDeviceId());
-        assertEquals(expectedDeviceName, result.getDeviceName());
-        assertEquals(user, result.getUser());
+        assertEquals(expectedToken, actual.getToken());
+        assertEquals(expectedDeviceId, actual.getDeviceId());
+        assertEquals(expectedDeviceName, actual.getDeviceName());
+        assertEquals(user, actual.getUser());
     }
 
     @Test

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterServiceTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterServiceTest.java
@@ -1,62 +1,67 @@
 package kr.co.pennyway.domain.context.account.service;
 
-import kr.co.pennyway.domain.context.account.collection.DeviceTokenCollection;
+import kr.co.pennyway.domain.context.account.collection.DeviceTokenRegisterCollection;
 import kr.co.pennyway.domain.context.common.fixture.UserFixture;
 import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
 import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
-import kr.co.pennyway.domain.domains.device.service.DeviceTokenRdbService;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
-import kr.co.pennyway.domain.domains.user.service.UserRdbService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
-@ExtendWith(MockitoExtension.class)
 public class DeviceTokenRegisterServiceTest {
-    @Mock
-    private UserRdbService userRdbService;
+    @Test
+    @DisplayName("사용자가 존재하지 않으면 예외가 발생합니다")
+    void when_user_not_found_then_throw_exception() {
+        // given
+        DeviceTokenRegisterCollection collection = new DeviceTokenRegisterCollection();
 
-    @Mock
-    private DeviceTokenRdbService deviceTokenRdbService;
+        // when & then
+        assertThrows(UserErrorException.class, () -> collection.register(null, "device1", "Android", "token1"));
+    }
 
-    @InjectMocks
-    private DeviceTokenRegisterService deviceTokenRegisterService;
+    @Test
+    @DisplayName("새로운 토큰 등록 시 올바른 정보로 생성됩니다")
+    void when_user_has_no_token_should_create_new_token() {
+        // given
+        DeviceTokenRegisterCollection deviceTokenRegisterCollection = new DeviceTokenRegisterCollection();
+
+        User user = UserFixture.GENERAL_USER.toUserWithCustomSetting(1L, "jayang", "Yang", UserFixture.GENERAL_USER.getNotifySetting());
+        String expectedToken = "token1";
+        String expectedDeviceId = "재서의 까리한 플립";
+        String expectedDeviceName = "Galaxy Flip 6";
+
+        // when
+        DeviceToken actual = deviceTokenRegisterCollection.register(user, expectedDeviceId, expectedDeviceName, expectedToken);
+
+        // then
+        assertEquals(expectedToken, actual.getToken());
+        assertEquals(expectedDeviceId, actual.getDeviceId());
+        assertEquals(expectedDeviceName, actual.getDeviceName());
+        assertEquals(user, actual.getUser());
+    }
 
     @Test
     @DisplayName("이미 소유 중인 토큰인 경우 마지막 로그인 날짜만 갱신합니다")
-    void shouldUpdateOwnerWhenTokenExists() {
+    void when_token_exists_should_update_last_signed_at() {
         // given
-        User user = UserFixture.GENERAL_USER.toUser();
-        String expectedToken = "token1";
-        String expectedDeviceId = "device1";
-        String expectedDeviceName = "Android";
-        DeviceToken existingToken = DeviceToken.of(expectedToken, expectedDeviceId, expectedDeviceName, user);
-
-        given(userRdbService.readUser(1L)).willReturn(Optional.of(user));
-        given(deviceTokenRdbService.readDeviceByToken(expectedToken)).willReturn(Optional.of(existingToken));
+        User owner = UserFixture.GENERAL_USER.toUser();
+        String token = "token1";
+        String deviceId = "device1";
+        DeviceToken existingToken = DeviceToken.of(token, deviceId, "Android", owner);
+        DeviceTokenRegisterCollection collection = new DeviceTokenRegisterCollection(existingToken);
 
         // when
-        DeviceToken result = deviceTokenRegisterService.execute(1L, expectedDeviceId, expectedDeviceName, expectedToken);
+        DeviceToken actual = collection.register(owner, deviceId, "Android", token);
 
         // then
-        assertEquals(existingToken, result);
-        assertEquals(user, result.getUser());
-        assertTrue(existingToken.isActivated());
-
-        verify(deviceTokenRdbService, never()).createDevice(any());
+        assertEquals(existingToken, actual);
+        assertEquals(owner, actual.getUser());
+        assertTrue(actual.isActivated());
     }
 
     @Test
@@ -66,7 +71,7 @@ public class DeviceTokenRegisterServiceTest {
         User originalOwner = UserFixture.GENERAL_USER.toUserWithCustomSetting(1L, "jayang", "Yang", UserFixture.GENERAL_USER.getNotifySetting());
         DeviceToken existingToken = DeviceToken.of("token1", "device1", "Android", originalOwner);
         existingToken.deactivate();
-        DeviceTokenCollection deviceTokenCollection = new DeviceTokenCollection(existingToken);
+        DeviceTokenRegisterCollection deviceTokenRegisterCollection = new DeviceTokenRegisterCollection(existingToken);
 
         User newOwner = UserFixture.GENERAL_USER.toUserWithCustomSetting(2L, "another", "User", UserFixture.GENERAL_USER.getNotifySetting());
         String expectedToken = "token1";
@@ -74,7 +79,7 @@ public class DeviceTokenRegisterServiceTest {
         String expectedDeviceName = "Android";
 
         // when
-        DeviceToken actual = deviceTokenCollection.register(newOwner, expectedDeviceId, expectedDeviceName, expectedToken);
+        DeviceToken actual = deviceTokenRegisterCollection.register(newOwner, expectedDeviceId, expectedDeviceName, expectedToken);
 
         // then
         assertTrue(actual.isActivated());
@@ -85,198 +90,80 @@ public class DeviceTokenRegisterServiceTest {
     }
 
     @Test
-    @DisplayName("새로운 토큰 등록 시 기존 활성 토큰들은 비활성화되고, 새로 등록된 토큰이 반환됩니다")
-    void shouldDeactivateExistingTokensWhenRegisteringNew() {
+    @DisplayName("새로운 토큰 등록 시, 디바이스의 기존 활성 토큰들은 비활성화되고, 새로 등록된 토큰이 반환됩니다")
+    void when_registering_new_token_should_deactivate_existing_token_for_same_device() {
         // given
-        User user = UserFixture.GENERAL_USER.toUserWithCustomSetting(1L, "jayang", "Yang", UserFixture.GENERAL_USER.getNotifySetting());
-        String expectedToken = "oldToken";
-        String expectedDeviceId = "device1";
-        String expectedDeviceName = "Android";
-        String expectedNewToken = "newToken";
-        DeviceToken originToken = DeviceToken.of(expectedToken, expectedDeviceId, expectedDeviceName, user);
+        User user = UserFixture.GENERAL_USER.toUser();
+        DeviceToken existingToken = DeviceToken.of("oldToken", "device1", "Android", user);
+        List<DeviceToken> userTokens = List.of(existingToken);
 
-        given(userRdbService.readUser(user.getId())).willReturn(Optional.of(user));
-        given(deviceTokenRdbService.readDeviceByToken(expectedNewToken)).willReturn(Optional.empty());
-        given(deviceTokenRdbService.readByUserIdAndDeviceId(user.getId(), expectedDeviceId)).willReturn(List.of(originToken));
-        given(deviceTokenRdbService.createDevice(any())).willAnswer(invocation -> invocation.getArgument(0));
+        String expectedToken = "newToken";
+
+        DeviceTokenRegisterCollection collection = new DeviceTokenRegisterCollection(null, userTokens);
 
         // when
-        DeviceToken result = deviceTokenRegisterService.execute(user.getId(), expectedDeviceId, expectedDeviceName, expectedNewToken);
+        DeviceToken actual = collection.register(user, "device1", "Android", expectedToken);
 
         // then
-        assertTrue(originToken.isExpired());
-        assertEquals(expectedNewToken, result.getToken());
-    }
-
-    @Test
-    @DisplayName("사용자가 존재하지 않으면 예외가 발생합니다")
-    void shouldThrowExceptionWhenUserNotFound() {
-        // given
-        given(userRdbService.readUser(1L)).willReturn(Optional.empty());
-
-        // when & then
-        assertThrows(UserErrorException.class, () ->
-                deviceTokenRegisterService.execute(1L, "device1", "Android", "token1"));
-    }
-
-    @Test
-    @DisplayName("새로운 토큰 등록 시 올바른 정보로 생성됩니다")
-    void when_user_has_no_token_should_create_new_token() {
-        // given
-        DeviceTokenCollection deviceTokenCollection = new DeviceTokenCollection();
-
-        User user = UserFixture.GENERAL_USER.toUserWithCustomSetting(1L, "jayang", "Yang", UserFixture.GENERAL_USER.getNotifySetting());
-        String expectedToken = "token1";
-        String expectedDeviceId = "재서의 까리한 플립";
-        String expectedDeviceName = "Galaxy Flip 6";
-
-        // when
-        DeviceToken actual = deviceTokenCollection.register(user, expectedDeviceId, expectedDeviceName, expectedToken);
-
-        // then
+        assertFalse(existingToken.isActivated());
+        assertTrue(actual.isActivated());
         assertEquals(expectedToken, actual.getToken());
-        assertEquals(expectedDeviceId, actual.getDeviceId());
-        assertEquals(expectedDeviceName, actual.getDeviceName());
-        assertEquals(user, actual.getUser());
     }
 
-    @Test
-    @DisplayName("기기의 토큰이 다른 소유자에게 등록되어 있지만 deviceId가 같은 경우, 소유자 정보를 갱신합니다")
-    void shouldUpdateOwnerWhenTokenExistsWithDifferentUser() {
-        // given
-        User user = UserFixture.GENERAL_USER.toUserWithCustomSetting(1L, "jayang", "Yang", UserFixture.GENERAL_USER.getNotifySetting());
-        User anotherUser = UserFixture.GENERAL_USER.toUserWithCustomSetting(2L, "another", "User", UserFixture.GENERAL_USER.getNotifySetting());
-        String expectedToken = "token1";
-        String expectedDeviceId = "device1";
-        String expectedDeviceName = "Android";
-        DeviceToken existingToken = DeviceToken.of(expectedToken, expectedDeviceId, expectedDeviceName, anotherUser);
-
-        given(userRdbService.readUser(user.getId())).willReturn(Optional.of(user));
-        given(deviceTokenRdbService.readDeviceByToken(expectedToken)).willReturn(Optional.of(existingToken));
-
-        // when
-        DeviceToken result = deviceTokenRegisterService.execute(user.getId(), expectedDeviceId, expectedDeviceName, expectedToken);
-
-        // then
-        assertEquals(existingToken, result);
-        assertEquals(user, result.getUser());
-        assertTrue(existingToken.isActivated());
-
-        verify(deviceTokenRdbService, never()).createDevice(any());
-    }
 
     @Test
-    @DisplayName("다른 디바이스에서 이미 사용 중인 토큰으로 등록을 시도하면 예외가 발생합니다")
-    void shouldThrowExceptionWhenTokenExistsForDifferentDevice() {
+    @DisplayName("다른 디바이스에서 이미 사용 중인 활성화 토큰으로 등록을 시도하면 예외가 발생합니다")
+    void should_throw_duplicate_exception_when_token_exists_for_different_device_id() {
         // given
-        User user = UserFixture.GENERAL_USER.toUser();
+        User owner = UserFixture.GENERAL_USER.toUserWithCustomSetting(1L, "jayang", "Yang", UserFixture.GENERAL_USER.getNotifySetting());
+        User hacker = UserFixture.GENERAL_USER.toUserWithCustomSetting(2L, "another", "User", UserFixture.GENERAL_USER.getNotifySetting());
+
         String token = "token1";
-        String deviceId = "device2";
-        DeviceToken existingToken = DeviceToken.of(token, "device1", "Android", user);
+        DeviceToken existingToken = DeviceToken.of(token, "token1", "Android", owner);
 
-        given(userRdbService.readUser(user.getId())).willReturn(Optional.of(user));
-        given(deviceTokenRdbService.readDeviceByToken(token)).willReturn(Optional.of(existingToken));
+        DeviceTokenRegisterCollection deviceTokenRegisterCollection = new DeviceTokenRegisterCollection(existingToken);
 
         // when & then
-        assertThrows(DeviceTokenErrorException.class, () ->
-                deviceTokenRegisterService.execute(user.getId(), deviceId, "Android", token));
+        assertThrows(DeviceTokenErrorException.class, () -> deviceTokenRegisterCollection.register(hacker, "HACKER_DEVICE_ID", "Android", token));
     }
 
     @Test
-    @DisplayName("다른 디바이스에 이미 등록된 토큰이지만 비활성화된 경우 소유권을 갱신하고 활성화합니다")
-    void shouldUpdateOwnerAndActivateWhenTokenExistsButDeactivated() {
+    @DisplayName("비활성화된 토큰은 다른 디바이스에서도 재사용할 수 있습니다")
+    void when_token_deactivated_should_allow_reuse_on_different_device() {
         // given
         User user = UserFixture.GENERAL_USER.toUser();
         String token = "token1";
-        String oldDeviceId = "device1";
-        String newDeviceId = "device2";
-        DeviceToken existingToken = DeviceToken.of(token, oldDeviceId, "Android", user);
+        String newDeviceId = "newDeviceId";
+
+        DeviceToken existingToken = DeviceToken.of(token, "old-device", "Android", user);
         existingToken.deactivate();
-
-        given(userRdbService.readUser(user.getId())).willReturn(Optional.of(user));
-        given(deviceTokenRdbService.readDeviceByToken(token)).willReturn(Optional.of(existingToken));
+        DeviceTokenRegisterCollection collection = new DeviceTokenRegisterCollection(existingToken);
 
         // when
-        DeviceToken result = deviceTokenRegisterService.execute(user.getId(), newDeviceId, "Android", token);
+        DeviceToken actual = collection.register(user, newDeviceId, "Android", token);
 
         // then
-        assertEquals(existingToken, result);
-        assertEquals(user, result.getUser());
-        assertTrue(result.isActivated());
-        assertEquals(newDeviceId, result.getDeviceId());
-
-        verify(deviceTokenRdbService, never()).createDevice(any());
-    }
-
-    @Test
-    @DisplayName("같은 사용자가 여러 기기에 토큰을 등록할 수 있습니다")
-    void shouldAllowSameUserToRegisterMultipleDevices() {
-        // given
-        User user = UserFixture.GENERAL_USER.toUser();
-        String device1Token = "token1";
-        String device2Token = "token2";
-
-        given(userRdbService.readUser(user.getId())).willReturn(Optional.of(user));
-        given(deviceTokenRdbService.readDeviceByToken(device1Token)).willReturn(Optional.empty());
-        given(deviceTokenRdbService.readDeviceByToken(device2Token)).willReturn(Optional.empty());
-        given(deviceTokenRdbService.createDevice(any())).willAnswer(invocation -> invocation.getArgument(0));
-
-        // when
-        DeviceToken result1 = deviceTokenRegisterService.execute(user.getId(), "device1", "Android", device1Token);
-        DeviceToken result2 = deviceTokenRegisterService.execute(user.getId(), "device2", "iPhone", device2Token);
-
-        // then
-        assertTrue(result1.isActivated());
-        assertTrue(result2.isActivated());
-        assertNotEquals(result1.getDeviceId(), result2.getDeviceId());
-    }
-
-    @Test
-    @DisplayName("이미 등록된 토큰에 대해 같은 디바이스로 재등록을 시도하면 소유자 정보만 갱신됩니다")
-    void shouldUpdateOwnerWhenTokenExistsForSameDevice() {
-        // given
-        User user = UserFixture.GENERAL_USER.toUser();
-        String token = "token1";
-        String deviceId = "device1";
-        User previousOwner = UserFixture.GENERAL_USER.toUserWithCustomSetting(2L, "other", "User", UserFixture.GENERAL_USER.getNotifySetting());
-        DeviceToken existingToken = DeviceToken.of(token, deviceId, "Android", previousOwner);
-
-        given(userRdbService.readUser(user.getId())).willReturn(Optional.of(user));
-        given(deviceTokenRdbService.readDeviceByToken(token)).willReturn(Optional.of(existingToken));
-
-        // when
-        DeviceToken result = deviceTokenRegisterService.execute(user.getId(), deviceId, "Android", token);
-
-        // then
-        assertEquals(existingToken, result);
-        assertEquals(user, result.getUser());
-        assertTrue(result.isActivated());
-        verify(deviceTokenRdbService, never()).createDevice(any());
+        assertEquals(existingToken, actual);
+        assertEquals(newDeviceId, actual.getDeviceId());
+        assertTrue(actual.isActivated());
     }
 
     @Test
     @DisplayName("같은 사용자가 같은 디바이스에 대해 새로운 토큰을 등록하면 기존 토큰은 비활성화됩니다")
-    void shouldDeactivateExistingTokensWhenRegisteringNewTokenForSameDevice() {
+    void when_registering_different_token_for_same_device_should_deactivate_existing() {
         // given
         User user = UserFixture.GENERAL_USER.toUser();
-        String oldToken = "oldToken";
-        String newToken = "newToken";
-        String deviceId = "device1";
-        DeviceToken existingToken = DeviceToken.of(oldToken, deviceId, "Android", user);
-        existingToken.activate();
+        DeviceToken existingToken = DeviceToken.of("oldToken", "device1", "Android", user);
+        List<DeviceToken> userTokens = List.of(existingToken);
 
-        given(userRdbService.readUser(user.getId())).willReturn(Optional.of(user));
-        given(deviceTokenRdbService.readDeviceByToken(newToken)).willReturn(Optional.empty());
-        given(deviceTokenRdbService.readByUserIdAndDeviceId(user.getId(), deviceId))
-                .willReturn(List.of(existingToken));
-        given(deviceTokenRdbService.createDevice(any())).willAnswer(invocation -> invocation.getArgument(0));
+        DeviceTokenRegisterCollection collection = new DeviceTokenRegisterCollection(null, userTokens);
 
         // when
-        DeviceToken result = deviceTokenRegisterService.execute(user.getId(), deviceId, "Android", newToken);
+        DeviceToken result = collection.register(user, "device1", "Android", "newToken");
 
         // then
         assertFalse(existingToken.isActivated());
         assertTrue(result.isActivated());
-        assertEquals(newToken, result.getToken());
+        assertEquals("newToken", result.getToken());
     }
 }

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterServiceTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterServiceTest.java
@@ -60,6 +60,31 @@ public class DeviceTokenRegisterServiceTest {
     }
 
     @Test
+    @DisplayName("동일한 deviceToken이 이미 비활성화된 상태로 등록되어 있다면, 소유자와 마지막 로그인 시간을 변경하고 토큰을 활성화한다.")
+    void when_token_exists_should_update_owner_and_last_signed_at() {
+        // given
+        User originalOwner = UserFixture.GENERAL_USER.toUserWithCustomSetting(1L, "jayang", "Yang", UserFixture.GENERAL_USER.getNotifySetting());
+        DeviceToken existingToken = DeviceToken.of("token1", "device1", "Android", originalOwner);
+        existingToken.deactivate();
+        DeviceTokenCollection deviceTokenCollection = new DeviceTokenCollection(existingToken);
+
+        User newOwner = UserFixture.GENERAL_USER.toUserWithCustomSetting(2L, "another", "User", UserFixture.GENERAL_USER.getNotifySetting());
+        String expectedToken = "token1";
+        String expectedDeviceId = "device1";
+        String expectedDeviceName = "Android";
+
+        // when
+        DeviceToken actual = deviceTokenCollection.register(newOwner, expectedDeviceId, expectedDeviceName, expectedToken);
+
+        // then
+        assertTrue(actual.isActivated());
+        assertEquals(expectedToken, actual.getToken());
+        assertEquals(expectedDeviceId, actual.getDeviceId());
+        assertEquals(expectedDeviceName, actual.getDeviceName());
+        assertEquals(newOwner, actual.getUser());
+    }
+
+    @Test
     @DisplayName("새로운 토큰 등록 시 기존 활성 토큰들은 비활성화되고, 새로 등록된 토큰이 반환됩니다")
     void shouldDeactivateExistingTokensWhenRegisteringNew() {
         // given


### PR DESCRIPTION
## 작업 이유
- Addressed factors that make TDD challenging.
- For more details, refer to [this blog post](https://jaeseo0519.tistory.com/435).

<br/>

## 작업 사항

- Business rules are now handled by first-class objects that represent domain rules.
- Service classes now perform integration testing with infrastructure components.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- Is the separation of business rules and infrastructure appropriate?
- Are there potential edge cases in how the first-class objects handle domain rules?

<br/>

## 발견한 이슈
- DeviceToken Persistence:
  - Despite being generated within a transaction (Tx), DeviceToken was not persisted unless explicitly created using a create method. Although the issue has been resolved, the root cause is still under investigation.

