### PR TITLE
Ignore: ✏️ Add Send Message Headers to the Error Message

### DIFF
--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/WebSocketGlobalExceptionHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/WebSocketGlobalExceptionHandler.java
@@ -1,16 +1,22 @@
 package kr.co.pennyway.socket.common.exception;
 
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import kr.co.pennyway.common.exception.GlobalErrorException;
+import kr.co.pennyway.common.exception.ReasonCode;
+import kr.co.pennyway.common.exception.StatusCode;
 import kr.co.pennyway.socket.common.dto.ServerSideMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.security.Principal;
-import java.util.Map;
+
+import static kr.co.pennyway.common.exception.ReasonCode.TYPE_MISMATCH_ERROR_IN_REQUEST_BODY;
 
 /**
  * 비지니스 예외를 처리하는 전역 핸들러.
@@ -20,36 +26,57 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class WebSocketGlobalExceptionHandler {
     private static final String ERROR_DESTINATION = "/queue/errors";
-    private static final String MESSAGE_ID = "message-id";
 
     private final SimpMessagingTemplate template;
 
     @MessageExceptionHandler(GlobalErrorException.class)
-    public void handleGlobalErrorException(Principal principal, StompHeaderAccessor accessor, GlobalErrorException ex) {
-        ServerSideMessage serverSideMessage = ServerSideMessage.of(ex.causedBy().getCode(), ex.getBaseErrorCode().getExplainError());
+    public void handleGlobalErrorException(Principal principal, StompHeaderAccessor accessor, GlobalErrorException e) {
+        ServerSideMessage serverSideMessage = ServerSideMessage.of(e.causedBy().getCode(), e.getBaseErrorCode().getExplainError());
         log.warn("handleGlobalErrorException: {}", serverSideMessage);
 
-        sendErrorMessage(principal, serverSideMessage, accessor.getFirstNativeHeader(MESSAGE_ID));
+        sendErrorMessage(principal, serverSideMessage, accessor);
+    }
+
+    @MessageExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public void handleMethodArgumentTypeMismatchException(Principal principal, StompHeaderAccessor accessor, MethodArgumentTypeMismatchException e) {
+        String code = String.valueOf(StatusCode.UNPROCESSABLE_CONTENT.getCode() * 10 + TYPE_MISMATCH_ERROR_IN_REQUEST_BODY.getCode());
+        ServerSideMessage serverSideMessage = ServerSideMessage.of(code, e.getMessage());
+        log.warn("handleMethodArgumentTypeMismatchException: {}", serverSideMessage);
+
+        sendErrorMessage(principal, serverSideMessage, accessor);
+    }
+
+    @MessageExceptionHandler(HttpMessageNotReadableException.class)
+    public void handleHttpMessageNotReadableException(Principal principal, StompHeaderAccessor accessor, HttpMessageNotReadableException e) {
+        String code, message;
+        if (e.getCause() instanceof MismatchedInputException mismatchedInputException) {
+            code = String.valueOf(StatusCode.UNPROCESSABLE_CONTENT.getCode() * 10 + TYPE_MISMATCH_ERROR_IN_REQUEST_BODY.getCode());
+            message = mismatchedInputException.getPath().get(0).getFieldName() + " 필드의 값이 유효하지 않습니다.";
+        } else {
+            code = String.valueOf(StatusCode.BAD_REQUEST.getCode() * 10 + ReasonCode.MALFORMED_REQUEST_BODY.getCode());
+            message = e.getMessage();
+        }
+
+        ServerSideMessage serverSideMessage = ServerSideMessage.of(code, message);
+        log.warn("handleHttpMessageNotReadableException: {}", serverSideMessage);
+
+        sendErrorMessage(principal, serverSideMessage, accessor);
     }
 
     @MessageExceptionHandler(Exception.class)
-    public void handleException(Principal principal, StompHeaderAccessor accessor, Exception ex) {
-        ServerSideMessage serverSideMessage = ServerSideMessage.of("5000", ex.getMessage());
+    public void handleException(Principal principal, StompHeaderAccessor accessor, Exception e) {
+        ServerSideMessage serverSideMessage = ServerSideMessage.of("5000", e.getMessage());
         log.error("handleException: {}", serverSideMessage);
 
-        sendErrorMessage(principal, serverSideMessage, accessor.getFirstNativeHeader(MESSAGE_ID));
+        sendErrorMessage(principal, serverSideMessage, accessor);
     }
 
-    private void sendErrorMessage(Principal principal, ServerSideMessage serverSideMessage, String messageId) {
+    private void sendErrorMessage(Principal principal, ServerSideMessage serverSideMessage, StompHeaderAccessor accessor) {
         if (principal == null) {
             log.warn("예외 메시지를 반환할 사용자가 없습니다.");
             return;
         }
 
-        if (messageId == null) {
-            template.convertAndSendToUser(principal.getName(), ERROR_DESTINATION, serverSideMessage);
-        } else {
-            template.convertAndSendToUser(principal.getName(), ERROR_DESTINATION, serverSideMessage, Map.of(MESSAGE_ID, messageId));
-        }
+        template.convertAndSendToUser(principal.getName(), ERROR_DESTINATION, serverSideMessage, accessor.getMessageHeaders());
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/WebSocketGlobalExceptionHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/WebSocketGlobalExceptionHandler.java
@@ -27,4 +27,16 @@ public class WebSocketGlobalExceptionHandler {
 
         template.convertAndSendToUser(principal.getName(), ERROR_DESTINATION, serverSideMessage);
     }
+
+    @MessageExceptionHandler(Exception.class)
+    public void handleException(Principal principal, Exception ex) {
+        ServerSideMessage serverSideMessage = ServerSideMessage.of("5000", ex.getMessage());
+        log.error("handleException: {}", serverSideMessage);
+
+        if (principal != null) {
+            template.convertAndSendToUser(principal.getName(), ERROR_DESTINATION, serverSideMessage);
+        } else {
+            log.warn("예외 메시지를 반환할 사용자가 없습니다.");
+        }
+    }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/WebSocketGlobalExceptionHandler.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/exception/WebSocketGlobalExceptionHandler.java
@@ -6,9 +6,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
 import java.security.Principal;
+import java.util.Map;
 
 /**
  * 비지니스 예외를 처리하는 전역 핸들러.
@@ -18,25 +20,36 @@ import java.security.Principal;
 @RequiredArgsConstructor
 public class WebSocketGlobalExceptionHandler {
     private static final String ERROR_DESTINATION = "/queue/errors";
+    private static final String MESSAGE_ID = "message-id";
+
     private final SimpMessagingTemplate template;
 
     @MessageExceptionHandler(GlobalErrorException.class)
-    public void handleGlobalErrorException(Principal principal, GlobalErrorException ex) {
+    public void handleGlobalErrorException(Principal principal, StompHeaderAccessor accessor, GlobalErrorException ex) {
         ServerSideMessage serverSideMessage = ServerSideMessage.of(ex.causedBy().getCode(), ex.getBaseErrorCode().getExplainError());
         log.warn("handleGlobalErrorException: {}", serverSideMessage);
 
-        template.convertAndSendToUser(principal.getName(), ERROR_DESTINATION, serverSideMessage);
+        sendErrorMessage(principal, serverSideMessage, accessor.getFirstNativeHeader(MESSAGE_ID));
     }
 
     @MessageExceptionHandler(Exception.class)
-    public void handleException(Principal principal, Exception ex) {
+    public void handleException(Principal principal, StompHeaderAccessor accessor, Exception ex) {
         ServerSideMessage serverSideMessage = ServerSideMessage.of("5000", ex.getMessage());
         log.error("handleException: {}", serverSideMessage);
 
-        if (principal != null) {
+        sendErrorMessage(principal, serverSideMessage, accessor.getFirstNativeHeader(MESSAGE_ID));
+    }
+
+    private void sendErrorMessage(Principal principal, ServerSideMessage serverSideMessage, String messageId) {
+        if (principal == null) {
+            log.warn("예외 메시지를 반환할 사용자가 없습니다.");
+            return;
+        }
+
+        if (messageId == null) {
             template.convertAndSendToUser(principal.getName(), ERROR_DESTINATION, serverSideMessage);
         } else {
-            log.warn("예외 메시지를 반환할 사용자가 없습니다.");
+            template.convertAndSendToUser(principal.getName(), ERROR_DESTINATION, serverSideMessage, Map.of(MESSAGE_ID, messageId));
         }
     }
 }


### PR DESCRIPTION
## 작업 이유
When a client's message is rejected for some reason, the client cannot handle the issue effectively.  
For example, if the client receives an "unauthenticated" error after sending a chat message, it must resend the message to the server.  
However, since the client cannot identify which message failed, we need to include a message identifier.  

<br/>

## 작업 사항
- When a business error occurs, the server sends an error message that includes the message's headers.
- If the client adds the `x-message-id` field to the header, they will be able to identify the specific message.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- Is the exception handling implemented correctly?

<br/>

## 발견한 이슈
- When a `@Validated` error occurs, it isn't handled by `HttpMessageNotReadableException.class`; instead, it is caught by `Exception.class`
- After converting `PreAuthorizeAspect` from Java to Kotlin, it throws a `joinPoint.proceed() cannot null` error.   

