### PR TITLE
Ignore: ✨ Log System Implementation

### DIFF
--- a/pennyway-app-external-api/.gitignore
+++ b/pennyway-app-external-api/.gitignore
@@ -43,3 +43,6 @@ bin/
 
 ## Test API
 src/main/java/kr/co/pennyway/api/apis/test
+
+## Log Files
+**/logs

--- a/pennyway-app-external-api/src/main/resources/application.yml
+++ b/pennyway-app-external-api/src/main/resources/application.yml
@@ -62,7 +62,7 @@ log:
   config:
     filename: app-dev
     maxHistory: 7
-    totalSizeCap: 1MB
+    totalSizeCap: 10MB
 
 ---
 spring:

--- a/pennyway-app-external-api/src/main/resources/application.yml
+++ b/pennyway-app-external-api/src/main/resources/application.yml
@@ -35,6 +35,11 @@ springdoc:
     groups:
       enabled: true
 
+log:
+  config:
+    path: ./logs
+    filename: app-local
+
 ---
 spring:
   config:
@@ -52,6 +57,12 @@ springdoc:
   api-docs:
     groups:
       enabled: true
+
+log:
+  config:
+    filename: app-dev
+    maxHistory: 7
+    totalSizeCap: 10MB
 
 ---
 spring:

--- a/pennyway-app-external-api/src/main/resources/application.yml
+++ b/pennyway-app-external-api/src/main/resources/application.yml
@@ -62,7 +62,7 @@ log:
   config:
     filename: app-dev
     maxHistory: 7
-    totalSizeCap: 10MB
+    totalSizeCap: 1MB
 
 ---
 spring:

--- a/pennyway-app-external-api/src/main/resources/application.yml
+++ b/pennyway-app-external-api/src/main/resources/application.yml
@@ -62,7 +62,8 @@ log:
   config:
     filename: app-dev
     maxHistory: 7
-    totalSizeCap: 10MB
+    maxFileSize: 10MB
+    totalSizeCap: 500MB
 
 ---
 spring:

--- a/pennyway-app-external-api/src/main/resources/application.yml
+++ b/pennyway-app-external-api/src/main/resources/application.yml
@@ -37,7 +37,6 @@ springdoc:
 
 log:
   config:
-    path: ./logs
     filename: app-local
 
 ---

--- a/pennyway-app-external-api/src/main/resources/logback-spring.xml
+++ b/pennyway-app-external-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 프로파일별 설정 파일 로드 -->
+    <springProfile name="local,dev,prod">
+        <property resource="application.yml"/>
+    </springProfile>
+
+    <!-- 로그 설정 프로퍼티 -->
+    <property name="LOG_PATH" value="./pennyway-app-external-api/src/main/resources/logs"/>
+    <springProperty name="LOG_FILE_NAME" source="log.config.filename"/>
+    <springProperty name="LOG_MAX_HISTORY" source="log.config.max-history"/>
+    <springProperty name="LOG_TOTAL_SIZE_CAP" source="log.config.total-size-cap"/>
+
+    <!-- 로그 패턴에 색상 적용 -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <!-- 로그 패턴 설정 -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+    <property name="FILE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %-5level ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
+
+    <!-- 콘솔 출력 설정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
+
+    <!-- 파일 출력 설정 -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>${LOG_MAX_HISTORY}</maxHistory>
+            <totalSizeCap>${LOG_TOTAL_SIZE_CAP}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- 프로파일별 로그 설정 -->
+    <springProfile name="local">
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="org.springframework.web" level="debug">
+            <appender-ref ref="FILE"/>
+        </logger>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="org.springframework.web" level="debug">
+            <appender-ref ref="FILE"/>
+        </logger>
+    </springProfile>
+</configuration>

