### PR TITLE
Ignore: 🔧 30x Performance Improvement in PreAuthorize AOP

### DIFF
--- a/pennyway-socket/build.gradle
+++ b/pennyway-socket/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.6'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.2.3'
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.9.22"
 }
 
 tasks.withType(KotlinCompile) {

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/aop/PreAuthorizer.kt
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/aop/PreAuthorizer.kt
@@ -1,0 +1,147 @@
+package kr.co.pennyway.socket.common.aop
+
+import kr.co.pennyway.socket.common.exception.PreAuthorizeErrorCode
+import kr.co.pennyway.socket.common.exception.PreAuthorizeErrorException
+import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal
+import kr.co.pennyway.socket.common.util.logger
+import org.springframework.context.ApplicationContext
+import org.springframework.stereotype.Component
+import java.lang.reflect.ParameterizedType
+import java.security.Principal
+import kotlin.reflect.KClass
+import kotlin.reflect.full.memberFunctions
+import kotlin.reflect.javaType
+
+@Component
+class PreAuthorizer(
+    _preAuthorizeAdvice: PreAuthorizeAdvice
+) {
+    init {
+        preAuthorizeAdvice = _preAuthorizeAdvice
+    }
+
+    companion object {
+        private lateinit var preAuthorizeAdvice: PreAuthorizeAdvice
+        private val log = logger()
+
+        /**
+         * 모든 요청을 허용합니다.
+         */
+        fun <T> permitAll(function: () -> T): T = function.invoke()
+
+        /**
+         * 사용자의 인증 여부만 검증합니다.
+         * @param principal 사용자 정보
+         * @throws 인증되지 않은 사용자인 경우 {@link PreAuthorizeErrorException} 예외를 발생시킵니다.
+         */
+        fun <T> authenticate(
+            principal: Principal,
+            function: () -> T
+        ): T {
+            when (isAuthenticated(principal)) {
+                true -> return function.invoke()
+                false -> {
+                    log.warn("인증 실패: {}", principal)
+                    throw PreAuthorizeErrorException(PreAuthorizeErrorCode.UNAUTHENTICATED)
+                }
+            }
+        }
+
+        /**
+         * 사용자의 인가 여부만 검증합니다.
+         * @param serviceClass 서비스 클래스
+         * @param args 메서드 참조에 필요한 인자
+         * @throws 인가되지 않은 사용자인 경우 {@link PreAuthorizeErrorException} 예외를 발생시킵니다.
+         */
+        fun <T, R> authorize(
+            serviceClass: KClass<T>,
+            methodName: String,
+            vararg args: Any?,
+            function: () -> R
+        ): R where T : Any {
+            return preAuthorizeAdvice.run(
+                serviceClass = serviceClass,
+                methodName = methodName,
+                function = function,
+                args = args
+            )
+        }
+
+        /**
+         * 사용자의 인증 및 인가 여부를 검증합니다.
+         * @param principal 사용자 정보
+         * @param methodReference 인가 검증을 위한 메서드 참조
+         * @param args 메서드 참조에 필요한 인자
+         * @throws 인증되지 않은 사용자인 경우 {@link PreAuthorizeErrorException} 예외를 발생시킵니다.
+         * @throws 인가되지 않은 사용자인 경우 {@link PreAuthorizeErrorException} 예외를 발생시킵니다.
+         */
+        fun <T, R> authorize(
+            principal: Principal,
+            serviceClass: KClass<T>,
+            methodName: String,
+            vararg args: Any?,
+            function: () -> R
+        ): R where T : Any {
+            when (isAuthenticated(principal)) {
+                true -> return preAuthorizeAdvice.run(
+                    serviceClass = serviceClass,
+                    methodName = methodName,
+                    function = function,
+                    args = args
+                )
+
+                false -> {
+                    log.warn("인증 실패: {}", principal)
+                    throw PreAuthorizeErrorException(PreAuthorizeErrorCode.UNAUTHENTICATED)
+                }
+            }
+        }
+
+        /**
+         * 현재 사용자가 인증되어 있는지 확인합니다.
+         * @return principal 초기화되지 않았거나, 인증된 상태라면 true, 그렇지 않으면 false
+         */
+        private fun isAuthenticated(principal: Principal?): Boolean = when (principal) {
+            is UserPrincipal -> principal.isAuthenticated()
+            else -> throw IllegalArgumentException("Principal must be UserPrincipal")
+        }
+    }
+
+    @Component
+    class PreAuthorizeAdvice(private val applicationContext: ApplicationContext) {
+        @OptIn(ExperimentalStdlibApi::class)
+        fun <T, R> run(
+            serviceClass: KClass<T>,
+            methodName: String,
+            vararg args: Any?,
+            function: () -> R
+        ): R where T : Any {
+            val manager = applicationContext.getBean(serviceClass.java)
+
+            val method = serviceClass.memberFunctions.find { it.name == methodName }
+                ?: throw NoSuchMethodException("$methodName not found in ${serviceClass.qualifiedName}")
+            val parameterTypes = method.parameters.drop(1).map { it.type.javaType }
+
+            val javaMethod = serviceClass.java.getDeclaredMethod(
+                methodName,
+                *parameterTypes.map {
+                    when (it) {
+                        is Class<*> -> it  // 이미 Class 객체라면 그대로 사용
+                        is ParameterizedType -> it.rawType as Class<*>  // 제네릭 타입이라면 raw type 사용
+                        else -> throw IllegalStateException("Unsupported type: $it")
+                    }
+                }.toTypedArray()
+            )
+
+            val result = javaMethod.invoke(manager, *args) as? Boolean
+                ?: throw IllegalArgumentException("Method must return Boolean")
+
+            if (!result) {
+                log.warn("인가 실패: {}", args)
+                throw PreAuthorizeErrorException(PreAuthorizeErrorCode.FORBIDDEN)
+            }
+
+            return function.invoke()
+        }
+    }
+}

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/util/PreAuthorizeSpELParser.kt
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/common/util/PreAuthorizeSpELParser.kt
@@ -71,7 +71,6 @@ object PreAuthorizeSpELParser {
             context.setBeanResolver(BeanFactoryResolver(applicationContext))
 
             method.parameters.forEachIndexed { index, parameter ->
-                println("parameter.name: ${parameter.name} -> args[index]: ${args[index]}")
                 setVariable(parameter.name, args[index])
             }
         }

--- a/pennyway-socket/src/test/java/kr/co/pennyway/socket/common/aop/AuthorizationTest.kt
+++ b/pennyway-socket/src/test/java/kr/co/pennyway/socket/common/aop/AuthorizationTest.kt
@@ -1,0 +1,154 @@
+package kr.co.pennyway.socket.common.aop
+
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting
+import kr.co.pennyway.domain.domains.user.domain.User
+import kr.co.pennyway.domain.domains.user.type.ProfileVisibility
+import kr.co.pennyway.domain.domains.user.type.Role
+import kr.co.pennyway.socket.common.aop.PreAuthorizer.Companion.authenticate
+import kr.co.pennyway.socket.common.aop.PreAuthorizer.Companion.authorize
+import kr.co.pennyway.socket.common.aop.PreAuthorizer.Companion.permitAll
+import kr.co.pennyway.socket.common.exception.PreAuthorizeErrorCode
+import kr.co.pennyway.socket.common.exception.PreAuthorizeErrorException
+import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestComponent
+import org.springframework.context.ApplicationContext
+import org.springframework.test.util.ReflectionTestUtils
+import java.time.LocalDateTime
+
+@SpringBootTest(classes = [PreAuthorizer::class, PreAuthorizer.PreAuthorizeAdvice::class, ApplicationContext::class, MockManager::class])
+class AuthorizationTest {
+    @Autowired
+    private lateinit var preAuthorizerAdvice: PreAuthorizer.PreAuthorizeAdvice
+
+    @Autowired
+    private val applicationContext: ApplicationContext? = null
+
+    @Test
+    fun `permitAll을 호출하면 언제나 정상적으로 진행된다`() {
+        // when
+        val result = permitAll { "some result" }
+
+        // then
+        assertEquals("some result", result)
+    }
+
+    @Test
+    fun `인증된 사용자는 정상적으로 진행된다`() {
+        // given
+        val (user, userPrincipal) = createValidFixture()
+
+        // when
+        val result = authenticate(principal = userPrincipal) {
+            "some result"
+        }
+
+        // then
+        assertEquals("some result", result)
+    }
+
+    @Test
+    fun `인증되지 않은 사용자는 UNAUTHENTICATED 예외가 발생한다`() {
+        // given
+        val (user, userPrincipal) = createExpiredFixture()
+
+        // when & then
+        assertThrows<PreAuthorizeErrorException> {
+            authenticate(principal = userPrincipal) {}
+        }.also { e ->
+            assertEquals(PreAuthorizeErrorCode.UNAUTHENTICATED, e.errorCode)
+        }
+    }
+
+    @Test
+    fun `인가된 사용자는 정상적으로 진행된다`() {
+        val result = authorize(MockManager::class, MockManager::execute.name) {
+            "some result"
+        }
+
+        // then
+        assertEquals("some result", result)
+    }
+
+    @Test
+    fun `인가되지 않은 사용자는 FORBIDDEN 예외를 반환한다`() {
+        // when & then
+        assertThrows<PreAuthorizeErrorException> {
+            authorize(MockManager::class, MockManager::executeFail.name) {}
+        }.also { e ->
+            assertEquals(PreAuthorizeErrorCode.FORBIDDEN, e.errorCode)
+        }
+    }
+
+    @Test
+    fun `인증되었으나, 1번 사용자가 아니라면 FORBIDDEN 예외를 반환한다`() {
+        // given
+        val (user, userPrincipal) = createValidFixture()
+
+        // when & then
+        assertThrows<PreAuthorizeErrorException> {
+            authorize(userPrincipal, MockManager::class, MockManager::hasPermission.name, 2L) {}
+        }.also { e ->
+            assertEquals(PreAuthorizeErrorCode.FORBIDDEN, e.errorCode)
+        }
+    }
+
+    private fun createValidFixture(): Pair<User, UserPrincipal> {
+        val user = createUser()
+        val userPrincipal = UserPrincipal.of(user, LocalDateTime.now().plusMinutes(30), "deviceId", "deviceName")
+
+        return user and userPrincipal
+    }
+
+    private fun createExpiredFixture(): Pair<User, UserPrincipal> {
+        val user = createUser()
+        val userPrincipal = UserPrincipal.of(user, LocalDateTime.now().minusHours(1), "deviceId", "deviceName")
+
+        return user and userPrincipal
+    }
+
+    private fun createUser(): User {
+        val user = User.builder()
+            .name("test")
+            .username("jayang")
+            .notifySetting(NotifySetting.of(true, true, true))
+            .role(Role.USER)
+            .password("password")
+            .phone("010-1234-5678")
+            .profileVisibility(ProfileVisibility.PUBLIC)
+            .build()
+
+        ReflectionTestUtils.setField(user, "id", 1L)
+
+        return user
+    }
+
+    data class Pair<out A, out B>(
+        val first: A,
+        val second: B
+    )
+
+    private infix fun <A, B> A.and(value: B) = Pair(this, value)
+}
+
+@TestComponent
+class MockManager {
+    fun execute(): Boolean {
+        println("인가된 사용자입니다.")
+        return true
+    }
+
+    fun executeFail(): Boolean {
+        println("인가되지 않은 사용자입니다.")
+        return false
+    }
+
+    fun hasPermission(userId: Long): Boolean {
+        println("userId: $userId")
+        return userId == 1L
+    }
+}

--- a/pennyway-socket/src/test/java/kr/co/pennyway/socket/common/aop/PreAuthorizeAopBenchmark.kt
+++ b/pennyway-socket/src/test/java/kr/co/pennyway/socket/common/aop/PreAuthorizeAopBenchmark.kt
@@ -1,0 +1,337 @@
+package kr.co.pennyway.socket.common.aop;
+
+import kr.co.pennyway.domain.domains.user.domain.NotifySetting
+import kr.co.pennyway.domain.domains.user.domain.User
+import kr.co.pennyway.domain.domains.user.type.ProfileVisibility
+import kr.co.pennyway.domain.domains.user.type.Role
+import kr.co.pennyway.socket.common.annotation.PreAuthorize
+import kr.co.pennyway.socket.common.aop.PreAuthorizer.Companion.authenticate
+import kr.co.pennyway.socket.common.aop.PreAuthorizer.Companion.authorize
+import kr.co.pennyway.socket.common.exception.PreAuthorizeErrorException
+import kr.co.pennyway.socket.common.security.authenticate.UserPrincipal
+import lombok.extern.slf4j.Slf4j
+import org.junit.jupiter.api.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestComponent
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory
+import org.springframework.test.util.ReflectionTestUtils
+import java.security.Principal
+import java.time.LocalDateTime
+
+@Disabled
+@Slf4j
+@SpringBootTest(
+    classes = [
+        PreAuthorizer::class,
+        PreAuthorizer.PreAuthorizeAdvice::class,
+        PreAuthorizeAspect::class,
+        AuthorizationBenchmark.BenchmarkConfig::class,
+        SpelAwareProxyProjectionFactory::class
+    ]
+)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AuthorizationBenchmark {
+    companion object {
+        private const val WARMUP_ITERATIONS = 1000
+        private const val TEST_ITERATIONS = 10000
+
+        private const val WARMUP_BATCH_SIZE = 10
+        private const val WARMUP_BATCH_COUNT = 10
+    }
+
+    @TestConfiguration
+    @EnableAspectJAutoProxy
+    class BenchmarkConfig {
+        @Bean
+        fun mockManager() = MockManager()
+
+        @Bean
+        fun testService() = TestService()
+    }
+
+    @Autowired
+    private lateinit var testService: TestService
+
+    private lateinit var validPrincipal: UserPrincipal
+    private lateinit var expiredPrincipal: UserPrincipal
+
+    @BeforeAll
+    fun setup() {
+        // 테스트용 Principal 생성
+        val user = createUser()
+        validPrincipal = UserPrincipal.of(user, LocalDateTime.now().plusMinutes(30), "deviceId", "deviceName")
+        expiredPrincipal = UserPrincipal.of(user, LocalDateTime.now().minusHours(1), "deviceId", "deviceName")
+
+        // 워밍업
+        repeat(WARMUP_ITERATIONS) {
+            // 각 시나리오별 워밍업 호출
+            authenticate(validPrincipal) { true }
+            authorize(MockManager::class, "hasPermission", 1L) { true }
+            authorize(MockManager::class, "hasComplexPermission", 1L, "READ", true) { true }
+        }
+
+        repeat(WARMUP_ITERATIONS) {
+            runCatching {
+                testService.simpleAuthCheck(validPrincipal)
+                testService.simplePermissionCheck(1L)
+                testService.complexPermissionCheck(1L, "READ", true)
+            }
+        }
+    }
+
+    @Test
+    fun `웜업 성능 비교`() {
+        // AOP 방식 웜업 성능 측정
+        prepareForWarmupTest()
+        measureWarmup("Spring AOP 방식") {
+            testService.simpleAuthCheck(validPrincipal)
+            testService.simplePermissionCheck(1L)
+            testService.complexPermissionCheck(1L, "READ", true)
+        }
+
+        // Reflection 방식 웜업 성능 측정
+        prepareForWarmupTest()
+        measureWarmup("Reflection 방식") {
+            authenticate(validPrincipal) { true }
+            authorize(MockManager::class, "hasPermission", 1L) { true }
+            authorize(MockManager::class, "hasComplexPermission", 1L, "READ", true) { true }
+        }
+    }
+
+    @Test
+    fun `벤치마크 - 단순 인증 체크`() {
+        measureTime("Spring AOP 단순 인증 체크") {
+            testService.simpleAuthCheck(validPrincipal)
+        }
+
+        measureTime("단순 인증 체크") {
+            authenticate(validPrincipal) { true }
+        }
+    }
+
+    @Test
+    fun `벤치마크 - 만료된 인증 체크`() {
+        measureTime("Spring AOP 만료된 인증 체크") {
+            assertThrows<PreAuthorizeErrorException> {
+                testService.simpleAuthCheck(expiredPrincipal)
+            }
+        }
+
+        measureTime("만료된 인증 체크") {
+            assertThrows<PreAuthorizeErrorException> {
+                authenticate(expiredPrincipal) { true }
+            }
+        }
+    }
+
+    @Test
+    fun `벤치마크 - 단순 인가 체크 (성공)`() {
+        measureTime("Spring AOP 단순 인가 체크 (성공)") {
+            testService.simplePermissionCheck(1L)
+        }
+
+        measureTime("단순 인가 체크 (성공)") {
+            authorize(MockManager::class, "hasPermission", 1L) { true }
+        }
+    }
+
+    @Test
+    fun `벤치마크 - 단순 인가 체크 (실패)`() {
+        measureTime("Spring AOP 단순 인가 체크 (실패)") {
+            assertThrows<PreAuthorizeErrorException> {
+                testService.simplePermissionCheck(2L)
+            }
+        }
+
+        measureTime("단순 인가 체크 (실패)") {
+            assertThrows<PreAuthorizeErrorException> {
+                authorize(MockManager::class, "hasPermission", 2L) { true }
+            }
+        }
+    }
+
+    @Test
+    fun `벤치마크 - 복잡한 인가 체크 (성공)`() {
+        measureTime("Spring AOP 복잡한 인가 체크 (성공)") {
+            testService.complexPermissionCheck(1L, "READ", true)
+        }
+
+        measureTime("복잡한 인가 체크 (성공)") {
+            authorize(
+                MockManager::class,
+                "hasComplexPermission",
+                1L, "READ", true
+            ) { true }
+        }
+    }
+
+    @Test
+    fun `벤치마크 - 복잡한 인가 체크 (실패)`() {
+        measureTime("Spring AOP 복잡한 인가 체크 (실패)") {
+            assertThrows<PreAuthorizeErrorException> {
+                testService.complexPermissionCheck(2L, "WRITE", false)
+            }
+        }
+
+        measureTime("복잡한 인가 체크 (실패)") {
+            assertThrows<PreAuthorizeErrorException> {
+                authorize(
+                    MockManager::class,
+                    "hasComplexPermission",
+                    2L, "WRITE", false
+                ) { true }
+            }
+        }
+    }
+
+    @Test
+    fun `벤치마크 - 인증 인가 복합 체크 (성공)`() {
+        measureTime("Spring AOP 인증 인가 복합 체크 (성공)") {
+            testService.compositeCheck(validPrincipal, 1L)
+        }
+
+        measureTime("인증 인가 복합 체크 (성공)") {
+            authorize(
+                validPrincipal,
+                MockManager::class,
+                "hasPermission",
+                1L
+            ) { true }
+        }
+    }
+
+    @Test
+    fun `벤치마크 - 인증 인가 복합 체크 (인증 실패)`() {
+        measureTime("Spring AOP 인증 인가 복합 체크 (인증 실패)") {
+            assertThrows<PreAuthorizeErrorException> {
+                testService.compositeCheck(expiredPrincipal, 1L)
+            }
+        }
+
+        measureTime("인증 인가 복합 체크 (인증 실패)") {
+            assertThrows<PreAuthorizeErrorException> {
+                authorize(
+                    expiredPrincipal,
+                    MockManager::class,
+                    "hasPermission",
+                    1L
+                ) { true }
+            }
+        }
+    }
+
+    @Test
+    fun `벤치마크 - 인증 인가 복합 체크 (인가 실패)`() {
+        measureTime("Spring AOP 인증 인가 복합 체크 (인가 실패)") {
+            assertThrows<PreAuthorizeErrorException> {
+                testService.compositeCheck(validPrincipal, 2L)
+            }
+        }
+
+        measureTime("인증 인가 복합 체크 (인가 실패)") {
+            assertThrows<PreAuthorizeErrorException> {
+                authorize(
+                    validPrincipal,
+                    MockManager::class,
+                    "hasPermission",
+                    2L
+                ) { true }
+            }
+        }
+    }
+
+    private fun measureTime(testName: String, block: () -> Unit) {
+        val times = mutableListOf<Long>()
+
+        repeat(TEST_ITERATIONS) {
+            val start = System.nanoTime()
+            block()
+            val end = System.nanoTime()
+            times.add(end - start)
+        }
+
+        val avgTime = times.average()
+        val p95Time = times.sorted()[((TEST_ITERATIONS * 0.95).toInt())]
+
+        println(
+            """
+            |테스트: $testName
+            |평균 실행 시간: ${avgTime / 1000} μs
+            |95th percentile: ${p95Time / 1000} μs
+            |===================================
+        """.trimMargin()
+        )
+    }
+
+    private fun prepareForWarmupTest() {
+        System.gc()
+        Thread.sleep(1000)  // GC 완료 대기
+    }
+
+    private fun measureWarmup(testName: String, block: () -> Unit) {
+        val batches = mutableListOf<Long>()
+
+        repeat(WARMUP_BATCH_COUNT) { batchIndex ->
+            val batchTimes = mutableListOf<Long>()
+
+            repeat(WARMUP_BATCH_SIZE) {
+                val start = System.nanoTime()
+                block()
+                val end = System.nanoTime()
+                batchTimes.add(end - start)
+            }
+
+            batches.add(batchTimes.average().toLong())
+
+            println(
+                """
+                |$testName - 배치 ${batchIndex + 1}
+                |평균 실행 시간: ${batches.last() / 1000} μs
+                |누적 평균 시간: ${batches.average() / 1000} μs
+                |=================
+            """.trimMargin()
+            )
+        }
+    }
+
+    private fun createUser(): User {
+        val user = User.builder()
+            .name("test")
+            .username("jayang")
+            .notifySetting(NotifySetting.of(true, true, true))
+            .role(Role.USER)
+            .password("password")
+            .phone("010-1234-5678")
+            .profileVisibility(ProfileVisibility.PUBLIC)
+            .build()
+
+        ReflectionTestUtils.setField(user, "id", 1L)
+        return user
+    }
+
+    @TestComponent("mockManager")
+    class MockManager {
+        fun hasPermission(userId: Long): Boolean = userId == 1L
+        fun hasComplexPermission(userId: Long, action: String, enabled: Boolean): Boolean =
+            userId == 1L && action == "READ" && enabled
+    }
+
+    @TestComponent
+    class TestService {
+        @PreAuthorize("#isAuthenticated(#principal)")
+        fun simpleAuthCheck(principal: Principal): Boolean = true
+
+        @PreAuthorize("@mockManager.hasPermission(#userId)")
+        fun simplePermissionCheck(userId: Long): Boolean = true
+
+        @PreAuthorize("@mockManager.hasComplexPermission(#userId, #action, #enabled)")
+        fun complexPermissionCheck(userId: Long, action: String, enabled: Boolean): Boolean = true
+
+        @PreAuthorize("#isAuthenticated(#principal) and @mockManager.hasPermission(#userId)")
+        fun compositeCheck(principal: Principal, userId: Long): Boolean = true
+    }
+}

--- a/pennyway-socket/src/test/resources/logback-test.xml
+++ b/pennyway-socket/src/test/resources/logback-test.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.springframework" level="INFO"/>
+    <include resource="kr.co.pennyway"/>
+    <logger name="kr.co.pennyway" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
## 작업 이유
- We were using a custom `@PreAuthorize` annotation to verify user authentication in the socket module.
- While it worked well, synchronization was necessary to avoid conflicts caused by `StandardEvaluationContext` in a concurrent environment.
- Additionally, I wanted to move away from using `Spring AOP`, as it felt cumbersome and inefficient.

<br/>

## 작업 사항
### 1️⃣ Before
```kotlin
@MessageMapping(CHAT_MESSAGE_PATH)
@PreAuthorize("#isAuthenticated(#principal) and @chatRoomAccessChecker.hasPermission(#chatRoomId, #principal)")
fun sendMessage(
    @DestinationVariable chatRoomId: Long,
    @Validated payload: ChatMessageDto.Request,
    principal: UserPrincipal,
    @Header("x-message-id") messageId: String?
) { ... }
```
- The `@PreAuthorize` annotation relies on string-based expressions.
- These expressions are evaluated in a `StandardEvaluationContext`, but since Spring beans are highly dynamic, this negatively impacts caching performance.

<br/>

### 2️⃣ After
```kotlin
@MessageMapping(CHAT_MESSAGE_PATH)
fun sendMessage(
    @DestinationVariable chatRoomId: Long,
    @Validated payload: ChatMessageDto.Request,
    principal: UserPrincipal,
    @Header("x-message-id") messageId: String?
) = authorize(
    principal = principal,
    serviceClass = ChatRoomAccessChecker::class,
    methodName = ChatRoomAccessChecker::hasPermission.name(),
    chatRoomId, principal
) { ... }
```
- The `PreAuthorizer` provides four methods:
   - *permitAll*() : Allows all requests.
   - *authenticate*(principal) : Verifies authentication only.
   - *authorize*(serviceClass, methodName, *args) : Checks authorization only.
   - *authorize*(principal, serviceClass, methodName, *args) : Performs both authentication and authorization.
- While the allocation of `methodName` could be improved, the overall design ensures better type safety.

<br/>

### 3️⃣ Benchmark

| Test Scenario | AOP (μs) | Reflection (μs) | Performance Improvement |
|--------------|-----------|-----------------|------------------------|
| Simple Authentication (Success) | 16.04 | 0.42 | 38.2x faster |
| Simple Authorization (Success) | 19.90 | 3.74 | 5.3x faster |
| Complex Authorization (Success) | 5.51 | 1.00 | 5.5x faster |
| Authentication + Authorization (Success) | 23.42 | 1.86 | 12.6x faster |
| Failed Authentication | 23.49 | 6.22 | 3.8x faster |
| Failed Authorization | 33.85 | 11.08 | 3.1x faster |
| Failed Complex Authorization | 20.62 | 6.08 | 3.4x faster |
| Failed Combined Check | 30.48 | 7.56 | 4.0x faster |

Looking at the warm-up performance data:

| Batch | AOP (μs) | Reflection (μs) | Notes |
|-------|-----------|-----------------|-------|
| 1 | 75.84 | 304.09 | Initial warm-up cost |
| 2 | 32.00 | 6.00 | Rapid optimization phase |
| 3 | 30.00 | 2.00 | Near steady state |
| 10 | 30.00 | 4.00 | Final steady state |

- Performance improved by **3 to 38 times**, as shown in the benchmark results.
- **Drawback**: The initial warm-up cost is 304μs, which is approximately 4 times higher than AOP’s 75μs.
   - However, warm-up happens only once at application startup, and optimal performance is achieved after 2–3 batch executions, making this drawback negligible.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- Main Limitation: Only one Manager bean can be used at a time.
- This change has not yet been applied to production.
   - It will be applied after conducting additional stability tests.

<br/>

## 발견한 이슈
```kotlin
val method = serviceClass.memberFunctions.find { it.name == methodName }
    ?: throw NoSuchMethodException("$methodName not found in ${serviceClass.qualifiedName}")
val parameterTypes = method.parameters.drop(1).map { it.type.javaType }

val javaMethod = serviceClass.java.getDeclaredMethod(
    methodName,
    *parameterTypes.map {
        when (it) {
            is Class<*> -> it  // 이미 Class 객체라면 그대로 사용
            is ParameterizedType -> it.rawType as Class<*>  // 제네릭 타입이라면 raw type 사용
            else -> throw IllegalStateException("Unsupported type: $it")
        }
    }.toTypedArray()
)
```
- This seemingly trivial code was added due to Kotlin's automatic type inference.
   - When using non-null `Long` types in Kotlin manager classes, Kotlin automatically converts them to the optimal primitive type (`long`).
   - However, when using Java reflection, the type is always retrieved as `java.lang.Long`, causing type mismatch errors.
   - To resolve this, the code dynamically converts the type parameters to match those being used by Kotlin.
