### PR TITLE
Ignore: ✨ Retrieve Chatroom Information in Admin Mode

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatRoomApi.java
@@ -49,6 +49,11 @@ public interface ChatRoomApi {
     @ApiResponse(responseCode = "200", description = "채팅방 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRoom", schema = @Schema(implementation = ChatRoomRes.RoomWithParticipants.class))))
     ResponseEntity<?> getChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @AuthenticationPrincipal SecurityUserDetails user);
 
+    @Operation(summary = "채팅방 관리자 모드 조회", method = "GET", description = "채팅방 정보를 관리자 모드로 조회한다. 채팅방 비밀번호를 포함하며, 채팅방 방장만이 조회 가능하다.")
+    @Parameter(name = "chatRoomId", description = "조회할 채팅방의 식별자", example = "1", required = true)
+    @ApiResponse(responseCode = "200", description = "채팅방 관리자 모드 조회 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRoom", schema = @Schema(implementation = ChatRoomRes.AdminView.class))))
+    ResponseEntity<?> getChatRoomAdmin(@PathVariable("chatRoomId") Long chatRoomId);
+
     @Operation(summary = "채팅방 수정", method = "PUT", description = "채팅방의 정보를 수정한다. 채팅방의 정보 수정에 성공하면 수정된 채팅방의 상세 정보를 반환한다.")
     @Parameter(name = "chatRoomId", description = "수정할 채팅방의 식별자", example = "1", required = true)
     @ApiResponse(responseCode = "200", description = "채팅방 수정 성공", content = @Content(schemaProperties = @SchemaProperty(name = "chatRoom", schema = @Schema(implementation = ChatRoomRes.Detail.class))))

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomController.java
@@ -58,6 +58,13 @@ public class ChatRoomController implements ChatRoomApi {
     }
 
     @Override
+    @GetMapping("/{chatRoomId}/admin")
+    @PreAuthorize("isAuthenticated() and @chatRoomManager.hasAdminPermission(principal.userId, #chatRoomId)")
+    public ResponseEntity<?> getChatRoomAdmin(@PathVariable("chatRoomId") Long chatRoomId) {
+        return ResponseEntity.ok(SuccessResponse.from(CHAT_ROOM, chatRoomUseCase.getChatRoom(chatRoomId)));
+    }
+
+    @Override
     @PutMapping("/{chatRoomId}")
     @PreAuthorize("isAuthenticated() and @chatRoomManager.hasAdminPermission(principal.userId, #chatRoomId)")
     public ResponseEntity<?> updateChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @Validated @RequestBody ChatRoomReq.Update request) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -100,6 +100,30 @@ public final class ChatRoomRes {
         }
     }
 
+    @Schema(description = "채팅방 정보 (어드민용)")
+    public record AdminView(
+            @Schema(description = "채팅방 ID", type = "long")
+            Long id,
+            @Schema(description = "채팅방 제목")
+            String title,
+            @Schema(description = "채팅방 설명")
+            String description,
+            @Schema(description = "채팅방 배경 이미지 URL")
+            String backgroundImageUrl,
+            @Schema(description = "비밀번호")
+            Integer password
+    ) {
+        public static AdminView of(ChatRoom chatRoom) {
+            return new AdminView(
+                    chatRoom.getId(),
+                    chatRoom.getTitle(),
+                    chatRoom.getDescription(),
+                    chatRoom.getBackgroundImageUrl(),
+                    chatRoom.getPassword()
+            );
+        }
+    }
+
     @Schema(description = "채팅방 요약 정보")
     public record Summary(
             @Schema(description = "채팅방 ID 목록. 빈 목록일 경우 빈 배열이 반환된다. 각 요소는 long 타입이다.")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
@@ -93,4 +93,8 @@ public final class ChatRoomMapper {
                 .recentMessages(chatMessagesRes)
                 .build();
     }
+
+    public static ChatRoomRes.AdminView toChatRoomResAdminView(ChatRoom chatRoom) {
+        return ChatRoomRes.AdminView.of(chatRoom);
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSearchService.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomSearchService.java
@@ -5,7 +5,10 @@ import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
 import kr.co.pennyway.domain.context.chat.service.ChatMessageService;
 import kr.co.pennyway.domain.context.chat.service.ChatMessageStatusService;
 import kr.co.pennyway.domain.context.chat.service.ChatRoomService;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.chatroom.dto.ChatRoomDetail;
+import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorCode;
+import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorException;
 import kr.co.pennyway.domain.domains.message.domain.ChatMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +47,11 @@ public class ChatRoomSearchService {
         }
 
         return result;
+    }
+
+    @Transactional(readOnly = true)
+    public ChatRoom readChatRoom(Long chatRoomId) {
+        return chatRoomService.readChatRoom(chatRoomId).orElseThrow(() -> new ChatRoomErrorException(ChatRoomErrorCode.NOT_FOUND_CHAT_ROOM));
     }
 
     @Transactional(readOnly = true)

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
@@ -34,6 +34,12 @@ public class ChatRoomUseCase {
         return ChatRoomMapper.toChatRoomResDetail(chatRoom, null, true, 1, 0);
     }
 
+    public ChatRoomRes.AdminView getChatRoom(Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomSearchService.readChatRoom(chatRoomId);
+
+        return ChatRoomMapper.toChatRoomResAdminView(chatRoom);
+    }
+
     public List<ChatRoomRes.Detail> getChatRooms(Long userId) {
         List<ChatRoomRes.Info> chatRooms = chatRoomSearchService.readChatRooms(userId);
 


### PR DESCRIPTION
## 작업 이유
- The chat room's password is required when an admin tries to modify it.

<br/>

## 작업 사항
![image](https://github.com/user-attachments/assets/5701e5e0-7b73-4541-9e25-7d4c12bea575)

- Added an API for admin view.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- We need to include information about whether notifications are on or off for each chat room when clients request their joined rooms.

