### PR TITLE
Ignore: 🔧 Move the Date Field to the Payload in Spending Sharing Message

### DIFF
--- a/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/JacksonConfig.kt
+++ b/pennyway-socket/src/main/java/kr/co/pennyway/socket/config/JacksonConfig.kt
@@ -1,0 +1,18 @@
+package kr.co.pennyway.socket.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class JacksonConfig {
+    @Bean
+    fun objectMapper(): ObjectMapper {
+        return ObjectMapper().apply {
+            registerModule(JavaTimeModule())
+            disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        }
+    }
+}


### PR DESCRIPTION
## 작업 이유
![image](https://github.com/user-attachments/assets/39dfb22c-c7be-409c-a614-4d5d0300a749)


<br/>

## 작업 사항
So, I changed the format for sharing message.

```json
"content": {
   "date": "YYYY-MM-DD"
   "spendingOnDates": [

   ]
}
```

For example,
```json
{
   "chatRoomId":1,
   "chatId":674629221743744486,
   "content": "{\"date\":\"2025-01-28\",\"spendingOnDates\":[{\"isCustom\":true,\"categoryId\":3,\"name\":\"피곤하다\",\"icon\":\"HEALTH\",\"amount\":100000},{\"isCustom\":true,\"categoryId\":1,\"name\":\"헬로\",\"icon\":\"LIVING\",\"amount\":81500},{\"isCustom\":false,\"categoryId\":-1,\"name\":\"교통\",\"icon\":\"TRANSPORTATION\",\"amount\":23000},{\"isCustom\":false,\"categoryId\":-1,\"name\":\"식비\",\"icon\":\"FOOD\",\"amount\":10500},{\"isCustom\":false,\"categoryId\":-1,\"name\":\"뷰티/패션\",\"icon\":\"BEAUTY_OR_FASHION\",\"amount\":8000}]}",
   "contentType":"TEXT",
   "categoryType":"SHARE",
   "createdAt":"2025-02-04 23:55:40",
   "senderId":4
}
```

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분
- none

<br/>

## 발견한 이슈
- none

