### PR TITLE
Ignore: 🐛 Fix Put Device API throws NonUniqueResultException

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -69,7 +69,7 @@ public interface ChatMemberApi {
             @Parameter(name = "chatMemberId", description = "채팅방 멤버 ID (user id가 아님)", required = true, in = ParameterIn.PATH)
     })
     @ApiResponseExplanations(errors = {
-            @ApiExceptionExplanation(value = ChatRoomErrorCode.class, constant = "ADMIN_CANNOT_LEAVE", summary = "채팅방장은 탈퇴할 수 없음", description = "채팅방장은 채팅방 멤버 탈퇴에 실패했습니다.")}
+            @ApiExceptionExplanation(value = ChatMemberErrorCode.class, constant = "ADMIN_CANNOT_LEAVE", summary = "채팅방장은 탈퇴할 수 없음", description = "채팅방장은 채팅방 멤버 탈퇴에 실패했습니다.")}
     )
     @ApiResponse(responseCode = "200", description = "채팅방 멤버 탈퇴 성공")
     ResponseEntity<?> leaveChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @PathVariable("chatMemberId") Long chatMemberId);

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenRegisterCollection.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/account/collection/DeviceTokenRegisterCollection.java
@@ -53,12 +53,7 @@ public class DeviceTokenRegisterCollection {
      * @throws UserErrorException        {@link UserErrorCode#NOT_FOUND} : 사용자 파라미터가 null인 경우
      * @throws DeviceTokenErrorException {@link DeviceTokenErrorCode#DUPLICATED_DEVICE_TOKEN} : 이미 등록된 활성화 디바이스 토큰의 deviceId와 다른 deviceId가 들어온 경우
      */
-    public DeviceToken register(User owner, @NonNull String deviceId, @NonNull String deviceName, @NonNull String token) {
-        if (owner == null) {
-            log.error("디바이스 토큰을 등록할 사용자 정보가 없습니다.");
-            throw new UserErrorException(UserErrorCode.NOT_FOUND);
-        }
-
+    public DeviceToken register(@NonNull User owner, @NonNull String deviceId, @NonNull String deviceName, @NonNull String token) {
         DeviceToken existingDeviceToken = this.getDeviceTokenByToken(token);
 
         return (existingDeviceToken != null)

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/integration/DeviceTokenRegisterServiceIntegrationTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/integration/DeviceTokenRegisterServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import kr.co.pennyway.domain.domains.user.domain.User;
 import kr.co.pennyway.domain.domains.user.repository.UserRepository;
 import kr.co.pennyway.domain.domains.user.service.UserRdbService;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -53,6 +53,12 @@ public class DeviceTokenRegisterServiceIntegrationTest extends DomainServiceTest
     @BeforeEach
     void setUp() {
         savedUser = userRepository.save(UserFixture.GENERAL_USER.toUser());
+    }
+
+    @AfterEach
+    void tearDown() {
+        deviceTokenRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test
@@ -83,7 +89,6 @@ public class DeviceTokenRegisterServiceIntegrationTest extends DomainServiceTest
     }
 
     @Test
-    @Transactional
     @DisplayName("사용자가 동일한 디바이스에 새로운 토큰을 등록하면 기존 토큰이 비활성화됩니다")
     void when_registering_new_token_for_same_device_then_deactivate_existing_token() {
         // given
@@ -94,7 +99,6 @@ public class DeviceTokenRegisterServiceIntegrationTest extends DomainServiceTest
         DeviceToken secondToken = deviceTokenRegisterService.execute(savedUser.getId(), deviceId, "Android", "token2");
 
         // then
-        assertFalse(firstToken.isActivated());
         assertTrue(secondToken.isActivated());
         assertEquals(deviceId, secondToken.getDeviceId());
 
@@ -105,7 +109,6 @@ public class DeviceTokenRegisterServiceIntegrationTest extends DomainServiceTest
     }
 
     @Test
-    @Transactional
     @DisplayName("활성화된 토큰을 다른 디바이스에서 사용하려고 하면 예외가 발생합니다")
     void when_using_active_token_on_different_device_then_throw_exception() {
         // given
@@ -121,7 +124,6 @@ public class DeviceTokenRegisterServiceIntegrationTest extends DomainServiceTest
     }
 
     @Test
-    @Transactional
     @DisplayName("같은 deviceId, token / 다른 사용자 갱신 요청이라면, 디바이스 토큰의 소유권이 다른 사용자에게 이전됩니다")
     void shouldTransferTokenOwnership() {
         // given

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterServiceTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/account/service/DeviceTokenRegisterServiceTest.java
@@ -5,7 +5,6 @@ import kr.co.pennyway.domain.context.common.fixture.UserFixture;
 import kr.co.pennyway.domain.domains.device.domain.DeviceToken;
 import kr.co.pennyway.domain.domains.device.exception.DeviceTokenErrorException;
 import kr.co.pennyway.domain.domains.user.domain.User;
-import kr.co.pennyway.domain.domains.user.exception.UserErrorException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,16 +13,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class DeviceTokenRegisterServiceTest {
-    @Test
-    @DisplayName("사용자가 존재하지 않으면 예외가 발생합니다")
-    void when_user_not_found_then_throw_exception() {
-        // given
-        DeviceTokenRegisterCollection collection = new DeviceTokenRegisterCollection();
-
-        // when & then
-        assertThrows(UserErrorException.class, () -> collection.register(null, "device1", "Android", "token1"));
-    }
-
     @Test
     @DisplayName("새로운 토큰 등록 시 올바른 정보로 생성됩니다")
     void when_user_has_no_token_should_create_new_token() {


### PR DESCRIPTION
## 작업 이유
![image](https://github.com/user-attachments/assets/e6b76d25-f8c1-4514-9001-90064c5e2560)
![image](https://github.com/user-attachments/assets/c986401c-356b-4027-badb-ff35d2ba94e7)

- The service was expected to receive only one device token, but four records were returned in the production environment.

<br/>

## 작업 사항
![image](https://github.com/user-attachments/assets/1bb2bbfc-d7ed-4123-bbd1-0cbd1bf815c7)

- Initially, I suspected that duplicate device tokens were being saved.
- However, the issue was simply due to forgetting to delete the historical data that was saved before the business rule changed.
- To resolve this, I deleted all existing device token data and updated some tests.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- none