--- a/pennyway-app-external-api/src/main/resources/logback-spring.xml
+++ b/pennyway-app-external-api/src/main/resources/logback-spring.xml
@@ -8,6 +8,7 @@
     <!-- 로그 설정 프로퍼티 -->
     <property name="LOG_PATH" value="./pennyway-app-external-api/src/main/resources/logs"/>
     <springProperty name="LOG_FILE_NAME" source="log.config.filename"/>
+    <springProperty name="LOG_MAX_FILE_SIZE" source="log.config.maxFileSize"/>
     <springProperty name="LOG_MAX_HISTORY" source="log.config.maxHistory"/>
     <springProperty name="LOG_TOTAL_SIZE_CAP" source="log.config.totalSizeCap"/>
 
@@ -33,7 +34,7 @@
         <encoder>
             <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
-        
+
         <!-- 에러 발생시 무시하도록 설정 -->
         <prudent>true</prudent>
 
@@ -42,10 +43,12 @@
             <fileNamePattern>${LOG_PATH}/%d{yyyy-MM-dd}/${LOG_FILE_NAME}.%i.log</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <!-- 파일당 최대 크기 -->
-                <maxFileSize>${LOG_TOTAL_SIZE_CAP}</maxFileSize>
+                <maxFileSize>${LOG_MAX_FILE_SIZE}</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>
             <!-- 보관 주기 -->
             <maxHistory>${LOG_MAX_HISTORY}</maxHistory>
+            <!-- 총 파일 크기 제한 -->
+            <totalSizeCap>${LOG_TOTAL_SIZE_CAP}</totalSizeCap>
         </rollingPolicy>
     </appender>
 

--- a/pennyway-app-external-api/src/main/resources/logback-spring.xml
+++ b/pennyway-app-external-api/src/main/resources/logback-spring.xml
@@ -8,8 +8,8 @@
     <!-- 로그 설정 프로퍼티 -->
     <property name="LOG_PATH" value="./pennyway-app-external-api/src/main/resources/logs"/>
     <springProperty name="LOG_FILE_NAME" source="log.config.filename"/>
-    <springProperty name="LOG_MAX_HISTORY" source="log.config.max-history"/>
-    <springProperty name="LOG_TOTAL_SIZE_CAP" source="log.config.total-size-cap"/>
+    <springProperty name="LOG_MAX_HISTORY" source="log.config.maxHistory"/>
+    <springProperty name="LOG_TOTAL_SIZE_CAP" source="log.config.totalSizeCap"/>
 
     <!-- 로그 패턴에 색상 적용 -->
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
@@ -29,14 +29,23 @@
 
     <!-- 파일 출력 설정 -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
+        <!--        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>-->
         <encoder>
             <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
+        
+        <!-- 에러 발생시 무시하도록 설정 -->
+        <prudent>true</prudent>
+
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- 롤링된 파일 명명 규칙 -->
+            <fileNamePattern>${LOG_PATH}/%d{yyyy-MM-dd}/${LOG_FILE_NAME}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- 파일당 최대 크기 -->
+                <maxFileSize>${LOG_TOTAL_SIZE_CAP}</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <!-- 보관 주기 -->
             <maxHistory>${LOG_MAX_HISTORY}</maxHistory>
-            <totalSizeCap>${LOG_TOTAL_SIZE_CAP}</totalSizeCap>
         </rollingPolicy>
     </appender>
 
@@ -51,7 +60,8 @@
         <root level="info">
             <appender-ref ref="CONSOLE"/>
         </root>
-        <logger name="org.springframework.web" level="debug">
+
+        <logger name="org.springframework.web" level="debug" additivity="false">
             <appender-ref ref="FILE"/>
         </logger>
     </springProfile>
@@ -60,7 +70,7 @@
         <root level="info">
             <appender-ref ref="CONSOLE"/>
         </root>
-        <logger name="org.springframework.web" level="debug">
+        <logger name="org.springframework.web" level="debug" additivity="false">
             <appender-ref ref="FILE"/>
         </logger>
     </springProfile>

