### PR TITLE
Ignore: ✨ Chat Room Admin Delegation API

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/api/ChatMemberApi.java
@@ -82,4 +82,17 @@ public interface ChatMemberApi {
     })
     @ApiResponse(responseCode = "200", description = "채팅방 멤버 추방 성공")
     ResponseEntity<?> banChatMember(@PathVariable("chatRoomId") Long chatRoomId, @PathVariable("chatMemberId") Long chatMemberId, @AuthenticationPrincipal SecurityUserDetails user);
+
+    @Operation(summary = "채팅방 관리자 위임", method = "PATCH", description = "채팅방 관리자를 위임한다. 채팅방장만이 채팅방 관리자를 위임할 수 있다.")
+    @Parameters({
+            @Parameter(name = "chatRoomId", description = "채팅방 ID", required = true, in = ParameterIn.PATH),
+            @Parameter(name = "chatMemberId", description = "위임할 채팅방 멤버 ID (user id가 아님)", required = true, in = ParameterIn.PATH)
+    })
+    @ApiResponseExplanations(errors = {
+            @ApiExceptionExplanation(value = ChatMemberErrorCode.class, constant = "NOT_FOUND", summary = "채팅방 멤버를 찾을 수 없음", description = "채팅방 멤버를 찾을 수 없어 채팅방 관리자 위임에 실패했습니다."),
+            @ApiExceptionExplanation(value = ChatMemberErrorCode.class, constant = "NOT_ADMIN", summary = "권한 없음", description = "권한이 없어 채팅방 관리자 위임에 실패했습니다."),
+            @ApiExceptionExplanation(value = ChatMemberErrorCode.class, constant = "NOT_SAME_CHAT_ROOM", summary = "다른 채팅방 멤버", description = "위임할 채팅방 멤버가 다른 채팅방 멤버여서 채팅방 관리자 위임에 실패했습니다.")
+    })
+    @ApiResponse(responseCode = "200", description = "채팅방 관리자 위임 성공")
+    ResponseEntity<?> delegateAdmin(@PathVariable("chatRoomId") Long chatRoomId, @PathVariable("chatMemberId") Long chatMemberId, @AuthenticationPrincipal SecurityUserDetails user);
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -71,6 +71,7 @@ public class ChatMemberController implements ChatMemberApi {
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
 
+    @Override
     @PatchMapping("/{chatMemberId}/delegate")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> delegateAdmin(

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/controller/ChatMemberController.java
@@ -70,4 +70,16 @@ public class ChatMemberController implements ChatMemberApi {
 
         return ResponseEntity.ok(SuccessResponse.noContent());
     }
+
+    @PatchMapping("/{chatMemberId}/delegate")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> delegateAdmin(
+            @PathVariable("chatRoomId") Long chatRoomId,
+            @PathVariable("chatMemberId") Long chatMemberId,
+            @AuthenticationPrincipal SecurityUserDetails user
+    ) {
+        chatMemberUseCase.delegate(user.getUserId(), chatMemberId, chatRoomId);
+
+        return ResponseEntity.ok(SuccessResponse.noContent());
+    }
 }

--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/usecase/ChatMemberUseCase.java
@@ -9,7 +9,9 @@ import kr.co.pennyway.api.apis.chat.service.ChatMemberSearchService;
 import kr.co.pennyway.api.common.storage.AwsS3Adapter;
 import kr.co.pennyway.common.annotation.UseCase;
 import kr.co.pennyway.domain.context.chat.dto.ChatMemberBanCommand;
+import kr.co.pennyway.domain.context.chat.dto.ChatRoomAdminDelegateCommand;
 import kr.co.pennyway.domain.context.chat.service.ChatMemberBanService;
+import kr.co.pennyway.domain.context.chat.service.ChatRoomAdminDelegateService;
 import kr.co.pennyway.domain.context.chat.service.ChatRoomLeaveService;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
 import kr.co.pennyway.domain.domains.member.dto.ChatMemberResult;
@@ -28,6 +30,7 @@ public class ChatMemberUseCase {
     private final ChatMemberSearchService chatMemberSearchService;
     private final ChatRoomLeaveService chatRoomLeaveService;
     private final ChatMemberBanService chatMemberBanService;
+    private final ChatRoomAdminDelegateService chatRoomAdminDelegateService;
 
     private final AwsS3Adapter awsS3Adapter;
 
@@ -49,5 +52,9 @@ public class ChatMemberUseCase {
 
     public void banChatMember(Long userId, Long targetMemberId, Long chatRoomId) {
         chatMemberBanService.execute(ChatMemberBanCommand.of(userId, targetMemberId, chatRoomId));
+    }
+
+    public void delegate(Long userId, Long targetChatMemberId, Long chatRoomId) {
+        chatRoomAdminDelegateService.execute(ChatRoomAdminDelegateCommand.of(chatRoomId, userId, targetChatMemberId));
     }
 }

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -140,6 +140,7 @@ public class ChatMember extends DateAuditable {
                 ", banned=" + banned +
                 ", notifyEnabled=" + notifyEnabled +
                 ", deletedAt=" + deletedAt +
+                ", role=" + role +
                 '}';
     }
 }

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.springframework.lang.NonNull;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -76,6 +77,19 @@ public class ChatMember extends DateAuditable {
 
         chatRoom.getChatMembers().add(this);
         this.chatRoom = chatRoom;
+    }
+
+    public void delegate(@NonNull ChatMember chatMember) {
+        if (chatMember == null || this.equals(chatMember)) {
+            throw new IllegalStateException("chatMember가 null이거나 자기 자신일 수 없습니다.");
+        }
+
+        if (this.role != ChatMemberRole.ADMIN) {
+            throw new IllegalStateException("방장만 다른 멤버에게 방장 권한을 위임할 수 있습니다.");
+        }
+
+        this.role = ChatMemberRole.MEMBER;
+        chatMember.role = ChatMemberRole.ADMIN;
     }
 
     /**

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import kr.co.pennyway.domain.common.converter.ChatMemberRoleConverter;
 import kr.co.pennyway.domain.common.model.DateAuditable;
 import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
 import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
 import kr.co.pennyway.domain.domains.user.domain.User;
 import lombok.AccessLevel;
@@ -81,11 +83,11 @@ public class ChatMember extends DateAuditable {
 
     public void delegate(@NonNull ChatMember chatMember) {
         if (chatMember == null || this.equals(chatMember)) {
-            throw new IllegalStateException("chatMember가 null이거나 자기 자신일 수 없습니다.");
+            throw new IllegalArgumentException("chatMember가 null이거나 자기 자신일 수 없습니다.");
         }
 
         if (this.role != ChatMemberRole.ADMIN) {
-            throw new IllegalStateException("방장만 다른 멤버에게 방장 권한을 위임할 수 있습니다.");
+            throw new ChatMemberErrorException(ChatMemberErrorCode.NOT_ADMIN);
         }
 
         this.role = ChatMemberRole.MEMBER;

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -86,6 +86,10 @@ public class ChatMember extends DateAuditable {
             throw new IllegalArgumentException("chatMember가 null이거나 자기 자신일 수 없습니다.");
         }
 
+        if (!this.getChatRoom().equals(chatMember.getChatRoom())) {
+            throw new IllegalArgumentException("ChatMember가 다른 ChatRoom에 속해있습니다.");
+        }
+
         if (this.role != ChatMemberRole.ADMIN) {
             throw new ChatMemberErrorException(ChatMemberErrorCode.NOT_ADMIN);
         }

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/domain/ChatMember.java
@@ -87,7 +87,7 @@ public class ChatMember extends DateAuditable {
         }
 
         if (!this.getChatRoom().equals(chatMember.getChatRoom())) {
-            throw new IllegalArgumentException("ChatMember가 다른 ChatRoom에 속해있습니다.");
+            throw new ChatMemberErrorException(ChatMemberErrorCode.NOT_SAME_CHAT_ROOM);
         }
 
         if (this.role != ChatMemberRole.ADMIN) {

--- a/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/exception/ChatMemberErrorCode.java
+++ b/pennyway-domain/domain-rdb/src/main/java/kr/co/pennyway/domain/domains/member/exception/ChatMemberErrorCode.java
@@ -16,6 +16,7 @@ public enum ChatMemberErrorCode implements BaseErrorCode {
     NOT_FOUND(StatusCode.NOT_FOUND, ReasonCode.REQUESTED_RESOURCE_NOT_FOUND, "회원을 찾을 수 없습니다."),
 
     /* 409 Conflict */
+    NOT_SAME_CHAT_ROOM(StatusCode.CONFLICT, ReasonCode.REQUEST_CONFLICTS_WITH_CURRENT_STATE_OF_RESOURCE, "가입한 채팅방 정보가 일치하지 않습니다."),
     ADMIN_CANNOT_LEAVE(StatusCode.CONFLICT, ReasonCode.REQUEST_CONFLICTS_WITH_CURRENT_STATE_OF_RESOURCE, "채팅방에 사용자가 남아 있다면, 채팅방 방장은 채팅방을 탈퇴할 수 없습니다."),
     ALREADY_JOINED(StatusCode.CONFLICT, ReasonCode.RESOURCE_ALREADY_EXISTS, "이미 가입한 회원입니다."),
     ;

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomAdminDelegateOperation.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomAdminDelegateOperation.java
@@ -1,0 +1,24 @@
+package kr.co.pennyway.domain.context.chat.collection;
+
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+
+import java.util.Objects;
+
+@Slf4j
+public class ChatRoomAdminDelegateOperation {
+    private final ChatMember chatAdmin;
+    private final ChatMember chatMember;
+
+    public ChatRoomAdminDelegateOperation(@NonNull ChatMember chatAdmin, @NonNull ChatMember chatMember) {
+        this.chatAdmin = Objects.requireNonNull(chatAdmin);
+        this.chatMember = Objects.requireNonNull(chatMember);
+    }
+
+    public void execute() {
+        chatAdmin.delegate(chatMember);
+
+        log.info("방장 권한 위임: {} -> {}", chatAdmin, chatMember);
+    }
+}

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/dto/ChatRoomAdminDelegateCommand.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/dto/ChatRoomAdminDelegateCommand.java
@@ -1,0 +1,25 @@
+package kr.co.pennyway.domain.context.chat.dto;
+
+public record ChatRoomAdminDelegateCommand(
+        Long chatRoomId,
+        Long chatAdminUserId,
+        Long targetChatMemberId
+) {
+    public ChatRoomAdminDelegateCommand {
+        if (chatRoomId == null) {
+            throw new IllegalArgumentException("chatRoomId must not be null");
+        }
+
+        if (chatAdminUserId == null) {
+            throw new IllegalArgumentException("chatAdminUserId must not be null");
+        }
+
+        if (targetChatMemberId == null) {
+            throw new IllegalArgumentException("targetChatMemberId must not be null");
+        }
+    }
+
+    public static ChatRoomAdminDelegateCommand of(Long chatRoomId, Long chatAdminUserId, Long targetChatMemberId) {
+        return new ChatRoomAdminDelegateCommand(chatRoomId, chatAdminUserId, targetChatMemberId);
+    }
+}

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomAdminDelegateService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomAdminDelegateService.java
@@ -1,6 +1,7 @@
 package kr.co.pennyway.domain.context.chat.service;
 
 import kr.co.pennyway.common.annotation.DomainService;
+import kr.co.pennyway.domain.common.annotation.DistributedLock;
 import kr.co.pennyway.domain.context.chat.collection.ChatRoomAdminDelegateOperation;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
@@ -17,6 +18,7 @@ public class ChatRoomAdminDelegateService {
     private final ChatMemberRdbService chatMemberRdbService;
 
     @Transactional
+    @DistributedLock(key = "'chat-room-admin-delegate-' + #chatRoomId")
     public void execute(Long chatRoomId, Long chatAdminUserId, Long targetChatMemberId) {
         var chatAdmin = chatMemberRdbService.readChatMember(chatAdminUserId, chatRoomId)
                 .filter(ChatMember::isActive)

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomAdminDelegateService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomAdminDelegateService.java
@@ -19,7 +19,7 @@ public class ChatRoomAdminDelegateService {
     private final ChatMemberRdbService chatMemberRdbService;
 
     @Transactional
-    @DistributedLock(key = "'chat-room-admin-delegate-' + #chatRoomId")
+    @DistributedLock(key = "'chat-room-admin-delegate-' + #command.chatRoomId()")
     public void execute(ChatRoomAdminDelegateCommand command) {
         var chatAdmin = chatMemberRdbService.readChatMember(command.chatAdminUserId(), command.chatRoomId())
                 .filter(ChatMember::isActive)

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomAdminDelegateService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomAdminDelegateService.java
@@ -2,6 +2,7 @@ package kr.co.pennyway.domain.context.chat.service;
 
 import kr.co.pennyway.common.annotation.DomainService;
 import kr.co.pennyway.domain.context.chat.collection.ChatRoomAdminDelegateOperation;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
 import kr.co.pennyway.domain.domains.member.service.ChatMemberRdbService;
@@ -18,8 +19,11 @@ public class ChatRoomAdminDelegateService {
     @Transactional
     public void execute(Long chatRoomId, Long chatAdminUserId, Long targetChatMemberId) {
         var chatAdmin = chatMemberRdbService.readChatMember(chatAdminUserId, chatRoomId)
+                .filter(ChatMember::isActive)
                 .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
+
         var targetMember = chatMemberRdbService.readChatMemberByChatMemberId(targetChatMemberId)
+                .filter(ChatMember::isActive)
                 .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
 
         new ChatRoomAdminDelegateOperation(chatAdmin, targetMember).execute();

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomAdminDelegateService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomAdminDelegateService.java
@@ -3,6 +3,7 @@ package kr.co.pennyway.domain.context.chat.service;
 import kr.co.pennyway.common.annotation.DomainService;
 import kr.co.pennyway.domain.common.annotation.DistributedLock;
 import kr.co.pennyway.domain.context.chat.collection.ChatRoomAdminDelegateOperation;
+import kr.co.pennyway.domain.context.chat.dto.ChatRoomAdminDelegateCommand;
 import kr.co.pennyway.domain.domains.member.domain.ChatMember;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
 import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
@@ -19,12 +20,12 @@ public class ChatRoomAdminDelegateService {
 
     @Transactional
     @DistributedLock(key = "'chat-room-admin-delegate-' + #chatRoomId")
-    public void execute(Long chatRoomId, Long chatAdminUserId, Long targetChatMemberId) {
-        var chatAdmin = chatMemberRdbService.readChatMember(chatAdminUserId, chatRoomId)
+    public void execute(ChatRoomAdminDelegateCommand command) {
+        var chatAdmin = chatMemberRdbService.readChatMember(command.chatAdminUserId(), command.chatRoomId())
                 .filter(ChatMember::isActive)
                 .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
 
-        var targetMember = chatMemberRdbService.readChatMemberByChatMemberId(targetChatMemberId)
+        var targetMember = chatMemberRdbService.readChatMemberByChatMemberId(command.targetChatMemberId())
                 .filter(ChatMember::isActive)
                 .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
 

--- a/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomAdminDelegateService.java
+++ b/pennyway-domain/domain-service/src/main/java/kr/co/pennyway/domain/context/chat/service/ChatRoomAdminDelegateService.java
@@ -1,0 +1,27 @@
+package kr.co.pennyway.domain.context.chat.service;
+
+import kr.co.pennyway.common.annotation.DomainService;
+import kr.co.pennyway.domain.context.chat.collection.ChatRoomAdminDelegateOperation;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberRdbService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@DomainService
+@RequiredArgsConstructor
+public class ChatRoomAdminDelegateService {
+    private final ChatMemberRdbService chatMemberRdbService;
+
+    @Transactional
+    public void execute(Long chatRoomId, Long chatAdminUserId, Long targetChatMemberId) {
+        var chatAdmin = chatMemberRdbService.readChatMember(chatAdminUserId, chatRoomId)
+                .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
+        var targetMember = chatMemberRdbService.readChatMemberByChatMemberId(targetChatMemberId)
+                .orElseThrow(() -> new ChatMemberErrorException(ChatMemberErrorCode.NOT_FOUND));
+
+        new ChatRoomAdminDelegateOperation(chatAdmin, targetMember).execute();
+    }
+}

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomAdminDelegateOperationTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomAdminDelegateOperationTest.java
@@ -80,7 +80,8 @@ public class ChatRoomAdminDelegateOperationTest {
 
         // when & then
         assertThatThrownBy(operation::execute)
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(ChatMemberErrorException.class)
+                .hasFieldOrPropertyWithValue("chatMemberErrorCode", ChatMemberErrorCode.NOT_SAME_CHAT_ROOM);
     }
 
     private ChatMember createChatMember(Long userId, Long chatMemberId, ChatMemberRole role, ChatRoom chatRoom) {

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomAdminDelegateOperationTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/collection/ChatRoomAdminDelegateOperationTest.java
@@ -1,0 +1,74 @@
+package kr.co.pennyway.domain.context.chat.collection;
+
+import kr.co.pennyway.domain.context.common.fixture.ChatRoomFixture;
+import kr.co.pennyway.domain.context.common.fixture.UserFixture;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorCode;
+import kr.co.pennyway.domain.domains.member.exception.ChatMemberErrorException;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ChatRoomAdminDelegateOperationTest {
+    private ChatRoom chatRoom = ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntity();
+
+    @Test
+    @DisplayName("방장은 다른 멤버에게 방장 권한을 위임할 수 있다")
+    void shouldDelegateAdmin() {
+        // given
+        var chatAdmin = createChatMember(1L, 1L, ChatMemberRole.ADMIN);
+        var chatMember = createChatMember(2L, 2L, ChatMemberRole.MEMBER);
+
+        var operation = new ChatRoomAdminDelegateOperation(chatAdmin, chatMember);
+
+        // when
+        operation.execute();
+
+        // then
+        assertEquals(ChatMemberRole.ADMIN, chatMember.getRole());
+        assertEquals(ChatMemberRole.MEMBER, chatAdmin.getRole());
+    }
+
+    @Test
+    @DisplayName("방장이 아닌 멤버는 방장 권한을 위임할 수 없다")
+    void shouldNotDelegateAdmin() {
+        // given
+        var chatAdmin = createChatMember(1L, 1L, ChatMemberRole.MEMBER);
+        var chatMember = createChatMember(2L, 2L, ChatMemberRole.MEMBER);
+
+        var operation = new ChatRoomAdminDelegateOperation(chatAdmin, chatMember);
+
+        // when & then
+        assertThatThrownBy(operation::execute)
+                .isInstanceOf(ChatMemberErrorException.class)
+                .hasFieldOrPropertyWithValue("chatMemberErrorCode", ChatMemberErrorCode.NOT_ADMIN);
+    }
+
+    @Test
+    @DisplayName("방장은 자기자신에게 방장 권한을 위임할 수 없다")
+    void shouldNotDelegateAdminToSelf() {
+        // given
+        var chatAdmin = createChatMember(1L, 1L, ChatMemberRole.ADMIN);
+
+        var operation = new ChatRoomAdminDelegateOperation(chatAdmin, chatAdmin);
+
+        // when & then
+        assertThatThrownBy(operation::execute)
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private ChatMember createChatMember(Long userId, Long chatMemberId, ChatMemberRole role) {
+        var user = UserFixture.GENERAL_USER.toUser();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        var chatMember = ChatMember.of(user, chatRoom, role);
+        ReflectionTestUtils.setField(chatMember, "id", chatMemberId);
+
+        return chatMember;
+    }
+}

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/integration/ChatRoomAdminDelegateServiceIntegrationTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/integration/ChatRoomAdminDelegateServiceIntegrationTest.java
@@ -1,0 +1,76 @@
+package kr.co.pennyway.domain.context.chat.integration;
+
+import kr.co.pennyway.domain.common.repository.ExtendedRepositoryFactory;
+import kr.co.pennyway.domain.config.DomainServiceIntegrationProfileResolver;
+import kr.co.pennyway.domain.config.DomainServiceTestInfraConfig;
+import kr.co.pennyway.domain.config.JpaTestConfig;
+import kr.co.pennyway.domain.context.chat.service.ChatRoomAdminDelegateService;
+import kr.co.pennyway.domain.context.common.fixture.ChatRoomFixture;
+import kr.co.pennyway.domain.context.common.fixture.UserFixture;
+import kr.co.pennyway.domain.domains.chatroom.domain.ChatRoom;
+import kr.co.pennyway.domain.domains.chatroom.repository.ChatRoomRepository;
+import kr.co.pennyway.domain.domains.chatroom.service.ChatRoomRdbService;
+import kr.co.pennyway.domain.domains.member.domain.ChatMember;
+import kr.co.pennyway.domain.domains.member.repository.ChatMemberRepository;
+import kr.co.pennyway.domain.domains.member.service.ChatMemberRdbService;
+import kr.co.pennyway.domain.domains.member.type.ChatMemberRole;
+import kr.co.pennyway.domain.domains.user.domain.User;
+import kr.co.pennyway.domain.domains.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+@EnableAutoConfiguration
+@SpringBootTest(classes = {ChatRoomAdminDelegateService.class, ChatMemberRdbService.class, ChatRoomRdbService.class})
+@EntityScan(basePackageClasses = {User.class, ChatRoom.class, ChatMember.class})
+@EnableJpaRepositories(
+        basePackageClasses = {UserRepository.class, ChatRoomRepository.class, ChatMemberRepository.class},
+        repositoryFactoryBeanClass = ExtendedRepositoryFactory.class
+)
+@ActiveProfiles(resolver = DomainServiceIntegrationProfileResolver.class)
+@Import(value = {JpaTestConfig.class})
+public class ChatRoomAdminDelegateServiceIntegrationTest extends DomainServiceTestInfraConfig {
+    @Autowired
+    private ChatRoomAdminDelegateService sut;
+
+    @Autowired
+    private ChatMemberRepository chatMemberRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @Transactional
+    void shouldDelegateAdmin() {
+        // given
+        var chatRoom = chatRoomRepository.save(ChatRoomFixture.PUBLIC_CHAT_ROOM.toEntityWithId(1L));
+        var chatAdmin = createChatMember(ChatMemberRole.ADMIN, chatRoom);
+        var chatMember = createChatMember(ChatMemberRole.MEMBER, chatRoom);
+
+        // when
+        sut.execute(chatRoom.getId(), chatAdmin.getUser().getId(), chatMember.getId());
+
+        // then
+        assertEquals(ChatMemberRole.ADMIN, chatMember.getRole());
+        assertEquals(ChatMemberRole.MEMBER, chatAdmin.getRole());
+    }
+
+    private ChatMember createChatMember(ChatMemberRole role, ChatRoom chatRoom) {
+        var user = userRepository.save(UserFixture.GENERAL_USER.toUser());
+
+        return chatMemberRepository.save(ChatMember.of(user, chatRoom, role));
+    }
+}

--- a/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/integration/ChatRoomAdminDelegateServiceIntegrationTest.java
+++ b/pennyway-domain/domain-service/src/test/java/kr/co/pennyway/domain/context/chat/integration/ChatRoomAdminDelegateServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import kr.co.pennyway.domain.common.repository.ExtendedRepositoryFactory;
 import kr.co.pennyway.domain.config.DomainServiceIntegrationProfileResolver;
 import kr.co.pennyway.domain.config.DomainServiceTestInfraConfig;
 import kr.co.pennyway.domain.config.JpaTestConfig;
+import kr.co.pennyway.domain.context.chat.dto.ChatRoomAdminDelegateCommand;
 import kr.co.pennyway.domain.context.chat.service.ChatRoomAdminDelegateService;
 import kr.co.pennyway.domain.context.common.fixture.ChatRoomFixture;
 import kr.co.pennyway.domain.context.common.fixture.UserFixture;
@@ -61,7 +62,7 @@ public class ChatRoomAdminDelegateServiceIntegrationTest extends DomainServiceTe
         var chatMember = createChatMember(ChatMemberRole.MEMBER, chatRoom);
 
         // when
-        sut.execute(chatRoom.getId(), chatAdmin.getUser().getId(), chatMember.getId());
+        sut.execute(ChatRoomAdminDelegateCommand.of(chatRoom.getId(), chatAdmin.getUser().getId(), chatMember.getId()));
 
         // then
         assertEquals(ChatMemberRole.ADMIN, chatMember.getRole());


### PR DESCRIPTION
## 작업 이유
- The admin should be able to delegate their role to another chat member within the same chat room.

<br/>

## 작업 사항
- Implemented service and controller logic.
- Added tests for the business logic.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

Please carefully review potential conflict scenarios.  
For instance, if the chat member who is about to be promoted to admin requests to leave the chat room, this could result in the   chat room having no admin in the worst-case scenario. 😅  

How to Handle This?  
Do you have any good ideas for addressing this?  
Feel free to share your thoughts!

<br/>

## 발견한 이슈
- none.

