### PR TITLE
Ignore: 🔧 Remove Chat Member Id from Leave Chat Room API Spec

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -64,15 +64,12 @@ public interface ChatMemberApi {
     ResponseEntity<?> readChatMembers(@PathVariable("chatRoomId") Long chatRoomId, @Validated @NotEmpty @RequestParam("ids") Set<Long> ids);
 
     @Operation(summary = "채팅방 멤버 탈퇴", method = "DELETE", description = "채팅방에서 탈퇴한다. 채팅방장은 채팅 멤버가 한 명이라도 남아있으면 탈퇴할 수 없으며, 채팅방장이 탈퇴할 경우 채팅방이 삭제된다.")
-    @Parameters({
-            @Parameter(name = "chatRoomId", description = "채팅방 ID", required = true, in = ParameterIn.PATH),
-            @Parameter(name = "chatMemberId", description = "채팅방 멤버 ID (user id가 아님)", required = true, in = ParameterIn.PATH)
-    })
+    @Parameter(name = "chatRoomId", description = "채팅방 ID", required = true, in = ParameterIn.PATH)
     @ApiResponseExplanations(errors = {
             @ApiExceptionExplanation(value = ChatMemberErrorCode.class, constant = "ADMIN_CANNOT_LEAVE", summary = "채팅방장은 탈퇴할 수 없음", description = "채팅방장은 채팅방 멤버 탈퇴에 실패했습니다.")}
     )
     @ApiResponse(responseCode = "200", description = "채팅방 멤버 탈퇴 성공")
-    ResponseEntity<?> leaveChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @PathVariable("chatMemberId") Long chatMemberId);
+    ResponseEntity<?> leaveChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @AuthenticationPrincipal SecurityUserDetails user);
 
     @Operation(summary = "채팅방 멤버 추방", method = "DELETE", description = "채팅방 멤버를 추방한다. 채팅방장만이 채팅방 멤버를 추방할 수 있다.")
     @Parameters({

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -54,10 +54,10 @@ public class ChatMemberController implements ChatMemberApi {
     }
 
     @Override
-    @DeleteMapping("/{chatMemberId}")
-    @PreAuthorize("isAuthenticated() and @chatRoomManager.hasPermission(principal.userId, #chatRoomId, #chatMemberId)")
-    public ResponseEntity<?> leaveChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @PathVariable("chatMemberId") Long chatMemberId) {
-        chatMemberUseCase.leaveChatRoom(chatMemberId);
+    @DeleteMapping("")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> leaveChatRoom(@PathVariable("chatRoomId") Long chatRoomId, @AuthenticationPrincipal SecurityUserDetails user) {
+        chatMemberUseCase.leaveChatRoom(user.getUserId(), chatRoomId);
 
         return ResponseEntity.ok(SuccessResponse.noContent());
     }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -43,8 +43,8 @@ public class ChatMemberUseCase {
         return ChatMemberMapper.toChatMemberResDetail(chatMembers);
     }
 
-    public void leaveChatRoom(Long chatMemberId) {
-        chatRoomLeaveService.execute(chatMemberId);
+    public void leaveChatRoom(Long userId, Long chatRoomId) {
+        chatRoomLeaveService.execute(userId, chatRoomId);
     }
 
     public void banChatMember(Long userId, Long targetMemberId, Long chatRoomId) {

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomLeaveService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomLeaveService.java
@@ -19,10 +19,10 @@ public class ChatRoomLeaveService {
     private final ChatRoomRdbService chatRoomRdbService;
 
     @Transactional
-    public void execute(Long chatMemberId) {
-        ChatMember chatMember = chatMemberRdbService.readChatMemberByChatMemberId(chatMemberId)
+    public void execute(Long userId, Long chatRoomId) {
+        ChatMember chatMember = chatMemberRdbService.readChatMember(userId, chatRoomId)
                 .orElseThrow(() -> {
-                    log.warn("채팅방 멤버를 찾을 수 없습니다. chatMemberId: {}", chatMemberId);
+                    log.warn("{}번 방에서 {}번 사용자의 채팅방 멤버 정보를를 찾을 수 없습니다.", chatRoomId, userId);
                     return new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND);
                 });
 

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/integration/ChatRoomLeaveServiceIntegrationTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/integration/ChatRoomLeaveServiceIntegrationTest.java
@@ -67,7 +67,7 @@ public class ChatRoomLeaveServiceIntegrationTest extends DomainServiceTestInfraC
         ChatMember normalMember = chatMemberRepository.save(ChatMember.of(user, chatRoom, ChatMemberRole.MEMBER));
 
         // when
-        chatRoomLeaveService.execute(normalMember.getId());
+        chatRoomLeaveService.execute(user.getId(), chatRoom.getId());
 
         // then
         ChatMember deletedMember = chatMemberRepository.findById(normalMember.getId()).orElseThrow();
@@ -86,7 +86,7 @@ public class ChatRoomLeaveServiceIntegrationTest extends DomainServiceTestInfraC
         ChatMember adminMember = chatMemberRepository.save(ChatMember.of(user, chatRoom, ChatMemberRole.ADMIN));
 
         // when
-        chatRoomLeaveService.execute(adminMember.getId());
+        chatRoomLeaveService.execute(user.getId(), chatRoom.getId());
 
         // then
         ChatMember deletedMember = chatMemberRepository.findById(adminMember.getId()).orElseThrow();
@@ -108,7 +108,7 @@ public class ChatRoomLeaveServiceIntegrationTest extends DomainServiceTestInfraC
         chatMemberRepository.save(ChatMember.of(normalUser, chatRoom, ChatMemberRole.MEMBER));
 
         // when & then
-        assertThatThrownBy(() -> chatRoomLeaveService.execute(adminMember.getId()))
+        assertThatThrownBy(() -> chatRoomLeaveService.execute(adminUser.getId(), chatRoom.getId()))
                 .isInstanceOf(ChatMemberErrorException.class)
                 .hasFieldOrPropertyWithValue("chatMemberErrorCode", ChatMemberErrorCode.ADMIN_CANNOT_LEAVE);
 
@@ -138,6 +138,6 @@ public class ChatRoomLeaveServiceIntegrationTest extends DomainServiceTestInfraC
         log.info("normalMember: {}", normalMember);
 
         // when & then
-        assertDoesNotThrow(() -> chatRoomLeaveService.execute(adminMember.getId()));
+        assertDoesNotThrow(() -> chatRoomLeaveService.execute(adminUser.getId(), chatRoom.getId()));
     }
 }


### PR DESCRIPTION
## 작업 이유
![image](https://github.com/user-attachments/assets/e9128dc4-d6a8-4d38-9602-dde0045a645a)
👌🙆‍♂️🆗

<br/>

## 작업 사항
The `chat_member_id` field is unnecessary in the Leave Chat Room API, as it does not align with the principles of Domain-Driven Design (DDD). Instead, the required data can be derived from the authenticated user's session or context.  
So remove it.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- none