--- a/pennyway-socket/.gitignore
+++ b/pennyway-socket/.gitignore
@@ -44,3 +44,6 @@ bin/
 ### Test ###
 src/main/resources/compose.yml
 src/main/resources/static/
+
+## Log files ##
+**/logs

--- a/pennyway-socket/src/main/resources/application.yml
+++ b/pennyway-socket/src/main/resources/application.yml
@@ -39,11 +39,22 @@ spring:
     activate:
       on-profile: local
 
+log:
+  config:
+    filename: socket-local
+
 ---
 spring:
   config:
     activate:
       on-profile: dev
+
+log:
+  config:
+    filename: socket-dev
+    maxHistory: 7
+    maxFileSize: 10MB
+    totalSizeCap: 500MB
 
 ---
 spring:

--- a/pennyway-socket/src/main/resources/logback-spring.xml
+++ b/pennyway-socket/src/main/resources/logback-spring.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 프로파일별 설정 파일 로드 -->
+    <springProfile name="local,dev,prod">
+        <property resource="application.yml"/>
+    </springProfile>
+
+    <!-- 로그 설정 프로퍼티 -->
+    <property name="LOG_PATH" value="./pennyway-socket/src/main/resources/logs"/>
+    <springProperty name="LOG_FILE_NAME" source="log.config.filename"/>
+    <springProperty name="LOG_MAX_FILE_SIZE" source="log.config.maxFileSize"/>
+    <springProperty name="LOG_MAX_HISTORY" source="log.config.maxHistory"/>
+    <springProperty name="LOG_TOTAL_SIZE_CAP" source="log.config.totalSizeCap"/>
+
+    <!-- 로그 패턴에 색상 적용 -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <!-- WebSocket 서버용 로그 패턴 설정 - 세션 ID와 연결 상태 정보 포함 -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+    <property name="FILE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %-5level ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
+
+    <!-- 콘솔 출력 설정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
+
+    <!-- 파일 출력 설정 -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+
+        <!-- 에러 발생시 무시하도록 설정 -->
+        <prudent>true</prudent>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- 롤링된 파일 명명 규칙 -->
+            <fileNamePattern>${LOG_PATH}/%d{yyyy-MM-dd}/${LOG_FILE_NAME}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- 파일당 최대 크기 -->
+                <maxFileSize>${LOG_MAX_FILE_SIZE}</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <!-- 보관 주기 -->
+            <maxHistory>${LOG_MAX_HISTORY}</maxHistory>
+            <!-- 총 파일 크기 제한 -->
+            <totalSizeCap>${LOG_TOTAL_SIZE_CAP}</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- 프로파일별 로그 설정 -->
+    <springProfile name="local">
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
+        <!-- WebSocket 관련 로거 설정 -->
+        <logger name="org.springframework.web.socket" level="debug" additivity="false">
+            <appender-ref ref="FILE"/>
+        </logger>
+
+        <logger name="org.springframework.messaging" level="debug" additivity="false">
+            <appender-ref ref="FILE"/>
+        </logger>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
+        <!-- WebSocket 관련 로거 설정 -->
+        <logger name="org.springframework.web.socket" level="debug" additivity="false">
+            <appender-ref ref="FILE"/>
+        </logger>
+
+        <logger name="org.springframework.messaging" level="debug" additivity="false">
+            <appender-ref ref="FILE"/>
+        </logger>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 작업 이유
- We had to search for the server logs in the production environment manually.
- It was extremely difficult to locate the logs unless we scanned them immediately after the client reported an issue.

<br/>

## 작업 사항
![image](https://github.com/user-attachments/assets/f5d07176-aa15-4433-b431-ea79ec14a487)
![image](https://github.com/user-attachments/assets/ea070872-1ccb-4ef5-af57-12880d49c1b2)

- Logs at the `debug` level are now available, except when running the application in the `local` profile.
- All log data is organized by `file size` and `date`

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- Let me know if you need more details about the log history or if there's anything that should be fixed.

<br/>

## 발견한 이슈
- none


