### PR TITLE
Ignore: ✨ Leave Chat Room API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -62,4 +62,15 @@ public interface ChatMemberApi {
     })
     @ApiResponse(responseCode = "200", description = "채팅방 멤버 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatMembers", array = @ArraySchema(schema = @Schema(implementation = ChatMemberRes.MemberDetail.class)))))
     ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotEmpty @RequestParam("ids") Set<Long> ids);
+
+    @Operation(summary = "채팅방 멤버 탈퇴", method = "DELETE", description = "채팅방에서 탈퇴한다. 채팅방장은 채팅 멤버가 한 명이라도 남아있으면 탈퇴할 수 없으며, 채팅방장이 탈퇴할 경우 채팅방이 삭제된다.")
+    @Parameters({
+            @Parameter(name = "chatRoomId", description = "채팅방 ID", required = true, in = ParameterIn.PATH),
+            @Parameter(name = "chatMemberId", description = "채팅방 멤버 ID (user id가 아님)", required = true, in = ParameterIn.PATH)
+    })
+    @ApiResponseExplanations(errors = {
+            @ApiExceptionExplanation(value = ChatRoomErrorCode.class, constant = "ADMIN_CANNOT_LEAVE", summary = "채팅방장은 탈퇴할 수 없음", description = "채팅방장은 채팅방 멤버 탈퇴에 실패했습니다.")}
+    )
+    @ApiResponse(responseCode = "200", description = "채팅방 멤버 탈퇴 성공")
+    ResponseEntity<?> leaveChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @PathVariable("chatMemberId") Long chatMemberId);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -52,4 +52,12 @@ public class ChatMemberController implements ChatMemberApi {
 
         return ResponseEntity.ok(SuccessResponse.from(CHAT_MEMBERS, chatMemberUseCase.readChatMembers(chatRoomId, chatMemberIds)));
     }
