### PR TITLE
Ignore: 🐛 Add "Is Null" Filter on the Foreign Entity in the Chat Room Entity

### DIFF
--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/chatroom/domain/ChatRoom.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/chatroom/domain/ChatRoom.java
@@ -42,6 +42,7 @@ public class ChatRoom extends DateAuditable {
     private LocalDateTime deletedAt;
 
     @OneToMany(mappedBy = "chatRoom")
+    @SQLRestriction("deleted_at IS NULL")
     private List<ChatMember> chatMembers = new ArrayList<>();
 
     @Builder


### PR DESCRIPTION
## 작업 이유
![image](https://github.com/user-attachments/assets/58e34333-3a6c-4e01-bb0b-fd536920d62a)

- The reason why leaving a chat room fails is due to an issue in the `hasOnlyAdmin()` method.
- When `Hibernate.size()` is called, it doesn't account for soft-deleted data, causing incorrect behavior.

<br/>

## 작업 사항
```java
public class ChatRoom extends DateAuditable {
    ...

    @OneToMany(mappedBy = "chatRoom")
    @SQLRestriction("deleted_at IS NULL") // Added filter for soft deletion
    private List<ChatMember> chatMembers = new ArrayList<>();
```
- Although I dislike using `@SQLRestriction`, it seems acceptable in this case due to its limited scope.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- none

