### PR TITLE
Ignore: 🐛 Fix Chat Room Background Image Process Logic

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomReq.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomReq.java
@@ -21,7 +21,6 @@ public final class ChatRoomReq {
             @Pattern(regexp = "^[0-9]{6}$", message = "채팅방 비밀번호는 6자리 정수여야 합니다.")
             String password,
             @Schema(description = "채팅방 배경 이미지 URL. NULL을 허용한다.", example = "delete/chatroom/{chatroom_id}/{uuid}_{timestamp}.{ext}")
-            @Pattern(regexp = "^delete/.*", message = "채팅방 배경 이미지 URL은 delete/로 시작해야 합니다.")
             String backgroundImageUrl
     ) {
         public ChatRoom toEntity(long chatRoomId, String originImageUrl) {
@@ -46,8 +45,7 @@ public final class ChatRoomReq {
             @Schema(description = "채팅방 비밀번호. NULL을 허용한다. 비밀번호는 6자리 정수만 허용", example = "123456")
             @Pattern(regexp = "^[0-9]{6}$", message = "채팅방 비밀번호는 6자리 정수여야 합니다.")
             String password,
-            @Schema(description = "채팅방 배경 이미지 URL. NULL을 허용한다.", example = "delete/chatroom/{chatroom_id}/{uuid}_{timestamp}.{ext}")
-            @Pattern(regexp = "^delete/.*", message = "채팅방 배경 이미지 URL은 delete/로 시작해야 합니다.")
+            @Schema(description = "채팅방 배경 이미지 URL은 신규 등록 혹은 수정의 경우 delete/로 시작해야 하며, 기존 이미지를 유지할 경우 https://cdn.dev.pennyway.co.kr/chatroom/로 시작해야 합니다. (없으면 NULL을 허용합니다.)", example = "delete/chatroom/{chatroom_id}/{uuid}_{timestamp}.{ext}")
             String backgroundImageUrl
     ) {
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/dto/ChatRoomRes.java
@@ -68,36 +68,6 @@ public final class ChatRoomRes {
             this.lastMessage = lastMessage;
             this.unreadMessageCount = (unreadMessageCount > 100) ? 100 : unreadMessageCount;
         }
-
-        public static Detail of(ChatRoom chatRoom, ChatRes.ChatDetail lastMessage, boolean isAdmin, int participantCount, long unreadMessageCount) {
-            return new Detail(
-                    chatRoom.getId(),
-                    chatRoom.getTitle(),
-                    chatRoom.getDescription(),
-                    chatRoom.getBackgroundImageUrl(),
-                    chatRoom.getPassword() != null,
-                    isAdmin,
-                    participantCount,
-                    chatRoom.getCreatedAt(),
-                    lastMessage,
-                    unreadMessageCount
-            );
-        }
-
-        public static Detail from(ChatRoomRes.Info info) {
-            return new Detail(
-                    info.chatRoom().id(),
-                    info.chatRoom().title(),
-                    info.chatRoom().description(),
-                    info.chatRoom().backgroundImageUrl(),
-                    info.chatRoom().password() != null,
-                    info.chatRoom().isAdmin(),
-                    info.chatRoom().participantCount(),
-                    info.chatRoom().createdAt(),
-                    info.lastMessage(),
-                    info.unreadMessageCount()
-            );
-        }
     }
 
     @Schema(description = "채팅방 상세 정보 ver.2")

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/mapper/ChatRoomMapper.java
@@ -25,7 +25,7 @@ public final class ChatRoomMapper {
      * @param pageable
      * @return
      */
-    public static SliceResponseTemplate<ChatRoomRes.Detail> toChatRoomResDetails(Slice<ChatRoomDetail> details, Pageable pageable) {
+    public static SliceResponseTemplate<ChatRoomRes.Detail> toChatRoomResDetails(Slice<ChatRoomDetail> details, Pageable pageable, String objectPrefix) {
         List<ChatRoomRes.Detail> contents = new ArrayList<>();
         for (ChatRoomDetail detail : details.getContent()) {
             contents.add(
@@ -33,7 +33,7 @@ public final class ChatRoomMapper {
                             detail.id(),
                             detail.title(),
                             detail.description(),
-                            detail.backgroundImageUrl(),
+                            createBackGroundImageUrl(detail.backgroundImageUrl(), objectPrefix),
                             detail.password() != null,
                             detail.isAdmin(),
                             detail.participantCount(),
@@ -47,7 +47,7 @@ public final class ChatRoomMapper {
         return SliceResponseTemplate.of(contents, pageable, contents.size(), details.hasNext());
     }
 
-    public static List<ChatRoomRes.Detail> toChatRoomResDetails(List<ChatRoomRes.Info> details) {
+    public static List<ChatRoomRes.Detail> toChatRoomResDetails(List<ChatRoomRes.Info> details, String objectPrefix) {
         List<ChatRoomRes.Detail> responses = new ArrayList<>();
 
         for (ChatRoomRes.Info info : details) {
@@ -56,7 +56,7 @@ public final class ChatRoomMapper {
                             info.chatRoom().id(),
                             info.chatRoom().title(),
                             info.chatRoom().description(),
-                            info.chatRoom().backgroundImageUrl(),
+                            createBackGroundImageUrl(info.chatRoom().backgroundImageUrl(), objectPrefix),
                             info.chatRoom().password() != null,
                             info.chatRoom().isAdmin(),
                             info.chatRoom().participantCount(),
@@ -70,7 +70,7 @@ public final class ChatRoomMapper {
         return responses;
     }
 
-    public static List<ChatRoomRes.Detailv2> toChatRoomResDetailsV2(List<ChatRoomRes.Info> details) {
+    public static List<ChatRoomRes.Detailv2> toChatRoomResDetailsV2(List<ChatRoomRes.Info> details, String objectPrefix) {
         List<ChatRoomRes.Detailv2> responses = new ArrayList<>();
 
         for (ChatRoomRes.Info info : details) {
@@ -79,7 +79,7 @@ public final class ChatRoomMapper {
                             info.chatRoom().id(),
                             info.chatRoom().title(),
                             info.chatRoom().description(),
-                            info.chatRoom().backgroundImageUrl(),
+                            createBackGroundImageUrl(info.chatRoom().backgroundImageUrl(), objectPrefix),
                             info.chatRoom().isNotifyEnabled(),
                             info.chatRoom().password() != null,
                             info.chatRoom().isAdmin(),
@@ -94,8 +94,19 @@ public final class ChatRoomMapper {
         return responses;
     }
 
-    public static ChatRoomRes.Detail toChatRoomResDetail(ChatRoom chatRoom, ChatRes.ChatDetail lastMessage, boolean isAdmin, int participantCount, long unreadMessageCount) {
-        return ChatRoomRes.Detail.of(chatRoom, lastMessage, isAdmin, participantCount, unreadMessageCount);
+    public static ChatRoomRes.Detail toChatRoomResDetail(ChatRoom chatRoom, ChatRes.ChatDetail lastMessage, boolean isAdmin, int participantCount, long unreadMessageCount, String objectPrefix) {
+        return new ChatRoomRes.Detail(
+                chatRoom.getId(),
+                chatRoom.getTitle(),
+                chatRoom.getDescription(),
+                createBackGroundImageUrl(chatRoom.getBackgroundImageUrl(), objectPrefix),
+                chatRoom.getPassword() != null,
+                isAdmin,
+                participantCount,
+                chatRoom.getCreatedAt(),
+                lastMessage,
+                unreadMessageCount
+        );
     }
 
     public static ChatRoomRes.RoomWithParticipants toChatRoomResRoomWithParticipants(ChatMemberResult.Detail myInfo, List<ChatMemberResult.Detail> recentParticipants, List<ChatMemberResult.Summary> otherParticipants, List<ChatMessage> chatMessages) {
@@ -120,5 +131,9 @@ public final class ChatRoomMapper {
 
     public static ChatRoomRes.AdminView toChatRoomResAdminView(ChatRoom chatRoom) {
         return ChatRoomRes.AdminView.of(chatRoom);
+    }
+
+    private static String createBackGroundImageUrl(String chatRoomBackgroundImage, String objectPrefix) {
+        return (chatRoomBackgroundImage == null) ? "" : objectPrefix + chatRoomBackgroundImage;
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelper.java
@@ -24,12 +24,12 @@ public class ChatRoomPatchHelper {
     private final AwsS3Adapter awsS3Adapter;
 
     public ChatRoom updateChatRoom(Long chatRoomId, ChatRoomReq.Update request) {
-        ChatRoom currentChatRoom = chatRoomService.readChatRoom(chatRoomId)
+        var currentChatRoom = chatRoomService.readChatRoom(chatRoomId)
                 .orElseThrow(() -> new ChatRoomErrorException(ChatRoomErrorCode.NOT_FOUND_CHAT_ROOM));
 
-        String originImageUrl = updateImage(currentChatRoom.getBackgroundImageUrl(), request.backgroundImageUrl(), chatRoomId);
+        var originImageUrl = updateImage(currentChatRoom.getBackgroundImageUrl(), request.backgroundImageUrl(), chatRoomId);
 
-        Integer password = (request.password() == null) ? null : Integer.valueOf(request.password());
+        var password = (request.password() == null) ? null : Integer.valueOf(request.password());
 
         return chatRoomPatchService.execute(ChatRoomPatchCommand.of(chatRoomId, request.title(), request.description(), originImageUrl, password));
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelper.java
@@ -5,24 +5,73 @@ import kr.co.pennyway.api.common.storage.AwsS3Adapter;
 import kr.co.pennyway.common.annotation.Helper;
 import kr.co.pennyway.domain.context.chat.dto.ChatRoomPatchCommand;
 import kr.co.pennyway.domain.context.chat.service.ChatRoomPatchService;
+import kr.co.pennyway.domain.context.chat.service.ChatRoomService;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorCode;
+import kr.co.pennyway.domain.domains.chatroom.exception.ChatRoomErrorException;
 import kr.co.pennyway.infra.client.aws.s3.ActualIdProvider;
+import kr.co.pennyway.infra.common.exception.StorageErrorCode;
+import kr.co.pennyway.infra.common.exception.StorageException;
 import lombok.RequiredArgsConstructor;
 
 @Helper
 @RequiredArgsConstructor
 public class ChatRoomPatchHelper {
+    private final ChatRoomService chatRoomService;
     private final ChatRoomPatchService chatRoomPatchService;
     private final AwsS3Adapter awsS3Adapter;
 
     public ChatRoom updateChatRoom(Long chatRoomId, ChatRoomReq.Update request) {
-        String originImageUrl = null;
-        if (request.backgroundImageUrl() != null) {
-            originImageUrl = awsS3Adapter.saveImage(request.backgroundImageUrl(), ActualIdProvider.createInstanceOfChatroomProfile(chatRoomId));
-        }
+        ChatRoom currentChatRoom = chatRoomService.readChatRoom(chatRoomId)
+                .orElseThrow(() -> new ChatRoomErrorException(ChatRoomErrorCode.NOT_FOUND_CHAT_ROOM));
+
+        String originImageUrl = updateImage(currentChatRoom.getBackgroundImageUrl(), request.backgroundImageUrl(), chatRoomId);
 
         Integer password = (request.password() == null) ? null : Integer.valueOf(request.password());
 
         return chatRoomPatchService.execute(ChatRoomPatchCommand.of(chatRoomId, request.title(), request.description(), originImageUrl, password));
+    }
+
+    /**
+     * 현재 채팅방 이미지와 요청된 이미지를 비교하여, 변경이 필요한 경우 처리합니다.
+     *
+     * @param currentImageUrl String : 현재 이미지 URL
+     * @param requestImageUrl String : 요청된 이미지 URL
+     * @param chatRoomId      Long : 채팅방 ID
+     * @return 채팅방에 저장될 이미지 URL
+     */
+    private String updateImage(String currentImageUrl, String requestImageUrl, Long chatRoomId) {
+        if (currentImageUrl != null && shouldDeleteCurrentImage(requestImageUrl)) { // 현재 이미지가 있고, 다른 이미지(null 혹은 신규)로 변경하는 경우, 현재 이미지 삭제
+            awsS3Adapter.deleteImage(currentImageUrl);
+        }
+
+        return processRequestImage(requestImageUrl, chatRoomId);
+    }
+
+    private boolean shouldDeleteCurrentImage(String requestImageUrl) {
+        return requestImageUrl == null || requestImageUrl.contains("/delete/");
+    }
+
+    private String processRequestImage(String requestImageUrl, Long chatRoomId) {
+        if (requestImageUrl == null) {
+            return null;
+        }
+
+        if (requestImageUrl.contains("/delete/")) {
+            return awsS3Adapter.saveImage(requestImageUrl, ActualIdProvider.createInstanceOfChatroomProfile(chatRoomId));
+        }
+
+        if (requestImageUrl.contains(awsS3Adapter.getObjectPrefix())) {
+            validateExistingImage(requestImageUrl);
+            return requestImageUrl;
+        }
+
+        throw new IllegalArgumentException("Invalid image URL format: " + requestImageUrl);
+    }
+
+    private void validateExistingImage(String imageUrl) {
+        if (!awsS3Adapter.isObjectExist(imageUrl)) {
+            throw new StorageException(StorageErrorCode.NOT_FOUND);
+        }
     }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -6,6 +6,7 @@ import kr.co.pennyway.api.apis.chat.mapper.ChatMemberMapper;
 import kr.co.pennyway.api.apis.chat.mapper.ChatRoomMapper;
 import kr.co.pennyway.api.apis.chat.service.ChatMemberJoinService;
 import kr.co.pennyway.api.apis.chat.service.ChatMemberSearchService;
+import kr.co.pennyway.api.common.storage.AwsS3Adapter;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.context.chat.dto.ChatMemberBanCommand;
 import kr.co.pennyway.domain.context.chat.service.ChatMemberBanService;
@@ -28,10 +29,12 @@ public class ChatMemberUseCase {
     private final ChatRoomLeaveService chatRoomLeaveService;
     private final ChatMemberBanService chatMemberBanService;
 
+    private final AwsS3Adapter awsS3Adapter;
+
     public ChatRoomRes.Detail joinChatRoom(Long userId, Long chatRoomId, Integer password) {
         Triple<ChatRoom, Integer, Long> chatRoom = chatMemberJoinService.execute(userId, chatRoomId, password);
 
-        return ChatRoomMapper.toChatRoomResDetail(chatRoom.getLeft(), null, false, chatRoom.getMiddle(), chatRoom.getRight());
+        return ChatRoomMapper.toChatRoomResDetail(chatRoom.getLeft(), null, false, chatRoom.getMiddle(), chatRoom.getRight(), awsS3Adapter.getObjectPrefix());
     }
 
     public List<ChatMemberRes.MemberDetail> readChatMembers(Long chatRoomId, Set<Long> chatMemberIds) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatRoomUseCase.java
@@ -5,6 +5,7 @@ import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
 import kr.co.pennyway.api.apis.chat.mapper.ChatRoomMapper;
 import kr.co.pennyway.api.apis.chat.service.*;
 import kr.co.pennyway.api.common.response.SliceResponseTemplate;
+import kr.co.pennyway.api.common.storage.AwsS3Adapter;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.context.chat.dto.ChatRoomDeleteCommand;
 import kr.co.pennyway.domain.context.chat.dto.ChatRoomToggleCommand;
@@ -31,10 +32,12 @@ public class ChatRoomUseCase {
 
     private final ChatMemberSearchService chatMemberSearchService;
 
+    private final AwsS3Adapter awsS3Adapter;
+
     public ChatRoomRes.Detail createChatRoom(ChatRoomReq.Create request, Long userId) {
         ChatRoom chatRoom = chatRoomSaveService.createChatRoom(request, userId);
 
-        return ChatRoomMapper.toChatRoomResDetail(chatRoom, null, true, 1, 0);
+        return ChatRoomMapper.toChatRoomResDetail(chatRoom, null, true, 1, 0, awsS3Adapter.getObjectPrefix());
     }
 
     public ChatRoomRes.AdminView getChatRoom(Long chatRoomId) {
@@ -47,13 +50,13 @@ public class ChatRoomUseCase {
     public List<ChatRoomRes.Detail> getChatRooms(Long userId) {
         List<ChatRoomRes.Info> chatRooms = chatRoomSearchService.readChatRooms(userId);
 
-        return ChatRoomMapper.toChatRoomResDetails(chatRooms);
+        return ChatRoomMapper.toChatRoomResDetails(chatRooms, awsS3Adapter.getObjectPrefix());
     }
 
     public List<ChatRoomRes.Detailv2> getChatRoomDetails(Long userId) {
         List<ChatRoomRes.Info> chatRooms = chatRoomSearchService.readChatRooms(userId);
 
-        return ChatRoomMapper.toChatRoomResDetailsV2(chatRooms);
+        return ChatRoomMapper.toChatRoomResDetailsV2(chatRooms, awsS3Adapter.getObjectPrefix());
     }
 
     public ChatRoomRes.RoomWithParticipants getChatRoomWithParticipants(Long userId, Long chatRoomId) {
@@ -69,14 +72,14 @@ public class ChatRoomUseCase {
     public SliceResponseTemplate<ChatRoomRes.Detail> searchChatRooms(Long userId, String target, Pageable pageable) {
         Slice<ChatRoomDetail> chatRooms = chatRoomSearchService.readChatRoomsBySearch(userId, target, pageable);
 
-        return ChatRoomMapper.toChatRoomResDetails(chatRooms, pageable);
+        return ChatRoomMapper.toChatRoomResDetails(chatRooms, pageable, awsS3Adapter.getObjectPrefix());
     }
 
     // 채팅방 자체의 정보 외엔 무의미한 데이터를 반환한다.
     public ChatRoomRes.Detail updateChatRoom(Long chatRoomId, ChatRoomReq.Update request) {
         ChatRoom chatRoom = chatRoomPatchHelper.updateChatRoom(chatRoomId, request);
 
-        return ChatRoomMapper.toChatRoomResDetail(chatRoom, null, true, 1, 0);
+        return ChatRoomMapper.toChatRoomResDetail(chatRoom, null, true, 1, 0, awsS3Adapter.getObjectPrefix());
     }
 
     public void turnOnNotification(Long userId, Long chatRoomId) {

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/storage/AwsS3Adapter.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/common/storage/AwsS3Adapter.java
@@ -46,6 +46,16 @@ public class AwsS3Adapter {
         awsS3Provider.deleteObject(key);
     }
 
+    /**
+     * Image URL에 해당하는 Object가 존재하는지 확인합니다.
+     */
+    public boolean isObjectExist(String imageUrl) {
+        return awsS3Provider.isObjectExist(imageUrl);
+    }
+
+    /**
+     * S3에 저장된 Object의 Prefix를 반환합니다.
+     */
     public String getObjectPrefix() {
         return awsS3Provider.getObjectPrefix();
     }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomSaveControllerUnitTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/controller/ChatRoomSaveControllerUnitTest.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.api.apis.chat.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pennyway.api.apis.chat.dto.ChatRes;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomReq;
 import kr.co.pennyway.api.apis.chat.dto.ChatRoomRes;
 import kr.co.pennyway.api.apis.chat.usecase.ChatRoomUseCase;
@@ -52,7 +53,7 @@ public class ChatRoomSaveControllerUnitTest {
         // given
         ChatRoom fixture = ChatRoomFixture.PRIVATE_CHAT_ROOM.toEntity(1L);
         ChatRoomReq.Create request = ChatRoomFixture.PRIVATE_CHAT_ROOM.toCreateRequest();
-        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.of(fixture, null, true, 1, 10));
+        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(createChatRoomResponse(fixture, null, true, 1, 10));
 
         // when
         ResultActions result = performPostChatRoom(request);
@@ -70,7 +71,7 @@ public class ChatRoomSaveControllerUnitTest {
         ChatRoom fixture = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(1L);
         ChatRoomReq.Create request = ChatRoomFixture.PUBLIC_CHAT_ROOM.toCreateRequest();
 
-        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(ChatRoomRes.Detail.of(fixture, null, true, 1, 10));
+        given(chatRoomUseCase.createChatRoom(request, 1L)).willReturn(createChatRoomResponse(fixture, null, true, 1, 10));
 
         // when
         ResultActions result = performPostChatRoom(request);
@@ -99,5 +100,20 @@ public class ChatRoomSaveControllerUnitTest {
         return mockMvc.perform(MockMvcRequestBuilders.post("/v2/chat-rooms")
                 .contentType("application/json")
                 .content(objectMapper.writeValueAsString(request)));
+    }
+
+    private ChatRoomRes.Detail createChatRoomResponse(ChatRoom chatRoom, ChatRes.ChatDetail lastMessage, boolean isAdmin, int participantCount, long unreadMessageCount) {
+        return new ChatRoomRes.Detail(
+                chatRoom.getId(),
+                chatRoom.getTitle(),
+                chatRoom.getDescription(),
+                chatRoom.getBackgroundImageUrl(),
+                chatRoom.getPassword() != null,
+                isAdmin,
+                participantCount,
+                chatRoom.getCreatedAt(),
+                lastMessage,
+                unreadMessageCount
+        );
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatRoomCreateIntegrationTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/integration/ChatRoomCreateIntegrationTest.java
@@ -55,7 +55,8 @@ public class ChatRoomCreateIntegrationTest extends ExternalApiDBTestConfig {
         // given
         User user = userService.createUser(UserFixture.GENERAL_USER.toUser());
         ChatRoomReq.Create request = ChatRoomFixture.PRIVATE_CHAT_ROOM.toCreateRequest();
-        given(awsS3Adapter.saveImage(eq(request.backgroundImageUrl()), any(ActualIdProvider.class))).willReturn("chatroom/1");
+        given(awsS3Adapter.saveImage(eq(request.backgroundImageUrl()), any(ActualIdProvider.class))).willReturn(ChatRoomFixture.getOriginImageUrl());
+        given(awsS3Adapter.getObjectPrefix()).willReturn("https://cdn.test.com/");
 
         // when
         ResponseEntity<SuccessResponse<Map<String, ChatRoomRes.Detail>>> response = postCreating(user, request);
@@ -65,7 +66,7 @@ public class ChatRoomCreateIntegrationTest extends ExternalApiDBTestConfig {
         Assertions.assertEquals(HttpStatus.OK, response.getStatusCode(), "200 OK 응답을 받아야 합니다.");
         Assertions.assertEquals(request.title(), detail.title(), "생성된 채팅방의 제목이 일치해야 합니다.");
         Assertions.assertEquals(request.description(), detail.description(), "생성된 채팅방의 설명이 일치해야 합니다.");
-        Assertions.assertEquals("chatroom/1", detail.backgroundImageUrl(), "생성된 채팅방의 배경 이미지 URL이 일치해야 합니다.");
+        Assertions.assertEquals("https://cdn.test.com/" + ChatRoomFixture.getOriginImageUrl(), detail.backgroundImageUrl(), "생성된 채팅방의 배경 이미지 URL이 일치해야 합니다.");
         Assertions.assertTrue(detail.isPrivate(), "생성된 채팅방은 비공개여야 합니다.");
     }
 

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelperTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelperTest.java
@@ -1,0 +1,136 @@
+package kr.co.pennyway.api.apis.chat.service;
+
+import kr.co.pennyway.api.apis.chat.dto.ChatRoomReq;
+import kr.co.pennyway.api.common.storage.AwsS3Adapter;
+import kr.co.pennyway.api.config.fixture.ChatRoomFixture;
+import kr.co.pennyway.domain.context.chat.service.ChatRoomPatchService;
+import kr.co.pennyway.domain.context.chat.service.ChatRoomService;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomPatchHelperTest {
+    private static final Long CHATROOM_ID = 1L;
+    private static final String DELETE_PATH = "delete/chatroom/1/test-uuid_123.jpg";
+    private static final String CONVERTED_PATH = "chatroom/1/test-uuid_123.jpg";
+    private static final String ORIGIN_PATH = "chatroom/1/origin/test-uuid_321.jpg";
+
+    @Mock
+    private ChatRoomService chatRoomService;
+    @Mock
+    private ChatRoomPatchService chatRoomPatchService;
+    @Mock
+    private AwsS3Adapter awsS3Adapter;
+    @InjectMocks
+    private ChatRoomPatchHelper chatRoomPatchHelper;
+
+    @Test
+    @DisplayName("이미지가 없는 채팅방에 이미지 추가")
+    void addNewImageToEmptyRoom() {
+        // given
+        ChatRoom chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(CHATROOM_ID);
+        ReflectionTestUtils.setField(chatRoom, "backgroundImageUrl", null);
+
+        when(chatRoomService.readChatRoom(CHATROOM_ID)).thenReturn(Optional.of(chatRoom));
+        when(awsS3Adapter.saveImage(eq(DELETE_PATH), any())).thenReturn(CONVERTED_PATH);
+
+        ChatRoomReq.Update request = new ChatRoomReq.Update("title", "desc", null, DELETE_PATH);
+
+        // when
+        chatRoomPatchHelper.updateChatRoom(CHATROOM_ID, request);
+
+        // then
+        verify(awsS3Adapter, never()).deleteImage(anyString());
+        verify(awsS3Adapter).saveImage(eq(DELETE_PATH), any());
+    }
+
+    @Test
+    @DisplayName("이미지가 있는 채팅방의 이미지 삭제")
+    void deleteExistingImage() {
+        // given
+        ChatRoom chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(CHATROOM_ID);
+        ReflectionTestUtils.setField(chatRoom, "backgroundImageUrl", ORIGIN_PATH);
+
+        when(chatRoomService.readChatRoom(CHATROOM_ID)).thenReturn(Optional.of(chatRoom));
+
+        ChatRoomReq.Update request = new ChatRoomReq.Update("title", "desc", null, null);
+
+        // when
+        chatRoomPatchHelper.updateChatRoom(CHATROOM_ID, request);
+
+        // then
+        verify(awsS3Adapter).deleteImage(ORIGIN_PATH);
+        verify(awsS3Adapter, never()).saveImage(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("이미지가 있는 채팅방의 이미지 변경")
+    void updateExistingImage() {
+        // given
+        ChatRoom chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(CHATROOM_ID);
+        ReflectionTestUtils.setField(chatRoom, "backgroundImageUrl", ORIGIN_PATH);
+
+        when(chatRoomService.readChatRoom(CHATROOM_ID)).thenReturn(Optional.of(chatRoom));
+        when(awsS3Adapter.saveImage(eq(DELETE_PATH), any())).thenReturn(CONVERTED_PATH);
+
+        ChatRoomReq.Update request = new ChatRoomReq.Update("title", "desc", null, DELETE_PATH);
+
+        // when
+        chatRoomPatchHelper.updateChatRoom(CHATROOM_ID, request);
+
+        // then
+        verify(awsS3Adapter).deleteImage(ORIGIN_PATH);
+        verify(awsS3Adapter).saveImage(eq(DELETE_PATH), any());
+    }
+
+    @Test
+    @DisplayName("이미지가 있는 채팅방의 이미지 유지")
+    void keepExistingImage() {
+        // given
+        ChatRoom chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(CHATROOM_ID);
+        ReflectionTestUtils.setField(chatRoom, "backgroundImageUrl", ORIGIN_PATH);
+
+        when(chatRoomService.readChatRoom(CHATROOM_ID)).thenReturn(Optional.of(chatRoom));
+        when(awsS3Adapter.getObjectPrefix()).thenReturn("https://cdn.test.com/");
+        when(awsS3Adapter.isObjectExist("https://cdn.test.com/" + ORIGIN_PATH)).thenReturn(true);
+
+        ChatRoomReq.Update request = new ChatRoomReq.Update("title", "desc", null, "https://cdn.test.com/" + ORIGIN_PATH);
+
+        // when
+        chatRoomPatchHelper.updateChatRoom(CHATROOM_ID, request);
+
+        // then
+        verify(awsS3Adapter, never()).deleteImage(anyString());
+        verify(awsS3Adapter, never()).saveImage(anyString(), any());
+        verify(awsS3Adapter).isObjectExist("https://cdn.test.com/" + ORIGIN_PATH);
+    }
+
+    @Test
+    @DisplayName("잘못된 이미지 URL 패턴으로 요청시 예외 발생")
+    void throwExceptionForInvalidUrlPattern() {
+        // given
+        ChatRoom chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity(CHATROOM_ID);
+        ReflectionTestUtils.setField(chatRoom, "backgroundImageUrl", ORIGIN_PATH);
+
+        when(chatRoomService.readChatRoom(CHATROOM_ID)).thenReturn(Optional.of(chatRoom));
+        when(awsS3Adapter.getObjectPrefix()).thenReturn("https://cdn.test.com/");
+
+        ChatRoomReq.Update request = new ChatRoomReq.Update("title", "desc", null, "invalid/path/image.jpg");
+
+        // when & then
+        assertThrows(IllegalArgumentException.class,
+                () -> chatRoomPatchHelper.updateChatRoom(CHATROOM_ID, request));
+    }
+}

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelperTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelperTest.java
@@ -6,6 +6,7 @@ import kr.co.pennyway.api.config.fixture.ChatRoomFixture;
 import kr.co.pennyway.domain.context.chat.service.ChatRoomPatchService;
 import kr.co.pennyway.domain.context.chat.service.ChatRoomService;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.infra.common.exception.StorageException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -130,7 +131,6 @@ class ChatRoomPatchHelperTest {
         ChatRoomReq.Update request = new ChatRoomReq.Update("title", "desc", null, "invalid/path/image.jpg");
 
         // when & then
-        assertThrows(IllegalArgumentException.class,
-                () -> chatRoomPatchHelper.updateChatRoom(CHATROOM_ID, request));
+        assertThrows(StorageException.class, () -> chatRoomPatchHelper.updateChatRoom(CHATROOM_ID, request));
     }
 }

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/ChatRoomFixture.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/config/fixture/ChatRoomFixture.java
@@ -4,9 +4,10 @@ import kr.co.pennyway.api.apis.chat.dto.ChatRoomReq;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 
 public enum ChatRoomFixture {
-    PRIVATE_CHAT_ROOM("페니웨이", "페니웨이 채팅방입니다.", "delete/chatroom/1/fsdflasdfa_12121210.jpg", "123456"),
-    PUBLIC_CHAT_ROOM("페니웨이", "페니웨이 채팅방입니다.", "delete/chatroom/1/fsdflasdfa_12121210.jpg", null);
+    PRIVATE_CHAT_ROOM("페니웨이", "페니웨이 채팅방입니다.", "delete/chatroom/1/test-uuid_123.jpg", "123456"),
+    PUBLIC_CHAT_ROOM("페니웨이", "페니웨이 채팅방입니다.", "delete/chatroom/1/test-uuid_123.jpg", null);
 
+    private static final String originImageUrl = "chatroom/1/test-uuid_123.jpg";
     private final String title;
     private final String description;
     private final String backgroundImageUrl;
@@ -17,6 +18,10 @@ public enum ChatRoomFixture {
         this.description = description;
         this.backgroundImageUrl = backgroundImageUrl;
         this.password = password;
+    }
+
+    public static String getOriginImageUrl() {
+        return originImageUrl;
     }
 
     public ChatRoom toEntity(Long id) {

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/dto/ChatRoomPatchCommand.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/dto/ChatRoomPatchCommand.java
@@ -26,7 +26,7 @@ public record ChatRoomPatchCommand(
             throw new IllegalArgumentException("채팅방 비밀번호는 Null 혹은, 6자리 정수여야 합니다.");
         }
 
-        if (backgroundImageUrl != null && backgroundImageUrl.startsWith("chatroom/")) {
+        if (backgroundImageUrl != null && !backgroundImageUrl.startsWith("chatroom/")) {
             throw new IllegalArgumentException("채팅방 배경 이미지 URL은 'chatroom/' 으로 시작해야 합니다.");
         }
     }

--- a/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/exception/StorageErrorCode.java
+++ b/pennyway-infra/src/main/java/kr/co/pennyway/infra/common/exception/StorageErrorCode.java
@@ -10,26 +10,30 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum StorageErrorCode implements BaseErrorCode {
-	// 400 Bad Request
-	MISSING_REQUIRED_PARAMETER(StatusCode.BAD_REQUEST, ReasonCode.MISSING_REQUIRED_PARAMETER, "필수 파라미터가 누락되었습니다."),
-	INVALID_EXTENSION(StatusCode.BAD_REQUEST, ReasonCode.MALFORMED_PARAMETER, "지원하지 않는 확장자입니다."),
-	INVALID_TYPE(StatusCode.BAD_REQUEST, ReasonCode.MALFORMED_PARAMETER, "지원하지 않는 타입입니다."),
-	INVALID_FILE(StatusCode.BAD_REQUEST, ReasonCode.MALFORMED_PARAMETER, "올바르지 않은 파일입니다."),
+    // 400 Bad Request
+    MISSING_REQUIRED_PARAMETER(StatusCode.BAD_REQUEST, ReasonCode.MISSING_REQUIRED_PARAMETER, "필수 파라미터가 누락되었습니다."),
+    INVALID_EXTENSION(StatusCode.BAD_REQUEST, ReasonCode.MALFORMED_PARAMETER, "지원하지 않는 확장자입니다."),
+    INVALID_TYPE(StatusCode.BAD_REQUEST, ReasonCode.MALFORMED_PARAMETER, "지원하지 않는 타입입니다."),
+    INVALID_FILE(StatusCode.BAD_REQUEST, ReasonCode.MALFORMED_PARAMETER, "올바르지 않은 파일입니다."),
 
-	// 404 Not Found
-	NOT_FOUND(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "요청한 리소스를 찾을 수 없습니다.");
+    // 404 Not Found
+    NOT_FOUND(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
 
-	private final StatusCode statusCode;
-	private final ReasonCode reasonCode;
-	private final String message;
+    // 422 Unprocessable Entity
+    INVALID_IMAGE_PATH(StatusCode.UNPROCESSABLE_CONTENT, ReasonCode.MALFORMED_PARAMETER, "올바르지 않은 이미지 경로입니다."),
+    ;
 
-	@Override
-	public CausedBy causedBy() {
-		return CausedBy.of(statusCode, reasonCode);
-	}
+    private final StatusCode statusCode;
+    private final ReasonCode reasonCode;
+    private final String message;
 
-	@Override
-	public String getExplainError() throws NoSuchFieldError {
-		return message;
-	}
+    @Override
+    public CausedBy causedBy() {
+        return CausedBy.of(statusCode, reasonCode);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldError {
+        return message;
+    }
 }


### PR DESCRIPTION
## 작업 이유
- I made a mistake to implement API where updating the chat room information due to the complexity of various scenarios:

| | origin image ✅ | origin image ❌ |
|---|---|---|
| non-image | Delete original image | Do nothing |
| new-image | Delete original image, and copy new image | Copy new image |
| exist-image | Only check object existence | ❌ |

- However, I was only handling background images with values of `null` or those starting with the `/delete` prefix.

<br/>

## 작업 사항
- Removed the `@Pattern` annotation in `ChatRoomReq.Update`.
- Added the required logic in the `ChatRoomPatchHelper`.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- I also forgot to include the chat member's profile image in the chat member response.  ....^^

