### PR TITLE
Socket: 🔧 The server sends a success message after a chat message is saved successfully

### DIFF
--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/command/SendMessageCommand.java
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/command/SendMessageCommand.java
@@ -4,6 +4,8 @@ import kr.co.pennyway.domain.domains.message.type.MessageCategoryType;
 import kr.co.pennyway.domain.domains.message.type.MessageContentType;
 import kr.co.pennyway.socket.common.constants.SystemMessageConstants;
 
+import java.util.Map;
+
 /**
  * 채팅 메시지 전송을 위한 Command 클래스
  */
@@ -12,7 +14,9 @@ public record SendMessageCommand(
         String content,
         MessageContentType contentType,
         MessageCategoryType categoryType,
-        long senderId
+        long senderId,
+        String senderName,
+        Map<String, Object> messageIdHeader
 ) {
     public SendMessageCommand {
         if (chatRoomId <= 0) {
@@ -45,26 +49,32 @@ public record SendMessageCommand(
                 content,
                 MessageContentType.TEXT,
                 MessageCategoryType.SYSTEM,
-                SystemMessageConstants.SYSTEM_SENDER_ID
+                SystemMessageConstants.SYSTEM_SENDER_ID,
+                null,
+                null
         );
     }
 
     /**
      * 사용자 메시지를 생성합니다.
      *
-     * @param chatRoomId  long : 채팅방 아이디
-     * @param content     String : 메시지 내용
-     * @param contentType {@link MessageContentType} : 메시지 타입
-     * @param senderId    long : 발신자 아이디
+     * @param chatRoomId      long : 채팅방 아이디
+     * @param content         String : 메시지 내용
+     * @param contentType     {@link MessageContentType} : 메시지 타입
+     * @param senderId        long : 발신자 아이디
+     * @param senderName      String : 발신자 이름
+     * @param messageIdHeader Map<String, String> : `x-message-id` 헤더. null일 경우 성공 메시지를 반환하지 않음.
      * @return {@link MessageCategoryType#NORMAL}로 생성된 SendMessageCommand
      */
-    public static SendMessageCommand createUserMessage(long chatRoomId, String content, MessageContentType contentType, long senderId) {
+    public static SendMessageCommand createUserMessage(long chatRoomId, String content, MessageContentType contentType, long senderId, String senderName, Map<String, Object> messageIdHeader) {
         return new SendMessageCommand(
                 chatRoomId,
                 content,
                 contentType,
                 MessageCategoryType.NORMAL,
-                senderId
+                senderId,
+                senderName,
+                messageIdHeader
         );
     }
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.kt
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.kt
@@ -7,7 +7,9 @@ import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal
 import kr.co.pennyway.socket.service.ChatMessageSendService
 import kr.co.pennyway.socket.service.LastMessageIdSaveService
 import org.springframework.messaging.handler.annotation.DestinationVariable
+import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
 import org.springframework.stereotype.Controller
 import org.springframework.validation.annotation.Validated
 
@@ -26,14 +28,17 @@ class ChatMessageController(
     fun sendMessage(
         @DestinationVariable chatRoomId: Long,
         @Validated payload: ChatMessageDto.Request,
-        principal: UserPrincipal
+        principal: UserPrincipal,
+        @Header("x-message-id") messageId: StompHeaderAccessor?
     ) {
         chatMessageSendService.execute(
             SendMessageCommand.createUserMessage(
                 chatRoomId,
                 payload.content(),
                 payload.contentType(),
-                principal.userId
+                principal.userId,
+                principal.name,
+                messageId?.let { mapOf("x-message-id" to it) }
             )
         )
     }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.kt
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/controller/ChatMessageController.kt
@@ -9,7 +9,6 @@ import kr.co.pennyway.socket.service.LastMessageIdSaveService
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.handler.annotation.MessageMapping
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor
 import org.springframework.stereotype.Controller
 import org.springframework.validation.annotation.Validated
 
@@ -29,7 +28,7 @@ class ChatMessageController(
         @DestinationVariable chatRoomId: Long,
         @Validated payload: ChatMessageDto.Request,
         principal: UserPrincipal,
-        @Header("x-message-id") messageId: StompHeaderAccessor?
+        @Header("x-message-id") messageId: String?
     ) {
         chatMessageSendService.execute(
             SendMessageCommand.createUserMessage(

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.kt
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.kt
@@ -8,6 +8,7 @@ import kr.co.pennyway.infra.common.properties.ChatExchangeProperties
 import kr.co.pennyway.socket.command.SendMessageCommand
 import kr.co.pennyway.socket.common.dto.ChatMessageDto
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Component
 
 @Component
@@ -16,7 +17,8 @@ class ChatMessageSendService(
     private val chatMessageService: ChatMessageService,
     private val messageBrokerAdapter: MessageBrokerAdapter,
     private val idGenerator: IdGenerator<Long>,
-    private val chatExchangeProperties: ChatExchangeProperties
+    private val chatExchangeProperties: ChatExchangeProperties,
+    private val simpMessagingTemplate: SimpMessagingTemplate
 ) {
     /**
      * 채팅 메시지를 전송한다.
@@ -24,20 +26,33 @@ class ChatMessageSendService(
      * @param command SendMessageCommand : 채팅 메시지 전송을 위한 Command
      */
     fun execute(command: SendMessageCommand) {
-        val message = ChatMessageBuilder.builder()
-            .chatRoomId(command.chatRoomId())
-            .chatId(idGenerator.generate())
-            .content(command.content())
-            .contentType(command.contentType())
-            .categoryType(command.categoryType())
-            .sender(command.senderId())
-            .build()
+        val message = command.toChatMessage(command)
             .let { chatMessageService.create(it) }
 
-        messageBrokerAdapter.convertAndSend(
-            chatExchangeProperties.exchange,
-            "chat.room.${command.chatRoomId()}",
-            ChatMessageDto.Response.from(message)
-        )
+        with(chatExchangeProperties) {
+            messageBrokerAdapter.convertAndSend(
+                exchange,
+                "chat.room.${command.chatRoomId}",
+                ChatMessageDto.Response.from(message)
+            )
+        }
+        
+        command.senderName.takeIf { it.isNotBlank() }?.let { senderName ->
+            simpMessagingTemplate.convertAndSendToUser(
+                senderName,
+                "/queue/chat/success",
+                message,
+                command.messageIdHeader()
+            )
+        }
     }
+
+    private fun SendMessageCommand.toChatMessage(command: SendMessageCommand) = ChatMessageBuilder.builder()
+        .chatRoomId(command.chatRoomId())
+        .chatId(idGenerator.generate())
+        .content(command.content())
+        .contentType(command.contentType())
+        .categoryType(command.categoryType())
+        .sender(command.senderId())
+        .build()
 }

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.kt
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.kt
@@ -36,12 +36,12 @@ class ChatMessageSendService(
                 ChatMessageDto.Response.from(message)
             )
         }
-        
+
         command.senderName.takeIf { it.isNotBlank() }?.let { senderName ->
             simpMessagingTemplate.convertAndSendToUser(
                 senderName,
-                "/queue/chat/success",
-                message,
+                "/queue/success",
+                Unit,
                 command.messageIdHeader()
             )
         }


### PR DESCRIPTION
## 작업 이유
- We improved error messages in #212, but the client still can't handle success messages.  
- Therefore, we need to send a message to notify the client when their chat message is successfully processed.

<br/>

## 작업 사항
![image](https://github.com/user-attachments/assets/a3d2f655-7dc9-489c-8a0e-54df38d960fe)

- The server sends a message that includes `x-message-id` to `success queue` after the chat message is successfully published.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- Since I am not very experienced with Kotlin, please review the code style.

<br/>

## 발견한 이슈
- When the client tries to subscribe, if the receipt header is missing, the server throws an error. 😅