+
+    @DeleteMapping("/{chatMemberId}")
+    @PreAuthorize("isAuthenticated() and @chatRoomManager.hasPermission(principal.userId, #chatRoomId, #chatMemberId)")
+    public ResponseEntity<?> leaveChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @PathVariable("chatMemberId") Long chatMemberId) {
+        chatMemberUseCase.leaveChatRoom(chatMemberId);
+
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -53,6 +53,7 @@ public class ChatMemberController implements ChatMemberApi {
         return ResponseEntity.ok(SuccessResponse.from(CHAT_MEMBERS, chatMemberUseCase.readChatMembers(chatRoomId, chatMemberIds)));
     }
 
+    @Override
     @DeleteMapping("/{chatMemberId}")
     @PreAuthorize("isAuthenticated() and @chatRoomManager.hasPermission(principal.userId, #chatRoomId, #chatMemberId)")
     public ResponseEntity<?> leaveChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @PathVariable("chatMemberId") Long chatMemberId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -7,6 +7,7 @@ import kr.co.pennyway.api.apis.chat.mapper.ChatRoomMapper;
 import kr.co.pennyway.api.apis.chat.service.ChatMemberJoinService;
 import kr.co.pennyway.api.apis.chat.service.ChatMemberSearchService;
 import kr.co.pennyway.common.annotation.UseCase;
+import kr.co.pennyway.domain.context.chat.service.ChatRoomLeaveService;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import java.util.Set;
 public class ChatMemberUseCase {
     private final ChatMemberJoinService chatMemberJoinService;
     private final ChatMemberSearchService chatMemberSearchService;
+    private final ChatRoomLeaveService chatRoomLeaveService;
 
     public ChatRoomRes.Detail joinChatRoom(Long userId, Long chatRoomId, Integer password) {
         Triple<ChatRoom, Integer, Long> chatRoom = chatMemberJoinService.execute(userId, chatRoomId, password);
@@ -33,5 +35,9 @@ public class ChatMemberUseCase {
         List<ChatMemberResult.Detail> chatMembers = chatMemberSearchService.readChatMembers(chatRoomId, chatMemberIds);
 
         return ChatMemberMapper.toChatMemberResDetail(chatMembers);
+    }
+
+    public void leaveChatRoom(Long chatMemberId) {
+        chatRoomLeaveService.execute(chatMemberId);
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/ChatRoomManager.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/security/authorization/ChatRoomManager.java
@@ -19,4 +19,12 @@ public class ChatRoomManager {
     public boolean hasPermission(Long userId, Long chatRoomId) {
         return chatMemberService.isExists(chatRoomId, userId);
     }
+
+    /**
+     * 사용자가 채팅방과 특정 멤버에 대한 접근 권한이 있는지 확인한다.
+     */
+    @Transactional(readOnly = true)
+    public boolean hasPermission(Long userId, Long chatRoomId, Long chatMemberId) {
+        return chatMemberService.isExists(chatRoomId, userId, chatMemberId);
+    }
 }

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/chatroom/domain/ChatRoom.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/chatroom/domain/ChatRoom.java
@@ -2,12 +2,15 @@ package kr.co.pennyway.domain.domains.chatroom.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import kr.co.pennyway.domain.common.model.DateAuditable;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.SQLDelete;
@@ -15,6 +18,7 @@ import org.hibernate.annotations.SQLRestriction;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -35,6 +39,9 @@ public class ChatRoom extends DateAuditable {
 
     @ColumnDefault("NULL")
     private LocalDateTime deletedAt;
+
+    @OneToMany(mappedBy = "chatRoom")
+    private List<ChatMember> chatMembers;
 
     @Builder
     public ChatRoom(Long id, String title, String description, String backgroundImageUrl, Integer password) {
@@ -82,6 +89,10 @@ public class ChatRoom extends DateAuditable {
 
     public boolean matchPassword(Integer password) {
         return this.password.equals(password);
+    }
+
+    public boolean hasOnlyAdmin() {
+        return Hibernate.size(chatMembers) == 1 && chatMembers.get(0).isAdmin();
     }
 
     @Override

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/chatroom/domain/ChatRoom.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/chatroom/domain/ChatRoom.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.SQLRestriction;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -41,7 +42,7 @@ public class ChatRoom extends DateAuditable {
     private LocalDateTime deletedAt;
 
     @OneToMany(mappedBy = "chatRoom")
-    private List<ChatMember> chatMembers;
+    private List<ChatMember> chatMembers = new ArrayList<>();
 
     @Builder
     public ChatRoom(Long id, String title, String description, String backgroundImageUrl, Integer password) {

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/chatroom/service/ChatRoomRdbService.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/chatroom/service/ChatRoomRdbService.java
@@ -38,4 +38,9 @@ public class ChatRoomRdbService {
     public Slice<ChatRoomDetail> readChatRooms(Long userId, String target, Pageable pageable) {
         return chatRoomRepository.findChatRooms(userId, target, pageable);
     }
+
+    @Transactional
+    public void delete(ChatRoom chatRoom) {
+        chatRoomRepository.delete(chatRoom);
+    }
 }

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -78,6 +78,10 @@ public class ChatMember extends DateAuditable {
         return deletedAt == null;
     }
 
+    public boolean isAdmin() {
+        return role.equals(ChatMemberRole.ADMIN);
+    }
+
     /**
      * 사용자 추방된 이력이 있는 지 확인한다.
      *

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -22,7 +21,6 @@ import java.util.Objects;
 @Table(name = "chat_member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
-@SQLDelete(sql = "UPDATE chat_member SET deleted_at = NOW() WHERE id = ?")
 public class ChatMember extends DateAuditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -95,6 +93,10 @@ public class ChatMember extends DateAuditable {
 
     public void disableNotify() {
         this.notifyEnabled = false;
+    }
+
+    public void leave() {
+        this.deletedAt = LocalDateTime.now();
     }
 
     public void ban() {

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -50,7 +50,7 @@ public class ChatMember extends DateAuditable {
         validate(user, chatRoom, role);
 
         this.user = user;
-        this.chatRoom = chatRoom;
+        this.participate(chatRoom);
         this.role = role;
         this.notifyEnabled = true;
     }
@@ -67,6 +67,15 @@ public class ChatMember extends DateAuditable {
         Objects.requireNonNull(user, "user는 null이 될 수 없습니다.");
         Objects.requireNonNull(chatRoom, "chatRoom은 null이 될 수 없습니다.");
         Objects.requireNonNull(role, "role은 null이 될 수 없습니다.");
+    }
+
+    private void participate(ChatRoom chatRoom) {
+        if (this.chatRoom != null) {
+            throw new IllegalStateException("ChatMember는 이미 ChatRoom에 속해있습니다.");
+        }
+
+        chatRoom.getChatMembers().add(this);
+        this.chatRoom = chatRoom;
     }
 
     /**

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/exception/ChatMemberErrorCode.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/exception/ChatMemberErrorCode.java
@@ -15,6 +15,7 @@ public enum ChatMemberErrorCode implements BaseErrorCode {
     NOT_FOUND(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "회원을 찾을 수 없습니다."),
 
     /* 409 Conflict */
+    ADMIN_CANNOT_LEAVE(StatusCode.CONFLICT, ReasonCode.REQUEST_CONFLICTS_WITH_CURRENT_STATE_OF_RESOURCE, "채팅방에 사용자가 남아 있다면, 채팅방 방장은 채팅방을 탈퇴할 수 없습니다."),
     ALREADY_JOINED(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 가입한 회원입니다."),
     ;
 

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
@@ -22,8 +22,8 @@ public interface ChatMemberRepository extends ExtendedRepository<ChatMember, Lon
     List<ChatMember> findByChatRoom_IdAndIdIn(Long chatRoomId, Set<Long> chatMemberIds);
 
     @Transactional(readOnly = true)
-    @Query("SELECT cm FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.id = :chatMemberId")
-    Optional<ChatMember> findByChatRoom_IdAndId(Long chatRoomId, Long chatMemberId);
+    @Query("SELECT cm FROM ChatMember cm WHERE cm.id = :chatMemberId")
+    Optional<ChatMember> findByChatRoom_Id(Long chatMemberId);
 
     @Transactional(readOnly = true)
     @Query("SELECT cm FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.user.id = :userId AND cm.deletedAt IS NULL")

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/repository/ChatMemberRepository.java
@@ -22,6 +22,10 @@ public interface ChatMemberRepository extends ExtendedRepository<ChatMember, Lon
     List<ChatMember> findByChatRoom_IdAndIdIn(Long chatRoomId, Set<Long> chatMemberIds);
 
     @Transactional(readOnly = true)
+    @Query("SELECT cm FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.id = :chatMemberId")
+    Optional<ChatMember> findByChatRoom_IdAndId(Long chatRoomId, Long chatMemberId);
+
+    @Transactional(readOnly = true)
     @Query("SELECT cm FROM ChatMember cm WHERE cm.chatRoom.id = :chatRoomId AND cm.user.id = :userId AND cm.deletedAt IS NULL")
     Optional<ChatMember> findActiveChatMember(Long chatRoomId, Long userId);
 

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepository.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepository.java
@@ -16,6 +16,8 @@ public interface CustomChatMemberRepository {
      */
     boolean existsOwnershipChatRoomByUserId(Long userId);
 
+    boolean existsByChatRoomIdAndUserIdAndId(Long chatRoomId, Long userId, Long chatMemberId);
+
     /**
      * 채팅방의 관리자 정보를 조회한다.
      */

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepositoryImpl.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/repository/CustomChatMemberRepositoryImpl.java
@@ -39,6 +39,17 @@ public class CustomChatMemberRepositoryImpl implements CustomChatMemberRepositor
     }
 
     @Override
+    public boolean existsByChatRoomIdAndUserIdAndId(Long chatRoomId, Long userId, Long chatMemberId) {
+        return queryFactory.select(ConstantImpl.create(1))
+                .from(chatMember)
+                .where(chatMember.chatRoom.id.eq(chatRoomId)
+                        .and(chatMember.user.id.eq(userId))
+                        .and(chatMember.id.eq(chatMemberId))
+                        .and(chatMember.deletedAt.isNull()))
+                .fetchFirst() != null;
+    }
+
+    @Override
     public Optional<ChatMemberResult.Detail> findAdminByChatRoomId(Long chatRoomId) {
         ChatMemberResult.Detail result =
                 queryFactory.select(

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
@@ -137,4 +137,9 @@ public class ChatMemberRdbService {
     public long countActiveMembers(Long chatRoomId) {
         return chatMemberRepository.countByChatRoomIdAndActive(chatRoomId);
     }
+
+    @Transactional
+    public void delete(ChatMember chatMember) {
+        chatMemberRepository.delete(chatMember);
+    }
 }

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
@@ -144,7 +144,7 @@ public class ChatMemberRdbService {
     }
 
     @Transactional
-    public void delete(ChatMember chatMember) {
-        chatMemberRepository.delete(chatMember);
+    public void update(ChatMember chatMember) {
+        chatMemberRepository.save(chatMember);
     }
 }

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
@@ -53,6 +53,11 @@ public class ChatMemberRdbService {
     }
 
     @Transactional(readOnly = true)
+    public Optional<ChatMember> readChatMemberByChatMemberId(Long chatMemberId, Long chatRoomId) {
+        return chatMemberRepository.findByChatRoom_IdAndId(chatRoomId, chatMemberId);
+    }
+
+    @Transactional(readOnly = true)
     public Optional<ChatMember> readChatMember(Long userId, Long chatRoomId) {
         return chatMemberRepository.findActiveChatMember(chatRoomId, userId).stream().findFirst();
     }

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
@@ -133,6 +133,14 @@ public class ChatMemberRdbService {
         return chatMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId);
     }
 
+    /**
+     * 삭제된 사용자 데이터는 조회하지 않는다.
+     */
+    @Transactional(readOnly = true)
+    public boolean isExists(Long chatRoomId, Long userId, Long chatMemberId) {
+        return chatMemberRepository.existsByChatRoomIdAndUserIdAndId(chatRoomId, userId, chatMemberId);
+    }
+
     @Transactional(readOnly = true)
     public boolean hasUserChatRoomOwnership(Long userId) {
         return chatMemberRepository.existsOwnershipChatRoomByUserId(userId);

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/service/ChatMemberRdbService.java
@@ -53,8 +53,8 @@ public class ChatMemberRdbService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<ChatMember> readChatMemberByChatMemberId(Long chatMemberId, Long chatRoomId) {
-        return chatMemberRepository.findByChatRoom_IdAndId(chatRoomId, chatMemberId);
+    public Optional<ChatMember> readChatMemberByChatMemberId(Long chatMemberId) {
+        return chatMemberRepository.findByChatRoom_Id(chatMemberId);
     }
 
     @Transactional(readOnly = true)

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomLeaveCollection.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomLeaveCollection.java
@@ -1,0 +1,62 @@
+package kr.co.pennyway.domain.context.chat.collection;
+
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ChatRoomLeaveCollection {
+    private final ChatMember chatMember;
+
+    public ChatRoomLeaveCollection(ChatMember chatMember) {
+        this.chatMember = chatMember;
+    }
+
+    /**
+     * 채팅방 멤버의 퇴장을 처리합니다.
+     *
+     * <pre>
+     * [비즈니스 규칙]
+     * - 방장(admin)과 일반 멤버는 서로 다른 퇴장 규칙을 따릅니다.
+     * - 방장은 자신만 채팅방에 남아있는 경우에만 퇴장할 수 있습니다.
+     * - 방장이 퇴장하면 채팅방도 함께 삭제됩니다.
+     * - 일반 멤버는 언제든지 퇴장할 수 있습니다.
+     * </pre>
+     *
+     * @return ChatRoomLeaveResult 퇴장 처리 결과 (채팅방 삭제 여부 포함)
+     * @throws ChatMemberErrorException {@link ChatMemberErrorCode#ADMIN_CANNOT_LEAVE} : 다른 멤버가 있는 상태에서 방장이 퇴장을 시도하는 경우
+     */
+    public ChatRoomLeaveResult leave() {
+        if (!chatMember.isAdmin()) {
+            return handleMemberLeave();
+        }
+
+        return handleAdminLeave();
+    }
+
+    private ChatRoomLeaveResult handleAdminLeave() {
+        ChatRoom chatRoom = chatMember.getChatRoom();
+        if (!chatRoom.hasOnlyAdmin()) {
+            log.warn("채팅방에 사용자가 남아 있다면, 채팅방 방장은 채팅방을 탈퇴할 수 없습니다. chatRoomId: {}, chatMemberId: {}",
+                    chatRoom.getId(), chatMember.getId());
+            throw new ChatMemberErrorException(ChatMemberErrorCode.ADMIN_CANNOT_LEAVE);
+        }
+
+        chatMember.leave();
+        log.info("채팅방 방장이 채팅방을 탈퇴합니다. chatRoom: {}, chatMember: {}", chatRoom, chatMember);
+        return new ChatRoomLeaveResult(chatMember, true);
+    }
+
+    private ChatRoomLeaveResult handleMemberLeave() {
+        chatMember.leave();
+        return new ChatRoomLeaveResult(chatMember, false);
+    }
+
+    public record ChatRoomLeaveResult(
+            ChatMember chatMember,
+            boolean shouldDeleteChatRoom
+    ) {
+    }
+}

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomLeaveCollection.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomLeaveCollection.java
@@ -51,6 +51,7 @@ public class ChatRoomLeaveCollection {
 
     private ChatRoomLeaveResult handleMemberLeave() {
         chatMember.leave();
+        log.info("채팅방 멤버가 채팅방을 탈퇴합니다. chatRoom: {}, chatMember: {}", chatMember.getChatRoom(), chatMember);
         return new ChatRoomLeaveResult(chatMember, false);
     }
 

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatMemberService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatMemberService.java
@@ -74,6 +74,14 @@ public class ChatMemberService {
         return chatMemberRdbService.isExists(chatRoomId, userId);
     }
 
+    /**
+     * 삭제된 사용자 데이터는 조회하지 않는다.
+     */
+    @Transactional(readOnly = true)
+    public boolean isExists(Long chatRoomId, Long userId, Long chatMemberId) {
+        return chatMemberRdbService.isExists(chatRoomId, userId, chatMemberId);
+    }
+
     @Transactional(readOnly = true)
     public boolean hasUserChatRoomOwnership(Long userId) {
         return chatMemberRdbService.hasUserChatRoomOwnership(userId);

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomLeaveService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomLeaveService.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.domain.context.chat.service;
 
 import kr.co.pennyway.common.annotation.DomainService;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomRdbService;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChatRoomLeaveService {
     private final ChatMemberRdbService chatMemberRdbService;
+    private final ChatRoomRdbService chatRoomRdbService;
 
     @Transactional
     public void execute(Long chatMemberId) {
@@ -32,7 +34,7 @@ public class ChatRoomLeaveService {
             if (chatRoom.hasOnlyAdmin()) {
                 chatMember.leave();
                 chatMemberRdbService.update(chatMember);
-                chatMemberRdbService.delete(chatRoom);
+                chatRoomRdbService.delete(chatRoom);
             } else {
                 log.warn("채팅방 방장은 채팅방을 탈퇴할 수 없습니다. chatRoomId: {}, chatMemberId: {}", chatRoom.getId(), chatMemberId);
                 throw new ChatMemberErrorException(ChatMemberErrorCode.ADMIN_CANNOT_LEAVE);

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomLeaveService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomLeaveService.java
@@ -1,0 +1,29 @@
+package kr.co.pennyway.domain.context.chat.service;
+
+import kr.co.pennyway.common.annotation.DomainService;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberRdbService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@DomainService
+@RequiredArgsConstructor
+public class ChatRoomLeaveService {
+    private final ChatMemberRdbService chatMemberRdbService;
+
+    @Transactional
+    public void execute(Long chatMemberId) {
+        ChatMember chatMember = chatMemberRdbService.readChatMemberByChatMemberId(chatMemberId)
+                .orElseThrow(() -> {
+                    log.warn("채팅방 멤버를 찾을 수 없습니다. chatMemberId: {}", chatMemberId);
+                    return new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND);
+                });
+
+        chatMember.leave();
+        chatMemberRdbService.update(chatMember);
+    }
+}

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomLeaveService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomLeaveService.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.domain.context.chat.service;
 
 import kr.co.pennyway.common.annotation.DomainService;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
@@ -22,6 +23,21 @@ public class ChatRoomLeaveService {
                     log.warn("채팅방 멤버를 찾을 수 없습니다. chatMemberId: {}", chatMemberId);
                     return new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND);
                 });
+
+        // 방장이면 채팅방에 자신만 남아있어야 하고, 그렇지 않으면 예외를 던진다.
+        // 만약 삭제 가능하다면, 방장을 탈퇴시키고 채팅방을 삭제한다.
+        if (chatMember.isAdmin()) {
+            ChatRoom chatRoom = chatMember.getChatRoom();
+
+            if (chatRoom.hasOnlyAdmin()) {
+                chatMember.leave();
+                chatMemberRdbService.update(chatMember);
+                chatMemberRdbService.delete(chatRoom);
+            } else {
+                log.warn("채팅방 방장은 채팅방을 탈퇴할 수 없습니다. chatRoomId: {}, chatMemberId: {}", chatRoom.getId(), chatMemberId);
+                throw new ChatMemberErrorException(ChatMemberErrorCode.ADMIN_CANNOT_LEAVE);
+            }
+        }
 
         chatMember.leave();
         chatMemberRdbService.update(chatMember);

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomLeaveService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomLeaveService.java
@@ -1,7 +1,7 @@
 package kr.co.pennyway.domain.context.chat.service;
 
 import kr.co.pennyway.common.annotation.DomainService;
-import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.context.chat.collection.ChatRoomLeaveCollection;
 import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomRdbService;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
@@ -26,22 +26,11 @@ public class ChatRoomLeaveService {
                     return new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND);
                 });
 
-        // 방장이면 채팅방에 자신만 남아있어야 하고, 그렇지 않으면 예외를 던진다.
-        // 만약 삭제 가능하다면, 방장을 탈퇴시키고 채팅방을 삭제한다.
-        if (chatMember.isAdmin()) {
-            ChatRoom chatRoom = chatMember.getChatRoom();
+        var result = new ChatRoomLeaveCollection(chatMember).leave();
 
-            if (chatRoom.hasOnlyAdmin()) {
-                chatMember.leave();
-                chatMemberRdbService.update(chatMember);
-                chatRoomRdbService.delete(chatRoom);
-            } else {
-                log.warn("채팅방 방장은 채팅방을 탈퇴할 수 없습니다. chatRoomId: {}, chatMemberId: {}", chatRoom.getId(), chatMemberId);
-                throw new ChatMemberErrorException(ChatMemberErrorCode.ADMIN_CANNOT_LEAVE);
-            }
+        chatMemberRdbService.update(result.chatMember());
+        if (result.shouldDeleteChatRoom()) {
+            chatRoomRdbService.delete(chatMember.getChatRoom());
         }
-
-        chatMember.leave();
-        chatMemberRdbService.update(chatMember);
     }
 }

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomLeaveCollectionTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomLeaveCollectionTest.java
@@ -1,0 +1,76 @@
+package kr.co.pennyway.domain.context.chat.collection;
+
+import kr.co.pennyway.domain.context.common.fixture.ChatRoomFixture;
+import kr.co.pennyway.domain.context.common.fixture.UserFixture;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ChatRoomLeaveCollectionTest {
+    @Test
+    @DisplayName("일반 멤버는 언제든지 퇴장할 수 있다")
+    void normalMemberShouldBeAbleToLeaveAnytime() {
+        // given
+        User user = UserFixture.GENERAL_USER.toUser();
+        ChatRoom chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity();
+        ChatMember normalMember = ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER);
+
+        ChatRoomLeaveCollection collection = new ChatRoomLeaveCollection(normalMember);
+
+        // when
+        ChatRoomLeaveCollection.ChatRoomLeaveResult result = collection.leave();
+
+        // then
+        assertEquals(normalMember, result.chatMember());
+        assertFalse(result.shouldDeleteChatRoom());
+        assertNotNull(normalMember.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("방장이 혼자 남은 경우 퇴장할 수 있고, 채팅방이 삭제되어야 한다")
+    void adminShouldBeAbleToLeaveWhenAloneAndRoomShouldBeDeleted() {
+        // given
+        User user = UserFixture.GENERAL_USER.toUser();
+        ChatRoom chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity();
+        ChatMember adminMember = ChatMember.of(user, chatRoom, ChatMemberRole.ADMIN);
+
+        ChatRoomLeaveCollection collection = new ChatRoomLeaveCollection(adminMember);
+
+        // when
+        ChatRoomLeaveCollection.ChatRoomLeaveResult result = collection.leave();
+
+        // then
+        assertEquals(adminMember, result.chatMember());
+        assertTrue(result.shouldDeleteChatRoom());
+        assertNotNull(adminMember.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("다른 멤버가 있는 경우 방장은 퇴장할 수 없다")
+    void adminShouldNotBeAbleToLeaveWhenOtherMembersExist() {
+        // given
+        User admin = UserFixture.GENERAL_USER.toUser();
+        User normal = UserFixture.GENERAL_USER.toUser();
+        ChatRoom chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity();
+        ChatMember adminMember = ChatMember.of(admin, chatRoom, ChatMemberRole.ADMIN);
+        ChatMember normalMember = ChatMember.of(normal, chatRoom, ChatMemberRole.MEMBER);
+
+        ChatRoomLeaveCollection collection = new ChatRoomLeaveCollection(adminMember);
+
+        // when
+        assertThatThrownBy(collection::leave)
+                .isInstanceOf(ChatMemberErrorException.class)
+                .hasFieldOrPropertyWithValue("chatMemberErrorCode", ChatMemberErrorCode.ADMIN_CANNOT_LEAVE);
+
+        // then
+        assertNull(adminMember.getDeletedAt());
+    }
+}

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/integration/ChatRoomLeaveServiceIntegrationTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/integration/ChatRoomLeaveServiceIntegrationTest.java
@@ -1,0 +1,120 @@
+package kr.co.pennyway.domain.context.chat.integration;
+
+import kr.co.pennyway.domain.common.repository.ExtendedRepositoryFactory;
+import kr.co.pennyway.domain.config.DomainServiceIntegrationProfileResolver;
+import kr.co.pennyway.domain.config.DomainServiceTestInfraConfig;
+import kr.co.pennyway.domain.config.JpaTestConfig;
+import kr.co.pennyway.domain.context.chat.service.ChatRoomLeaveService;
+import kr.co.pennyway.domain.context.common.fixture.ChatRoomFixture;
+import kr.co.pennyway.domain.context.common.fixture.UserFixture;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.repository.ChatRoomRepository;
+import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomRdbService;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
+import kr.co.pennyway.domain.domains.member.repository.ChatMemberRepository;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberRdbService;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@EnableAutoConfiguration
+@SpringBootTest(classes = {ChatRoomLeaveService.class, ChatMemberRdbService.class, ChatRoomRdbService.class})
+@EntityScan(basePackageClasses = {User.class, ChatRoom.class, ChatMember.class})
+@EnableJpaRepositories(
+        basePackageClasses = {UserRepository.class, ChatRoomRepository.class, ChatMemberRepository.class},
+        repositoryFactoryBeanClass = ExtendedRepositoryFactory.class
+)
+@ActiveProfiles(resolver = DomainServiceIntegrationProfileResolver.class)
+@Import(value = {JpaTestConfig.class})
+public class ChatRoomLeaveServiceIntegrationTest extends DomainServiceTestInfraConfig {
+    @Autowired
+    private ChatRoomLeaveService chatRoomLeaveService;
+
+    @Autowired
+    private ChatMemberRepository chatMemberRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("일반 멤버가 채팅방을 나가면 멤버는 삭제되고 채팅방은 유지된다")
+    void whenNormalMemberLeaves_thenMemberIsDeletedAndRoomRemains() {
+        // given
+        User user = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntityWithId(1L));
+        ChatMember normalMember = chatMemberRepository.save(ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER));
+
+        // when
+        chatRoomLeaveService.execute(normalMember.getId());
+
+        // then
+        ChatMember deletedMember = chatMemberRepository.findById(normalMember.getId()).orElseThrow();
+        ChatRoom remainingRoom = chatRoomRepository.findById(chatRoom.getId()).orElseThrow();
+
+        assertNotNull(deletedMember.getDeletedAt());
+        assertNull(remainingRoom.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("방장이 혼자 있는 채팅방을 나가면 방장과 채팅방 모두 삭제된다")
+    void whenLastAdminLeaves_thenBothMemberAndRoomAreDeleted() {
+        // given
+        User user = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntityWithId(2L));
+        ChatMember adminMember = chatMemberRepository.save(ChatMember.of(user, chatRoom, ChatMemberRole.ADMIN));
+
+        // when
+        chatRoomLeaveService.execute(adminMember.getId());
+
+        // then
+        ChatMember deletedMember = chatMemberRepository.findById(adminMember.getId()).orElseThrow();
+        Optional<ChatRoom> deletedRoom = chatRoomRepository.findById(chatRoom.getId()); // 조회 조건에서 삭제된 데이터는 조회되지 않음
+
+        assertNotNull(deletedMember.getDeletedAt());
+        assertTrue(deletedRoom.isEmpty());
+    }
+
+    @Test
+    @DisplayName("다른 멤버가 있는 채팅방에서 방장이 나가려고 하면 예외가 발생한다")
+    void whenAdminLeavesWithOtherMembers_thenThrowsException() {
+        // given
+        User adminUser = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        User normalUser = userRepository.save(UserFixture.GENERAL_USER.toUser());
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntityWithId(3L));
+
+        ChatMember adminMember = chatMemberRepository.save(ChatMember.of(adminUser, chatRoom, ChatMemberRole.ADMIN));
+        chatMemberRepository.save(ChatMember.of(normalUser, chatRoom, ChatMemberRole.MEMBER));
+
+        // when & then
+        assertThatThrownBy(() -> chatRoomLeaveService.execute(adminMember.getId()))
+                .isInstanceOf(ChatMemberErrorException.class)
+                .hasFieldOrPropertyWithValue("chatMemberErrorCode", ChatMemberErrorCode.ADMIN_CANNOT_LEAVE);
+
+        // 상태가 변경되지 않았는지 확인
+        ChatMember unchangedMember = chatMemberRepository.findById(adminMember.getId()).orElseThrow();
+        ChatRoom unchangedRoom = chatRoomRepository.findById(chatRoom.getId()).orElseThrow();
+        assertNull(unchangedMember.getDeletedAt());
+        assertNull(unchangedRoom.getDeletedAt());
+    }
+}


### PR DESCRIPTION
## 작업 이유
- Chat members can leave a chat room.
- However, the chat room master cannot leave if at least one other member remains in the room.

<br/>

## 작업 사항
- Implemented business logic for leaving chat rooms.
- Added service unit tests.
- Added service integration tests.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- None.

<br/>

## 발견한 이슈
- Temporarily disabled the `ChatRoomDetailIntegrationTest` due to a malfunction:
   - When a `ChatMember` tries to add itself to the `ChatRoom` fields after the session is closed, a `failed to lazily initialize` error occurs
   - While I could use `ChatMemberJoinService` to address this, it has too many dependencies and does not return the `ChatMember` entity.
   - I plan to address these issues in the next task.

