### PR TITLE
Ignore: 🐛 Remove Prefix During S3 Image Validation & Fix Infinite Invitation Messages

### DIFF
--- a/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelper.java
+++ b/pennyway-app-external-api/src/main/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelper.java
@@ -69,9 +69,11 @@ public class ChatRoomPatchHelper {
         }
 
         if (requestImageUrl.startsWith(awsS3Adapter.getObjectPrefix())) {
-            validateExistingImage(requestImageUrl);
+            var originImageUrl = requestImageUrl.substring(awsS3Adapter.getObjectPrefix().length());
 
-            return requestImageUrl.substring(awsS3Adapter.getObjectPrefix().length());
+            validateExistingImage(originImageUrl);
+
+            return originImageUrl;
         }
 
         throw new StorageException(StorageErrorCode.INVALID_IMAGE_PATH);

--- a/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelperTest.java
+++ b/pennyway-app-external-api/src/test/java/kr/co/pennyway/api/apis/chat/service/ChatRoomPatchHelperTest.java
@@ -105,7 +105,7 @@ class ChatRoomPatchHelperTest {
 
         when(chatRoomService.readChatRoom(CHATROOM_ID)).thenReturn(Optional.of(chatRoom));
         when(awsS3Adapter.getObjectPrefix()).thenReturn("https://cdn.test.com/");
-        when(awsS3Adapter.isObjectExist("https://cdn.test.com/" + ORIGIN_PATH)).thenReturn(true);
+        when(awsS3Adapter.isObjectExist(ORIGIN_PATH)).thenReturn(true);
 
         ChatRoomReq.Update request = new ChatRoomReq.Update("title", "desc", null, "https://cdn.test.com/" + ORIGIN_PATH);
 
@@ -115,7 +115,7 @@ class ChatRoomPatchHelperTest {
         // then
         verify(awsS3Adapter, never()).deleteImage(anyString());
         verify(awsS3Adapter, never()).saveImage(anyString(), any());
-        verify(awsS3Adapter).isObjectExist("https://cdn.test.com/" + ORIGIN_PATH);
+        verify(awsS3Adapter).isObjectExist(ORIGIN_PATH);
     }
 
     @Test

--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.kt
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/service/ChatMessageSendService.kt
@@ -38,7 +38,7 @@ class ChatMessageSendService(
             )
         }
 
-        command.senderName.takeIf { it.isNotBlank() }?.let { senderName ->
+        command.senderName?.takeIf { it.isNotBlank() }?.let { senderName ->
             simpMessagingTemplate.convertAndSendToUser(
                 senderName,
                 "/queue/success",


### PR DESCRIPTION
## 작업 이유
- We found an issue where the client fails to update their chat room information when the chat room's profile image remains unchanged.
- The socket server was sending a join message perpetually. Since this was an urgent issue, I fixed it in this PR.

<br/>

## 작업 사항
- During S3 image validation, the service now removes the prefix from the profile URL.
- The root cause of the infinite message loop was the handling of the success response after sending a message. When the client sent a message, the process confirming the successful transmission triggered an error as the system attempted to publish the message. This led to an infinite consumption loop in the message queue (MQ). To resolve this, I modified the logic to properly handle cases where the sender name is null, preventing the error from occurring.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- none